### PR TITLE
Match oldest repo instead of new one.

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -28,6 +28,10 @@ The Repository CR needs to be created in the namespace where Tekton Pipelines
 associated with the
 source code repository would be executed it cannot target another namespace.
 
+If there is multiples CRD matching the same event, only the oldest one would
+match. If you need to match a specific namespace you would need to use the
+target-namepsace feature in the pipeine annotation (see below).
+
 There is another optional layer of security where PipelineRun can have an
 annotation to explicitely target a specific
 namespace. It would stilll need to have a Repository CRD created in that
@@ -42,8 +46,7 @@ pipelinesascode.tekton.dev/target-namespace: "mynamespace"
 ```
 
 and Pipelines as Code will only match the repository in the mynamespace
-Namespace instead of trying to match it from all
-available repository on cluster.
+Namespace instead of trying to match it from all available repository on cluster.
 
 ## Authoring PipelineRun in `.tekton/` directory
 

--- a/pkg/matcher/repo_runinfo_matcher.go
+++ b/pkg/matcher/repo_runinfo_matcher.go
@@ -30,19 +30,20 @@ func GetRepoByCR(ctx context.Context, cs *params.Run, ns string) (*apipac.Reposi
 		return nil, err
 	}
 	matches := []string{}
-	for _, value := range repositories.Items {
+	for i := len(repositories.Items) - 1; i >= 0; i-- {
+		repo := repositories.Items[i]
 		matches = append(matches,
-			fmt.Sprintf("RepositoryValue: URL=%s, eventType=%s BaseBranch:=%s", value.Spec.URL,
-				value.Spec.EventType, value.Spec.Branch))
+			fmt.Sprintf("RepositoryValue: URL=%s, eventType=%s BaseBranch:=%s", repo.Spec.URL,
+				repo.Spec.EventType, repo.Spec.Branch))
 
-		if value.Spec.URL == cs.Info.Event.URL &&
-			value.Spec.EventType == cs.Info.Event.EventType {
-			if value.Spec.Branch != cs.Info.Event.BaseBranch {
-				if !branchMatch(value.Spec.Branch, cs.Info.Event.BaseBranch) {
+		if repo.Spec.URL == cs.Info.Event.URL &&
+			repo.Spec.EventType == cs.Info.Event.EventType {
+			if repo.Spec.Branch != cs.Info.Event.BaseBranch {
+				if !branchMatch(repo.Spec.Branch, cs.Info.Event.BaseBranch) {
 					continue
 				}
 			}
-			return &value, nil
+			return &repo, nil
 		}
 	}
 	for _, value := range matches {

--- a/pkg/matcher/repo_runinfo_matcher_test.go
+++ b/pkg/matcher/repo_runinfo_matcher_test.go
@@ -37,7 +37,15 @@ func Test_getRepoByCR(t *testing.T) {
 			args: args{
 				data: testclient.Data{
 					Repositories: []*v1alpha1.Repository{
-						testnewrepo.NewRepo("test-good", targetURL, mainBranch, targetNamespace, "pull_request", "", ""),
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-good",
+								URL:              targetURL,
+								Branch:           mainBranch,
+								InstallNamespace: targetNamespace,
+								EventType:        "pull_request",
+							},
+						),
 					},
 				},
 				runevent: info.Event{URL: targetURL, BaseBranch: mainBranch, EventType: "pull_request"},
@@ -50,7 +58,15 @@ func Test_getRepoByCR(t *testing.T) {
 			args: args{
 				data: testclient.Data{
 					Repositories: []*v1alpha1.Repository{
-						testnewrepo.NewRepo("test-good", targetURL, mainBranch, targetNamespace, "pull_request", "", ""),
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-good",
+								URL:              targetURL,
+								Branch:           mainBranch,
+								InstallNamespace: targetNamespace,
+								EventType:        "pull_request",
+							},
+						),
 					},
 				},
 				runevent: info.Event{URL: targetURL, BaseBranch: mainBranch, EventType: "push"},
@@ -63,7 +79,15 @@ func Test_getRepoByCR(t *testing.T) {
 			args: args{
 				data: testclient.Data{
 					Repositories: []*v1alpha1.Repository{
-						testnewrepo.NewRepo("test-good", targetURL, mainBranch, targetNamespace, "pull_request", "", ""),
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-good",
+								URL:              targetURL,
+								Branch:           mainBranch,
+								InstallNamespace: targetNamespace,
+								EventType:        "pull_request",
+							},
+						),
 					},
 				},
 				runevent: info.Event{URL: targetURL, BaseBranch: "anotherBaseBranch", EventType: "pull_request"},
@@ -76,7 +100,15 @@ func Test_getRepoByCR(t *testing.T) {
 			args: args{
 				data: testclient.Data{
 					Repositories: []*v1alpha1.Repository{
-						testnewrepo.NewRepo("test-good", "http://nottarget.url", mainBranch, targetNamespace, "pull_request", "", ""),
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-good",
+								URL:              "http://nottarget.url",
+								Branch:           mainBranch,
+								InstallNamespace: targetNamespace,
+								EventType:        "pull_request",
+							},
+						),
 					},
 				},
 				runevent: info.Event{URL: targetURL, BaseBranch: mainBranch, EventType: "pull_request"},
@@ -89,7 +121,15 @@ func Test_getRepoByCR(t *testing.T) {
 			args: args{
 				data: testclient.Data{
 					Repositories: []*v1alpha1.Repository{
-						testnewrepo.NewRepo("test-good", targetURL, mainBranch, targetNamespace, "pull_request", "", ""),
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-good",
+								URL:              targetURL,
+								Branch:           mainBranch,
+								InstallNamespace: targetNamespace,
+								EventType:        "pull_request",
+							},
+						),
 					},
 				},
 				runevent: info.Event{
@@ -105,7 +145,15 @@ func Test_getRepoByCR(t *testing.T) {
 			args: args{
 				data: testclient.Data{
 					Repositories: []*v1alpha1.Repository{
-						testnewrepo.NewRepo("test-good", targetURL, "refs/tags/*", targetNamespace, "pull_request", "", ""),
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-good",
+								URL:              targetURL,
+								Branch:           "refs/tags/*",
+								InstallNamespace: targetNamespace,
+								EventType:        "pull_request",
+							},
+						),
 					},
 				},
 				runevent: info.Event{

--- a/pkg/pipelineascode/testrun_github_test.go
+++ b/pkg/pipelineascode/testrun_github_test.go
@@ -20,7 +20,7 @@ import (
 	testDynamic "github.com/openshift-pipelines/pipelines-as-code/pkg/test/dynamic"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
 	kitesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/kubernetestint"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/repository"
+	testnewrepo "github.com/openshift-pipelines/pipelines-as-code/pkg/test/repository"
 	ghwebvcs "github.com/openshift-pipelines/pipelines-as-code/pkg/webvcs/github"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
@@ -263,7 +263,15 @@ func TestRun(t *testing.T) {
 			finalStatus:     "skipped",
 			finalStatusText: "not find a namespace match",
 			repositories: []*v1alpha1.Repository{
-				repository.NewRepo("test-run", "https://service/documentation", "a branch", "namespace", "pull_request", "", ""),
+				testnewrepo.NewRepo(
+					testnewrepo.RepoTestcreationOpts{
+						Name:             "test-good",
+						URL:              "https://service/documentation",
+						Branch:           "a branch",
+						InstallNamespace: "namespace",
+						EventType:        "pull_request",
+					},
+				),
 			},
 		},
 
@@ -283,7 +291,15 @@ func TestRun(t *testing.T) {
 			finalStatus:     "skipped",
 			finalStatusText: "not find a namespace match",
 			repositories: []*v1alpha1.Repository{
-				repository.NewRepo("test-run", "https://nowhere.com", "a branch", "namespace", "pull_request", "", ""),
+				testnewrepo.NewRepo(
+					testnewrepo.RepoTestcreationOpts{
+						Name:             "test-run",
+						URL:              "https://nowhere.com",
+						Branch:           "a branch",
+						InstallNamespace: "namespace",
+						EventType:        "pull_request",
+					},
+				),
 			},
 		},
 
@@ -336,7 +352,17 @@ func TestRun(t *testing.T) {
 
 			if tt.repositories == nil {
 				tt.repositories = []*v1alpha1.Repository{
-					repository.NewRepo("test-run", tt.runevent.URL, tt.runevent.BaseBranch, "namespace", tt.runevent.EventType, secretName, vcsURL),
+					testnewrepo.NewRepo(
+						testnewrepo.RepoTestcreationOpts{
+							Name:             "test-run",
+							URL:              tt.runevent.URL,
+							Branch:           tt.runevent.BaseBranch,
+							InstallNamespace: "namespace",
+							EventType:        tt.runevent.EventType,
+							SecretName:       secretName,
+							VcsURL:           vcsURL,
+						},
+					),
 				}
 			}
 			tdata := testclient.Data{

--- a/pkg/test/repository/repository.go
+++ b/pkg/test/repository/repository.go
@@ -5,63 +5,75 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis/duck/v1beta1"
 )
 
-func NewRepo(name, url, branch, installNamespace, eventtype, secretname, vcsurl string) *v1alpha1.Repository {
+type RepoTestcreationOpts struct {
+	Name             string
+	URL              string
+	Branch           string
+	InstallNamespace string
+	EventType        string
+	SecretName       string
+	VcsURL           string
+	CreateTime       metav1.Time
+}
+
+func NewRepo(opts RepoTestcreationOpts) *v1alpha1.Repository {
 	cw := clockwork.NewFakeClock()
 	repo := &v1alpha1.Repository{
-		TypeMeta: v1.TypeMeta{},
-		ObjectMeta: v1.ObjectMeta{
-			Name:      name,
-			Namespace: installNamespace,
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              opts.Name,
+			Namespace:         opts.InstallNamespace,
+			CreationTimestamp: opts.CreateTime,
 		},
 		Spec: v1alpha1.RepositorySpec{
-			URL:       url,
-			Branch:    branch,
-			EventType: eventtype,
+			URL:       opts.URL,
+			Branch:    opts.Branch,
+			EventType: opts.EventType,
 		},
 		Status: []v1alpha1.RepositoryRunStatus{
 			{
 				Status:          v1beta1.Status{},
 				PipelineRunName: "pipelinerun5",
-				StartTime:       &v1.Time{Time: cw.Now().Add(-56 * time.Minute)},
-				CompletionTime:  &v1.Time{Time: cw.Now().Add(-55 * time.Minute)},
+				StartTime:       &metav1.Time{Time: cw.Now().Add(-56 * time.Minute)},
+				CompletionTime:  &metav1.Time{Time: cw.Now().Add(-55 * time.Minute)},
 			},
 			{
 				Status:          v1beta1.Status{},
 				PipelineRunName: "pipelinerun4",
-				StartTime:       &v1.Time{Time: cw.Now().Add(-46 * time.Minute)},
-				CompletionTime:  &v1.Time{Time: cw.Now().Add(-45 * time.Minute)},
+				StartTime:       &metav1.Time{Time: cw.Now().Add(-46 * time.Minute)},
+				CompletionTime:  &metav1.Time{Time: cw.Now().Add(-45 * time.Minute)},
 			},
 			{
 				Status:          v1beta1.Status{},
 				PipelineRunName: "pipelinerun3",
-				StartTime:       &v1.Time{Time: cw.Now().Add(-36 * time.Minute)},
-				CompletionTime:  &v1.Time{Time: cw.Now().Add(-35 * time.Minute)},
+				StartTime:       &metav1.Time{Time: cw.Now().Add(-36 * time.Minute)},
+				CompletionTime:  &metav1.Time{Time: cw.Now().Add(-35 * time.Minute)},
 			},
 			{
 				Status:          v1beta1.Status{},
 				PipelineRunName: "pipelinerun2",
-				StartTime:       &v1.Time{Time: cw.Now().Add(-26 * time.Minute)},
-				CompletionTime:  &v1.Time{Time: cw.Now().Add(-25 * time.Minute)},
+				StartTime:       &metav1.Time{Time: cw.Now().Add(-26 * time.Minute)},
+				CompletionTime:  &metav1.Time{Time: cw.Now().Add(-25 * time.Minute)},
 			},
 			{
 				Status:          v1beta1.Status{},
 				PipelineRunName: "pipelinerun1",
-				StartTime:       &v1.Time{Time: cw.Now().Add(-16 * time.Minute)},
-				CompletionTime:  &v1.Time{Time: cw.Now().Add(-15 * time.Minute)},
+				StartTime:       &metav1.Time{Time: cw.Now().Add(-16 * time.Minute)},
+				CompletionTime:  &metav1.Time{Time: cw.Now().Add(-15 * time.Minute)},
 			},
 		},
 	}
-	if secretname != "" {
+	if opts.SecretName != "" {
 		repo.Spec.WebvcsSecret = &v1alpha1.WebvcsSecretSpec{
-			Name: secretname,
+			Name: opts.SecretName,
 		}
 	}
-	if vcsurl != "" {
-		repo.Spec.WebvcsAPIURL = vcsurl
+	if opts.VcsURL != "" {
+		repo.Spec.WebvcsAPIURL = opts.VcsURL
 	}
 	return repo
 }


### PR DESCRIPTION
Match only the oldest one if we have multiple repo matching the same
event.

Just in case if there is a hijack attempt even tho I don't see a way to
exploit that.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
