### PR TITLE
e2e tests

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -1,0 +1,186 @@
+name: KinD e2e tests
+
+on:
+  workflow_dispatch: # yamllint disable-line
+  push: # yamllint disable-line
+  pull_request: # yamllint disable-line
+  tags: # yamllint disable-line
+jobs:
+  e2e-tests:
+    name: e2e tests
+    runs-on: ubuntu-latest
+    env:
+      # https://github.com/google/go-containerregistry/pull/125 allows insecure registry for
+      # '*.local' hostnames. This works both for `ko` and our own tag-to-digest resolution logic,
+      # thus allowing us to test without bypassing tag-to-digest resolution.
+      REGISTRY_NAME: registry.local
+      REGISTRY_PORT: 5000
+      KO_DOCKER_REPO: registry.local:5000/ko
+      EL_NAME: kind.pac
+      TEST_GITHUB_REPO_OWNER_GITHUBAPP: openshift-pipelines/pipelines-as-code-e2e-tests
+      # TEST_GITHUB_REPO_OWNER_WEBHOOK: pac/pac-test-webhooks
+
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/.cache/pip
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Install ko
+        run: curl -sfL https://github.com/google/ko/releases/download/v0.9.3/ko_0.9.3_Linux_x86_64.tar.gz -o-|tar xvzf - -C /usr/local/bin ko
+
+      - name: Configure KinD Cluster
+        run: |
+          # KinD configuration.
+          cat > kind.yaml <<EOF
+          apiVersion: kind.x-k8s.io/v1alpha4
+          kind: Cluster
+          nodes:
+          # configure ports for ambassador
+          - role: control-plane
+            kubeadmConfigPatches:
+            - |
+              kind: InitConfiguration
+              nodeRegistration:
+                kubeletExtraArgs:
+                  node-labels: "ingress-ready=true"
+            extraPortMappings:
+            - containerPort: 80
+              hostPort: 80
+              protocol: TCP
+          # Configure registry for KinD.
+          containerdConfigPatches:
+          - |-
+            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."$REGISTRY_NAME:$REGISTRY_PORT"]
+              endpoint = ["http://$REGISTRY_NAME:$REGISTRY_PORT"]
+          EOF
+      - uses: helm/kind-action@v1.2.0
+        with:
+          cluster_name: kind
+          config: kind.yaml
+
+      - name: Setup local registry
+        run: |
+          # Run a registry.
+          docker run -d --restart=always \
+            -p $REGISTRY_PORT:$REGISTRY_PORT --name $REGISTRY_NAME registry:2
+
+          # Connect the registry to the KinD network.
+          docker network connect "kind" $REGISTRY_NAME
+
+          # Make the $REGISTRY_NAME -> 127.0.0.1, to tell `ko` to publish to
+          # local reigstry, even when pushing $REGISTRY_NAME:$REGISTRY_PORT/some/image
+          sudo echo "127.0.0.1 $REGISTRY_NAME" | sudo tee -a /etc/hosts
+
+      - name: Wait for ready nodes
+        run: |
+          kubectl wait --timeout=2m --for=condition=Ready nodes --all
+
+      - name: Install ambassador
+        run: |
+          kubectl create ns ambassador && sleep 5
+          kubectl apply -f https://github.com/datawire/ambassador-operator/releases/latest/download/ambassador-operator-crds.yaml
+          kubectl apply -n ambassador -f https://github.com/datawire/ambassador-operator/releases/latest/download/ambassador-operator-kind.yaml
+          kubectl wait --timeout=180s -n ambassador --for=condition=deployed ambassadorinstallations/ambassador
+
+      - name: Install Tekton
+        run: |
+          kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+          kubectl apply --filename https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
+          kubectl apply --filename https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml
+          kubectl apply --filename https://storage.googleapis.com/tekton-releases/dashboard/latest/tekton-dashboard-release.yaml
+
+      - name: Wait for Tekton to be installed
+        run: |
+          i=0
+          for tt in pipelines triggers;do
+            while true;do
+              [[ ${i} == 120 ]] && exit 1
+              ep=$(kubectl get ep -n tekton-pipelines tekton-${tt}-webhook -o jsonpath='{.subsets[*].addresses[*].ip}')
+              [[ -n ${ep} ]] && break
+              sleep 2
+              i=$((i+1))
+            done
+          done
+
+      - name: Apply config with KO
+        run: |
+          # Test with kind load
+          ko apply -f ./config
+
+      - name: Create Ambassador Route
+        run: |
+          sudo echo "127.0.0.1 $EL_NAME" | sudo tee -a /etc/hosts
+          cat <<EOF | kubectl apply -f-
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: kind.pipelines.devcluster.openshift.com-ingress
+            namespace: pipelines-as-code
+            annotations:
+              kubernetes.io/ingress.class: "ambassador"
+          spec:
+            rules:
+            - host: "${EL_NAME}"
+              http:
+                paths:
+                - path: /
+                  pathType: Exact
+                  backend:
+                    service:
+                      name: el-pipelines-as-code-interceptor
+                      port:
+                        number: 8080
+          EOF
+      - name: Wait that the ingress host is up
+        run: |
+          for i in {1..60};do
+            curl -s --fail-early -L http://kind.pac/|grep -q pipelines-as-code && break
+            sleep 2
+          done
+
+      - name: Create PAC github-app-secret
+        run: |
+          kubectl -n pipelines-as-code create secret generic pipelines-as-code-secret \
+            --from-literal github-private-key="${{ secrets.APP_PRIVATE_KEY }}" \
+            --from-literal github-application-id=${{ secrets.APPLICATION_ID }} \
+            --from-literal webhook.secret=${{ secrets.WEBHOOK_SECRET }}
+
+      - name: Install and Run pysmee
+        run: |
+          pip3 install pysmee
+          set -x
+          nohup pysmee forward ${{ secrets.PYSMEE_URL }} http://${EL_NAME} &
+
+      - name: Run E2E Tests
+        run: |
+          export TEST_GITHUB_API_URL=api.github.com
+          export TEST_GITHUB_REPO_OWNER_GITHUBAPP=openshift-pipelines/pipelines-as-code-e2e-tests
+          export TEST_GITHUB_REPO_OWNER_WEBHOOK=openshift-pipelines/pipelines-as-code-e2e-tests-webhook
+
+          export TEST_GITHUB_TOKEN="${{ secrets.GH_APPS_TOKEN }}"
+          export TEST_EL_WEBHOOK_SECRET="${{ secrets.WEBHOOK_SECRET }}"
+          export TEST_GITHUB_REPO_INSTALLATION_ID="${{ secrets.INSTALLATION_ID }}"
+          export TEST_EL_URL="http://${EL_NAME}"
+          make test-e2e
+      - name: Collect logs
+        if: ${{ always() }}
+        run: |
+          mkdir -p /tmp/logs
+          kind export logs /tmp/logs
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
+      - name: Upload artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: /tmp/logs

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -314,14 +314,15 @@ If the object fetched cannot be parsed as a Tekton `Task` it will error out.
 
 - A user create a Pull Request.
 
-- If the user sending the Pull Request is not the owner of the repository or not
-  a public member of the organization where the repository belong to, `Pipelines
-  as Code` will not run.
+- The user would only be allowed run the CI if :
+  - The user is the owner of the repository.
+  - The user is a collaborator on the repository.
+  - The user is a public member on the organization of the repository.
 
 - If the user sending the Pull Request is inside an OWNER file located in the
-  repository root in the main branch (the main branch as defined in the Github
-  configuration for the repo) in the `approvers` or `reviewers` section like
-  this :
+  repository root on the main branch (the main branch as defined in the Github
+  configuration for the repo) and added to either `approvers` or `reviewers`
+  sections like this :
 
 ```yaml
 approvers:
@@ -330,21 +331,21 @@ approvers:
 
 then the user `approved` will be allowed.
 
-If the sender of a PR is not allowed to run CI but one of allowed user issue a
-`/ok-to-test` in any line of a comment the PR will be allowed to run CI.
+- If the sender of a PR is not allowed to run CI but one of allowed user issue a
+  `/ok-to-test` in any line of a comment the PR will be allowed to run CI.
 
-If the user is allowed, `Pipelines as Code` will start creating the
+- If the user is allowed, `Pipelines as Code` will start creating the
 `PipelineRun` in the target user namespace.
 
-The user can follow the execution of your pipeline with the
+- The user can follow the execution of your pipeline with the
 [tkn](https://github.com/tektoncd/cli) cli :
 
 ```bash
 tkn pr logs -n my-pipeline-ci -Lf
 ```
 
-Or via your kubernetes UI like the OpenShift console inside your namespace to
-follow the pipelinerun execution.
+Or with the OpenShift console inside your namespace to follow the pipelinerun
+execution via the URL provided on the "Checks" tab if you run with Github App.
 
 ## Status
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -314,14 +314,15 @@ If the object fetched cannot be parsed as a Tekton `Task` it will error out.
 
 - A user create a Pull Request.
 
-- If the user sending the Pull Request is not the owner of the repository or not
-  a public member of the organization where the repository belong to, `Pipelines
-  as Code` will not run.
+- The user would only be allowed to run the CI if :
+  - The user is the owner of the repository.
+  - The user is a collaborator on the repository.
+  - The user is a public member on the organization of the repository.
 
 - If the user sending the Pull Request is inside an OWNER file located in the
-  repository root in the main branch (the main branch as defined in the Github
-  configuration for the repo) in the `approvers` or `reviewers` section like
-  this :
+  repository root on the main branch (the main branch as defined in the Github
+  configuration for the repo) and added to either `approvers` or `reviewers`
+  sections like this :
 
 ```yaml
 approvers:
@@ -330,21 +331,21 @@ approvers:
 
 then the user `approved` will be allowed.
 
-If the sender of a PR is not allowed to run CI but one of allowed user issue a
-`/ok-to-test` in any line of a comment the PR will be allowed to run CI.
+- If the sender of a PR is not allowed to run CI but one of allowed user issue a
+  `/ok-to-test` in any line of a comment the PR will be allowed to run CI.
 
-If the user is allowed, `Pipelines as Code` will start creating the
+- If the user is allowed, `Pipelines as Code` will start creating the
 `PipelineRun` in the target user namespace.
 
-The user can follow the execution of your pipeline with the
+- The user can follow the execution of your pipeline with the
 [tkn](https://github.com/tektoncd/cli) cli :
 
 ```bash
 tkn pr logs -n my-pipeline-ci -Lf
 ```
 
-Or via your kubernetes UI like the OpenShift console inside your namespace to
-follow the pipelinerun execution.
+Or with the OpenShift console inside your namespace to follow the pipelinerun
+execution via the URL provided on the "Checks" tab if you run with Github App.
 
 ## Status
 

--- a/hack/dev/e2e-tests-cleanup.sh
+++ b/hack/dev/e2e-tests-cleanup.sh
@@ -7,7 +7,8 @@ for target in ${TEST_GITHUB_REPO_OWNER_GITHUBAPP} ${TEST_GITHUB_REPO_OWNER_WEBHO
     [[ -z ${target} ]] && continue
     export GH_REPO=${target}
     export GH_HOST=$(echo ${TEST_GITHUB_API_URL}|sed 's,https://,,')
-    export GH_ENTERPRISE_TOKEN=$(echo ${TEST_GITHUB_TOKEN})
+    export GH_ENTERPRISE_TOKEN=${TEST_GITHUB_TOKEN}
+    export GH_TOKEN=${TEST_GITHUB_TOKEN}
 
     echo "Closing lingering PR on ${target}"
     for prn in $(gh pr list --jq .[].number --json number);do

--- a/hack/dev/e2e-tests-cleanup.sh
+++ b/hack/dev/e2e-tests-cleanup.sh
@@ -3,7 +3,8 @@ set -eu
 
 type -p gh >/dev/null || { echo "You need gh installed"; exit 1 ;}
 
-for target in ${TEST_GITHUB_REPO_OWNER_GITHUBAPP} ${TEST_GITHUB_REPO_OWNER_WEBHOOK};do
+for target in ${TEST_GITHUB_REPO_OWNER_GITHUBAPP} ${TEST_GITHUB_REPO_OWNER_WEBHOOK:-""};do
+    [[ -z ${target} ]] && continue
     export GH_REPO=${target}
     export GH_HOST=$(echo ${TEST_GITHUB_API_URL}|sed 's,https://,,')
     export GH_ENTERPRISE_TOKEN=$(echo ${TEST_GITHUB_TOKEN})

--- a/test/bitbucket_cloud_pullrequest_test.go
+++ b/test/bitbucket_cloud_pullrequest_test.go
@@ -27,8 +27,10 @@ func TestBitbucketCloudPullRequest(t *testing.T) {
 	ctx := context.Background()
 
 	runcnx, opts, bcvcs, err := bitbucketCloudSetup(ctx)
-	assert.NilError(t, err)
-
+	if err != nil {
+		t.Skip(err.Error())
+		return
+	}
 	bcrepo := createBitbucketRepoCRD(ctx, t, bcvcs, runcnx, opts, targetNS, pullRequestEvent, mainBranch)
 	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
 	title := "TestPullRequest - " + targetRefName

--- a/test/github_pullrequest_privaterepository_test.go
+++ b/test/github_pullrequest_privaterepository_test.go
@@ -17,8 +17,8 @@ import (
 
 func TestGithubPullRequestPrivateRepository(t *testing.T) {
 	for _, onWebhook := range []bool{false, true} {
-		if onWebhook && os.Getenv("GITHUB_REPO_OWNER_WEBHOOK") == "" {
-			t.Skip("GITHUB_REPO_OWNER_WEBHOOK is not set")
+		if onWebhook && os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK") == "" {
+			t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
 			continue
 		}
 		targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")

--- a/test/github_pullrequest_privaterepository_test.go
+++ b/test/github_pullrequest_privaterepository_test.go
@@ -6,6 +6,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
@@ -16,6 +17,10 @@ import (
 
 func TestGithubPullRequestPrivateRepository(t *testing.T) {
 	for _, onWebhook := range []bool{false, true} {
+		if onWebhook && os.Getenv("GITHUB_REPO_OWNER_WEBHOOK") == "" {
+			t.Skip("GITHUB_REPO_OWNER_WEBHOOK is not set")
+			continue
+		}
 		targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 		ctx := context.Background()
 		runcnx, opts, ghcnx, err := githubSetup(ctx, onWebhook)

--- a/test/github_pullrequest_remote_annotations_test.go
+++ b/test/github_pullrequest_remote_annotations_test.go
@@ -105,7 +105,6 @@ func TestGithubPullRequestRemoteAnnotations(t *testing.T) {
 
 	assert.Equal(t, "pull_request", pr.Labels["pipelinesascode.tekton.dev/event-type"])
 	assert.Equal(t, repo.GetName(), pr.Labels["pipelinesascode.tekton.dev/repository"])
-	assert.Equal(t, opts.Owner, pr.Labels["pipelinesascode.tekton.dev/sender"])
 	assert.Equal(t, sha, pr.Labels["pipelinesascode.tekton.dev/sha"])
 	assert.Equal(t, opts.Owner, pr.Labels["pipelinesascode.tekton.dev/url-org"])
 	assert.Equal(t, opts.Repo, pr.Labels["pipelinesascode.tekton.dev/url-repository"])

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -29,8 +29,8 @@ func TestGithubPullRequest(t *testing.T) {
 	for _, onWebhook := range []bool{false, true} {
 		targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 		ctx := context.Background()
-		if onWebhook && os.Getenv("GITHUB_REPO_OWNER_WEBHOOK") == "" {
-			t.Skip("GITHUB_REPO_OWNER_WEBHOOK is not set")
+		if onWebhook && os.Getenv("TEST_HUB_REPO_OWNER_WEBHOOK") == "" {
+			t.Skip("TEST_HUB_REPO_OWNER_WEBHOOK is not set")
 			continue
 		}
 		runcnx, opts, ghvcs, err := githubSetup(ctx, onWebhook)

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -29,7 +29,10 @@ func TestGithubPullRequest(t *testing.T) {
 	for _, onWebhook := range []bool{false, true} {
 		targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 		ctx := context.Background()
-
+		if onWebhook && os.Getenv("GITHUB_REPO_OWNER_WEBHOOK") == "" {
+			t.Skip("GITHUB_REPO_OWNER_WEBHOOK is not set")
+			continue
+		}
 		runcnx, opts, ghvcs, err := githubSetup(ctx, onWebhook)
 		assert.NilError(t, err)
 		if onWebhook {

--- a/test/github_push_test.go
+++ b/test/github_push_test.go
@@ -6,6 +6,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
@@ -21,6 +22,10 @@ func TestGithubPush(t *testing.T) {
 		targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-push")
 		targetBranch := targetNS
 		targetEvent := "push"
+		if onWebhook && os.Getenv("GITHUB_REPO_OWNER_WEBHOOK") == "" {
+			t.Skip("GITHUB_REPO_OWNER_WEBHOOK is not set")
+			continue
+		}
 
 		ctx := context.Background()
 		runcnx, opts, gvcs, err := githubSetup(ctx, onWebhook)

--- a/test/github_push_test.go
+++ b/test/github_push_test.go
@@ -22,8 +22,8 @@ func TestGithubPush(t *testing.T) {
 		targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-push")
 		targetBranch := targetNS
 		targetEvent := "push"
-		if onWebhook && os.Getenv("GITHUB_REPO_OWNER_WEBHOOK") == "" {
-			t.Skip("GITHUB_REPO_OWNER_WEBHOOK is not set")
+		if onWebhook && os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK") == "" {
+			t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
 			continue
 		}
 

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -67,7 +67,7 @@ func bitbucketCloudSetup(ctx context.Context) (*params.Run, E2EOptions, bitbucke
 		"BITBUCKET_CLOUD_TOKEN", "BITBUCKET_CLOUD_E2E_REPOSITORY", "BITBUCKET_CLOUD_API_URL",
 	} {
 		if env := os.Getenv("TEST_" + value); env == "" {
-			return nil, E2EOptions{}, bitbucketcloud.VCS{}, fmt.Errorf("\"TEST_%s\" env variable is required, cannot continue", value)
+			return nil, E2EOptions{}, bitbucketcloud.VCS{}, fmt.Errorf("\"TEST_%s\" env variable is required, skipping", value)
 		}
 	}
 
@@ -100,8 +100,11 @@ func githubSetup(ctx context.Context, viaDirectWebhook bool) (*params.Run, E2EOp
 	githubRepoOwnerDirectWebhook := os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK")
 
 	for _, value := range []string{
-		"EL_URL", "GITHUB_API_URL", "GITHUB_TOKEN",
-		"GITHUB_REPO_OWNER_WEBHOOK", "GITHUB_REPO_OWNER_GITHUBAPP", "EL_WEBHOOK_SECRET",
+		"EL_URL",
+		"GITHUB_API_URL",
+		"GITHUB_TOKEN",
+		"GITHUB_REPO_OWNER_GITHUBAPP",
+		"EL_WEBHOOK_SECRET",
 	} {
 		if env := os.Getenv("TEST_" + value); env == "" {
 			return nil, E2EOptions{}, github.VCS{}, fmt.Errorf("\"TEST_%s\" env variable is required, cannot continue", value)


### PR DESCRIPTION
- skip webhook and bitbucket if not set
- don't bug on WEBHOOK not configured
- Set GH_TOKEN as well for gh
- Github: allow a user who belong to the repo to run CI
- Github: allow a user who belong to the repo to run CI
- Fix e2e tests for remote annotations when the sender != Owner of the repo
- fix env variable
- Add github action for E2E
