### PR TITLE
Add CloneURL, Lower Secrets name and PRName to status

### DIFF
--- a/pkg/kubeinteraction/secrets_test.go
+++ b/pkg/kubeinteraction/secrets_test.go
@@ -18,8 +18,8 @@ import (
 func TestCreateBasicAuthSecret(t *testing.T) {
 	nsNotThere := "not_there"
 	nsthere := "there"
+	secrete := "verysecrete"
 
-	ctx, _ := rtesting.SetupFakeContext(t)
 	tdata := testclient.Data{
 		Namespaces: []*corev1.Namespace{
 			{
@@ -51,45 +51,63 @@ func TestCreateBasicAuthSecret(t *testing.T) {
 			},
 		},
 	}
-	stdata, _ := testclient.SeedTestData(t, ctx, tdata)
-	observer, _ := zapobserver.New(zap.InfoLevel)
-	fakelogger := zap.New(observer).Sugar()
-	kint := Interaction{
-		Run: &params.Run{
-			Clients: clients.Clients{
-				Kube: stdata.Kube,
-				Log:  fakelogger,
-			},
-		},
-	}
-	runevent := info.Event{
+	event := info.Event{
 		Owner:      "owner",
 		Repository: "repo",
 		URL:        "https://forge/owner/repo",
 	}
 
 	tests := []struct {
-		name     string
-		targetNS string
+		name                   string
+		targetNS               string
+		event                  info.Event
+		expectedGitCredentials string
+		expectedSecretName     string
 	}{
 		{
-			name:     "Target secret not there",
-			targetNS: nsNotThere,
+			name:                   "Target secret not there",
+			targetNS:               nsNotThere,
+			event:                  event,
+			expectedGitCredentials: "https://git:verysecrete@forge/owner/repo",
+			expectedSecretName:     "pac-git-basic-auth-owner-repo",
 		},
 		{
-			name:     "Target secret already there",
-			targetNS: nsthere,
+			name:                   "Target secret already there",
+			targetNS:               nsthere,
+			event:                  event,
+			expectedGitCredentials: "https://git:verysecrete@forge/owner/repo",
+			expectedSecretName:     "pac-git-basic-auth-owner-repo",
+		},
+		{
+			name:                   "Lowercase secrets",
+			targetNS:               nsthere,
+			event:                  info.Event{Owner: "UPPER", Repository: "CASE", URL: "https://forge/UPPER/CASE"},
+			expectedGitCredentials: "https://git:verysecrete@forge/UPPER/CASE",
+			expectedSecretName:     "pac-git-basic-auth-upper-case",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := kint.CreateBasicAuthSecret(ctx, &runevent, &info.PacOpts{VCSToken: "verysecrete"}, tt.targetNS)
+			ctx, _ := rtesting.SetupFakeContext(t)
+			stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			fakelogger := zap.New(observer).Sugar()
+			kint := Interaction{
+				Run: &params.Run{
+					Clients: clients.Clients{
+						Kube: stdata.Kube,
+						Log:  fakelogger,
+					},
+				},
+			}
+			err := kint.CreateBasicAuthSecret(ctx, &tt.event, &info.PacOpts{VCSToken: secrete}, tt.targetNS)
 			assert.NilError(t, err)
+
 			slist, err := kint.Run.Clients.Kube.CoreV1().Secrets(tt.targetNS).List(ctx, metav1.ListOptions{})
 			assert.NilError(t, err)
 			assert.Assert(t, len(slist.Items) > 0, "Secret has not been created")
-			assert.Equal(t, slist.Items[0].Name, "pac-git-basic-auth-owner-repo")
-			assert.Equal(t, slist.Items[0].StringData[".git-credentials"], "https://git:verysecrete@forge/owner/repo")
+			assert.Equal(t, slist.Items[0].Name, tt.expectedSecretName)
+			assert.Equal(t, slist.Items[0].StringData[".git-credentials"], tt.expectedGitCredentials)
 		})
 	}
 }

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -22,4 +22,7 @@ type Event struct {
 
 	// Bitbucket
 	AccountID string
+
+	// Bitbucket Server
+	CloneURL string // bitbucket server has a different cloneurl than normal url
 }

--- a/pkg/pipelineascode/status.go
+++ b/pkg/pipelineascode/status.go
@@ -154,13 +154,13 @@ func postFinalStatus(ctx context.Context, cs *params.Run, k8int kubeinteraction.
 		fmt.Fprintf(&outputBuffer, "failed to execute template: ")
 		return pr, err
 	}
-
 	output := outputBuffer.String()
 	err = createStatus(ctx, vcsintf, cs, webvcs.StatusOpts{
-		Status:     "completed",
-		Conclusion: pipelineRunStatus(pr),
-		Text:       output,
-		DetailsURL: consoleURL,
+		Status:          "completed",
+		Conclusion:      pipelineRunStatus(pr),
+		Text:            output,
+		PipelineRunName: pr.Name,
+		DetailsURL:      consoleURL,
 	}, false)
 
 	return pr, err

--- a/pkg/pipelineascode/templating.go
+++ b/pkg/pipelineascode/templating.go
@@ -3,6 +3,8 @@ package pipelineascode
 import (
 	"regexp"
 	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 )
 
 var reTemplate = regexp.MustCompile(`{{([^}]{2,})}}`)
@@ -16,5 +18,22 @@ func ReplacePlaceHoldersVariables(template string, dico map[string]string) strin
 			return s
 		}
 		return dico[key]
+	})
+}
+
+// processTemplates process all templates replacing
+func processTemplates(event *info.Event, template string) string {
+	repoURL := event.URL
+	// On bitbucket server you are have a special url for checking it out, they
+	// seemed to fix it in 2.0 but i guess we have to live with this until then.
+	if event.CloneURL != "" {
+		repoURL = event.CloneURL
+	}
+
+	return ReplacePlaceHoldersVariables(template, map[string]string{
+		"revision":   event.SHA,
+		"repo_url":   repoURL,
+		"repo_owner": strings.ToLower(event.Owner),
+		"repo_name":  strings.ToLower(event.Repository),
 	})
 }

--- a/pkg/pipelineascode/templating_test.go
+++ b/pkg/pipelineascode/templating_test.go
@@ -4,23 +4,78 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"gotest.tools/v3/assert"
 )
 
 func TestReplacePlaceHoldersVariables(t *testing.T) {
-	template := `revision: {{ revision }}}
-url: {{ url }}
-bar: {{ bar}}
-`
-	expected := `revision: master}
-url: https://chmouel.com
-bar: {{ bar}}
-`
-	dico := map[string]string{
-		"revision": "master",
-		"url":      "https://chmouel.com",
+	tests := []struct {
+		name     string
+		template string
+		expected string
+		dicto    map[string]string
+	}{
+		{
+			name:     "Test Replace",
+			template: `revision: {{ revision }}} url: {{ url }} bar: {{ bar}}`,
+			expected: `revision: master} url: https://chmouel.com bar: {{ bar}}`,
+			dicto: map[string]string{
+				"revision": "master",
+				"url":      "https://chmouel.com",
+			},
+		},
 	}
-	got := ReplacePlaceHoldersVariables(template, dico)
-	if d := cmp.Diff(got, expected); d != "" {
-		t.Fatalf("-got, +want: %v", d)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ReplacePlaceHoldersVariables(tt.template, tt.dicto)
+			if d := cmp.Diff(got, tt.expected); d != "" {
+				t.Fatalf("-got, +want: %v", d)
+			}
+		})
+	}
+}
+
+func TestProcessTemplates(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    *info.Event
+		template string
+		expected string
+	}{
+		{
+			name: "test process templates",
+			event: &info.Event{
+				SHA:        "abcd",
+				URL:        "http://chmouel.com",
+				Owner:      "owner",
+				Repository: "repository",
+			},
+			template: `{{ revision }} {{ repo_owner }} {{ repo_name }} {{ repo_url }}`,
+			expected: "abcd owner repository http://chmouel.com",
+		},
+		{
+			name: "test process templates lowering owner and repository",
+			event: &info.Event{
+				Owner:      "OWNER",
+				Repository: "REPOSITORY",
+			},
+			template: `{{ repo_owner }} {{ repo_name }}`,
+			expected: "owner repository",
+		},
+		{
+			name: "test process use cloneurl",
+			event: &info.Event{
+				CloneURL: "https://cloneurl",
+				URL:      "http://chmouel.com",
+			},
+			template: `{{ repo_url }}`,
+			expected: "https://cloneurl",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processed := processTemplates(tt.event, tt.template)
+			assert.Equal(t, tt.expected, processed)
+		})
 	}
 }

--- a/pkg/webvcs/interface.go
+++ b/pkg/webvcs/interface.go
@@ -8,12 +8,13 @@ import (
 )
 
 type StatusOpts struct {
-	Status     string
-	Conclusion string
-	Text       string
-	DetailsURL string
-	Summary    string
-	Title      string
+	PipelineRunName string
+	Status          string
+	Conclusion      string
+	Text            string
+	DetailsURL      string
+	Summary         string
+	Title           string
 }
 
 type Interface interface {


### PR DESCRIPTION
Add a CloneURL to info.Events for Bitbucket Server mostly but may be use by
others.

Lower secrets name, since an org is a project in bitbucket server and a project
can be uppercase which bugs out the secret creation.

Add PipelineRunName to status for VCS drivers to add, which in case of bitbucket
server is useful.
