### PR TITLE
Add \n to OKToTestCommentRegexp

### DIFF
--- a/pkg/acl/acl.go
+++ b/pkg/acl/acl.go
@@ -6,7 +6,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const OKToTestCommentRegexp = `(^|\n)/ok-to-test(\r\n|$)`
+const OKToTestCommentRegexp = `(^|\n)\/ok-to-test(\r\n|\r|\n|$)`
 
 // ownersConfig prow owner, only supporting approvers or reviewers in yaml
 type ownersConfig struct {

--- a/pkg/acl/acl_test.go
+++ b/pkg/acl/acl_test.go
@@ -1,6 +1,50 @@
 package acl
 
-import "testing"
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestRegexp(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		matched bool
+	}{
+		{
+			name:    "bad/match regexp",
+			text:    "foo bar",
+			matched: false,
+		},
+		{
+			name:    "good/match regexp",
+			text:    "/ok-to-test",
+			matched: true,
+		},
+		{
+			name:    "good/match regexp newline",
+			text:    "\n/ok-to-test",
+			matched: true,
+		},
+		{
+			name:    "bad/match regexp newline space",
+			text:    "\n /ok-to-test",
+			matched: false,
+		},
+		{
+			name:    "good/in the middle",
+			text:    "foo bar\n/ok-to-test\nhello moto",
+			matched: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched := MatchRegexp(OKToTestCommentRegexp, tt.text)
+			assert.Equal(t, tt.matched, matched)
+		})
+	}
+}
 
 func TestUserInOwnerFile(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
on bitbucket server it is  just the \n for carriage return, on github it's \r\n
add unit tests.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
