### PR TITLE
[githubaction] collect all pods logs directly after pipeline finished

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -190,6 +190,13 @@ jobs:
         run: |
           mkdir -p /tmp/logs
           kind export logs /tmp/logs
+
+          mkdir /tmp/logs/pac-runs
+          for pod in $(kubectl get pod -o name -n pipelines-as-code
+            -l triggers.tekton.dev/eventlistener=pipelines-as-code-interceptor|sed 's,.*/,,');do
+            kubectl logs ${pod} > /tmp/logs/pac-runs/${pod}.log;
+          done
+
       - name: Upload artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
