### PR TITLE
Make sure we strip refs/heads when exposing branch

### DIFF
--- a/pkg/templates/templating.go
+++ b/pkg/templates/templating.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 )
 
@@ -35,8 +36,8 @@ func Process(event *info.Event, template string) string {
 		"repo_url":      repoURL,
 		"repo_owner":    strings.ToLower(event.Organization),
 		"repo_name":     strings.ToLower(event.Repository),
-		"target_branch": strings.ToLower(event.BaseBranch),
-		"source_branch": strings.ToLower(event.HeadBranch),
+		"target_branch": formatting.SanitizeBranch(event.BaseBranch),
+		"source_branch": formatting.SanitizeBranch(event.HeadBranch),
 		"sender":        strings.ToLower(event.Sender),
 	})
 }

--- a/pkg/templates/templating_test.go
+++ b/pkg/templates/templating_test.go
@@ -57,6 +57,16 @@ func TestProcessTemplates(t *testing.T) {
 			expected: "abcd owner repository http://chmouel.com ohyeah ohno apollo",
 		},
 		{
+			name: "strip refs head from branches",
+			event: &info.Event{
+				HeadBranch: "refs/heads/ohyeah",
+				BaseBranch: "refs/heads/ohno",
+				Sender:     "apollo",
+			},
+			template: `{{ source_branch }} {{ target_branch }}`,
+			expected: "ohyeah ohno",
+		},
+		{
 			name: "test process templates lowering owner and repository",
 			event: &info.Event{
 				Organization: "OWNER",


### PR DESCRIPTION
we would not be able to use it otherwise.

Fixes #459

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
