### PR TITLE
Update CheckRun when there is one

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -156,8 +156,6 @@ spec:
   workspaces:
     - name: source
       volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
         spec:
           accessModes:
             - ReadWriteOnce

--- a/pkg/provider/github/events.go
+++ b/pkg/provider/github/events.go
@@ -54,6 +54,7 @@ func (v *Provider) getAppToken(ctx context.Context, kube kubernetes.Interface, g
 	if err != nil {
 		return "", fmt.Errorf("could not parse the github application_id number from secret: %w", err)
 	}
+	v.ApplicationID = &applicationID
 
 	privateKey := secret.Data["github-private-key"]
 

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -21,6 +21,7 @@ const apiPublicURL = "https://api.github.com/"
 type Provider struct {
 	Client        *github.Client
 	Token, APIURL *string
+	ApplicationID *int64
 }
 
 func (v *Provider) Validate(ctx context.Context, cs *params.Run, event *info.Event) error {


### PR DESCRIPTION
# Changes

When there was an already exiting check_run we discover it. It fixes the
issue when we :

- Create a commit
- There is a failure before we have checked out the pipelinerun match
  (ie: hub is down and fail to get the taskRef remotely)
- We do a /retest and the error is fixed.
- We would still have the status of the first failure as well a second
  successfull one.

We now list the check_runs attached to the ref created by our
ApplicationID and re-use that ID instead of creating a new one.

There is a slight bug in github interface, if we update the check run
and set as pending, it doesn't reflect it in the UI. It does change it
when the check_run went from failure to successfull so that's fine.

Demo:

https://user-images.githubusercontent.com/98980/161552542-bd0cb1ee-be5c-4f1a-83f5-6c4a50f81b01.mp4



# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then make sure to get the flakiness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
