### PR TITLE
Use sync.Map instead of map

### DIFF
--- a/pkg/hub/get_test.go
+++ b/pkg/hub/get_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -16,18 +17,19 @@ func TestGetTask(t *testing.T) {
 	const testHubURL = "https://myprecioushub"
 	const testCatalogHubName = "tekton"
 
-	hubCatalogs := map[string]settings.HubCatalog{
-		"default": {
+	var hubCatalogs sync.Map
+	hubCatalogs.Store(
+		"default", settings.HubCatalog{
 			ID:   "default",
 			URL:  testHubURL,
 			Name: testCatalogHubName,
-		},
-		"anotherHub": {
+		})
+	hubCatalogs.Store(
+		"anotherHub", settings.HubCatalog{
 			ID:   "anotherHub",
 			URL:  testHubURL,
 			Name: testCatalogHubName,
-		},
-	}
+		})
 	tests := []struct {
 		name        string
 		task        string
@@ -120,7 +122,7 @@ func TestGetTask(t *testing.T) {
 				},
 				Info: info.Info{Pac: &info.PacOpts{
 					Settings: &settings.Settings{
-						HubCatalogs: hubCatalogs,
+						HubCatalogs: &hubCatalogs,
 					},
 				}},
 			}

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
@@ -120,18 +121,18 @@ func (r *Run) UpdatePACInfo(ctx context.Context) error {
 }
 
 func New() *Run {
+	hubCatalog := &sync.Map{}
+	hubCatalog.Store("default", settings.HubCatalog{
+		ID:   "default",
+		Name: settings.HubCatalogNameDefaultValue,
+		URL:  settings.HubURLDefaultValue,
+	})
 	return &Run{
 		Info: info.Info{
 			Pac: &info.PacOpts{
 				Settings: &settings.Settings{
 					ApplicationName: settings.PACApplicationNameDefaultValue,
-					HubCatalogs: map[string]settings.HubCatalog{
-						"default": {
-							ID:   "default",
-							Name: settings.HubCatalogNameDefaultValue,
-							URL:  settings.HubURLDefaultValue,
-						},
-					},
+					HubCatalogs:     hubCatalog,
 				},
 			},
 		},

--- a/pkg/params/settings/default_test.go
+++ b/pkg/params/settings/default_test.go
@@ -23,11 +23,10 @@ func TestGetCatalogHub(t *testing.T) {
 	config["catalog-1-url"] = "https://foo.com"
 	config["catalog-1-name"] = "https://foo.com"
 	tests := []struct {
-		name             string
-		config           map[string]string
-		numCatalogs      int
-		wantLog          string
-		existingSettings *Settings
+		name        string
+		config      map[string]string
+		numCatalogs int
+		wantLog     string
 	}{
 		{
 			name:        "good/default catalog",
@@ -80,11 +79,13 @@ func TestGetCatalogHub(t *testing.T) {
 			if tt.config == nil {
 				tt.config = map[string]string{}
 			}
-			if tt.existingSettings == nil {
-				tt.existingSettings = &Settings{}
-			}
-			catalogs := gethHubCatalogs(fakelogger, tt.existingSettings, tt.config)
-			assert.Equal(t, len(catalogs), tt.numCatalogs)
+			catalogs := getHubCatalogs(fakelogger, tt.config)
+			length := 0
+			catalogs.Range(func(_, _ interface{}) bool {
+				length++
+				return true
+			})
+			assert.Equal(t, length, tt.numCatalogs)
 			if tt.wantLog != "" {
 				assert.Assert(t, len(catcher.FilterMessageSnippet(tt.wantLog).TakeAll()) > 0, "could not find log message: got ", catcher)
 			}


### PR DESCRIPTION
This will move the code to use sync.Map instead of map to fix concurrent write

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
