### PR TITLE
Gitlab: Fix posting prun status on GitOPS comments

### DIFF
--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
@@ -207,7 +208,9 @@ func (v *Provider) CreateStatus(_ context.Context, event *info.Event, statusOpts
 	_, _, _ = v.Client.Commits.SetCommitStatus(event.SourceProjectID, event.SHA, opt)
 
 	// only add a note when we are on a MR
-	if event.EventType == triggertype.PullRequest.String() || event.EventType == "Merge_Request" || event.EventType == "Merge Request" {
+	if event.EventType == triggertype.PullRequest.String() ||
+		event.EventType == "Merge_Request" || event.EventType == "Merge Request" ||
+		opscomments.IsAnyOpsEventType(event.EventType) {
 		mopt := &gitlab.CreateMergeRequestNoteOptions{Body: gitlab.Ptr(body)}
 		_, _, err := v.Client.Notes.CreateMergeRequestNote(event.TargetProjectID, event.PullRequestNumber, mopt)
 		return err

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -135,6 +135,20 @@ func TestCreateStatus(t *testing.T) {
 			},
 		},
 		{
+			name:       "gitops comments completed",
+			wantClient: true,
+			wantErr:    false,
+			args: args{
+				statusOpts: provider.StatusOpts{
+					Conclusion: "completed",
+				},
+				event: &info.Event{
+					TriggerTarget: "Note",
+				},
+				postStr: "has completed",
+			},
+		},
+		{
 			name:       "completed with a details url",
 			wantClient: true,
 			wantErr:    false,

--- a/pkg/provider/gitlab/parse_payload_test.go
+++ b/pkg/provider/gitlab/parse_payload_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v56/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	thelp "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab/test"
@@ -116,7 +117,7 @@ func TestParsePayload(t *testing.T) {
 				payload: sample.NoteEventAsJSON(""),
 			},
 			want: &info.Event{
-				EventType:     "Note",
+				EventType:     opscomments.NoOpsCommentEventType.String(),
 				TriggerTarget: "pull_request",
 				Organization:  "hello-this-is-me-ze",
 				Repository:    "project",
@@ -129,7 +130,7 @@ func TestParsePayload(t *testing.T) {
 				payload: sample.NoteEventAsJSON("/test dummy"),
 			},
 			want: &info.Event{
-				EventType:     "Note",
+				EventType:     opscomments.TestSingleCommentEventType.String(),
 				TriggerTarget: "pull_request",
 				Organization:  "hello-this-is-me-ze",
 				Repository:    "project",
@@ -143,7 +144,7 @@ func TestParsePayload(t *testing.T) {
 				payload: sample.NoteEventAsJSON("/cancel"),
 			},
 			want: &info.Event{
-				EventType:     "Note",
+				EventType:     opscomments.CancelCommentAllEventType.String(),
 				TriggerTarget: "pull_request",
 				Organization:  "hello-this-is-me-ze",
 				Repository:    "project",
@@ -156,7 +157,7 @@ func TestParsePayload(t *testing.T) {
 				payload: sample.NoteEventAsJSON("/cancel dummy"),
 			},
 			want: &info.Event{
-				EventType:     "Note",
+				EventType:     opscomments.CancelCommentSingleEventType.String(),
 				TriggerTarget: "pull_request",
 				Organization:  "hello-this-is-me-ze",
 				Repository:    "project",

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -43,7 +43,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var successRegexp = regexp.MustCompile(`^Pipelines as Code CI.*has.*successfully`)
+// successRegexp will match a success text paac comment,sometime it includes html tags so we need to consider that.
+var successRegexp = regexp.MustCompile(`.*Pipelines as Code CI.*has.*successfully.*validated your commit.*`)
 
 func TestGiteaPullRequestTaskAnnotations(t *testing.T) {
 	topts := &tgitea.TestOpts{


### PR DESCRIPTION
We were not posting the status on GitOPS comments, this is because we were not catching the Note events as defined by the Gitlab provider.

Better functional tests to check the actual comments has been posted properly on GitOPS comments for gitea.

This has been backported as well for release-v0.24.x in https://github.com/openshift-pipelines/pipelines-as-code/pull/1585

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
