### PR TITLE
Implement GetFiles Func of Bitbucket Server Provider for CEL Expression

### DIFF
--- a/pkg/provider/bitbucketserver/test/test_types.go
+++ b/pkg/provider/bitbucketserver/test/test_types.go
@@ -1,0 +1,24 @@
+package test
+
+type Pagination struct {
+	Start    int  `json:"start"`
+	Size     int  `json:"size"`
+	Limit    int  `json:"limit"`
+	LastPage bool `json:"isLastPage"`
+	NextPage int  `json:"nextPageStart"`
+}
+
+type DiffPath struct {
+	ToString string `json:"toString"`
+}
+
+type DiffStat struct {
+	Path    DiffPath  `json:"path"`
+	SrcPath *DiffPath `json:"srcPath,omitempty"` // used in lib that's why leaving it here nil
+	Type    string    `json:"type"`
+}
+
+type DiffStats struct {
+	Pagination
+	Values []*DiffStat
+}

--- a/test/bitbucket_server_push_test.go
+++ b/test/bitbucket_server_push_test.go
@@ -1,0 +1,66 @@
+//go:build e2e
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	tbbs "github.com/openshift-pipelines/pipelines-as-code/test/pkg/bitbucketserver"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+)
+
+func TestBitbucketServerCELPathChangeOnPush(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	bitbucketWSOwner := os.Getenv("TEST_BITBUCKET_SERVER_E2E_REPOSITORY")
+
+	ctx, runcnx, opts, client, err := tbbs.Setup(ctx)
+	assert.NilError(t, err)
+
+	repo := tbbs.CreateCRD(ctx, t, client, runcnx, bitbucketWSOwner, targetNS)
+	runcnx.Clients.Log.Infof("Repository %s has been created", repo.Name)
+	defer tbbs.TearDownNs(ctx, t, runcnx, targetNS)
+
+	files := map[string]string{
+		".tekton/pipelinerun.yaml": "testdata/pipelinerun-cel-path-changed.yaml",
+	}
+
+	mainBranchRef := "refs/heads/main"
+	branch, resp, err := client.Git.CreateRef(ctx, bitbucketWSOwner, targetNS, mainBranchRef)
+	assert.NilError(t, err, "error creating branch: http status code: %d : %v", resp.Status, err)
+	runcnx.Clients.Log.Infof("Branch %s has been created", branch.Name)
+	defer tbbs.TearDown(ctx, t, runcnx, client, -1, bitbucketWSOwner, branch.Name)
+
+	files, err = payload.GetEntries(files, targetNS, branch.Name, triggertype.Push.String(), map[string]string{})
+	assert.NilError(t, err)
+	gitCloneURL, err := scm.MakeGitCloneURL(repo.Clone, opts.UserName, opts.Password)
+	assert.NilError(t, err)
+	scmOpts := &scm.Opts{
+		GitURL:        gitCloneURL,
+		Log:           runcnx.Clients.Log,
+		WebURL:        repo.Clone,
+		TargetRefName: targetNS,
+		BaseRefName:   repo.Branch,
+		CommitTitle:   fmt.Sprintf("commit %s", targetNS),
+	}
+	scm.PushFilesToRefGit(t, scmOpts, files)
+	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetNS)
+
+	successOpts := wait.SuccessOpt{
+		TargetNS:        targetNS,
+		OnEvent:         triggertype.Push.String(),
+		NumberofPRMatch: 1,
+		MinNumberStatus: 1,
+	}
+	wait.Succeeded(ctx, t, runcnx, opts, successOpts)
+}

--- a/test/testdata/pipelinerun-cel-path-changed.yaml
+++ b/test/testdata/pipelinerun-cel-path-changed.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "\\ .TargetEvent //" && target_branch == "\\ .TargetBranch //" && ".tekton/***".pathChanged()
+spec:
+  pipelineSpec:
+    tasks:
+      - name: path-changed-task
+        taskSpec:
+          steps:
+            - name: test-changed-files-params-push
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "HELLOMOTO"]


### PR DESCRIPTION
implemented GetFiles func of Bitbucket server which lists changed files on an event. it also solves the issue in Bitbucket server where pathChanged() function in CEL expression was not working because the func was not implemented. this does slove the issue.

upstream issue: #1738 
https://issues.redhat.com/browse/SRVKP-5834

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ❌️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ✅️        |

  (update the documentation accordingly)
