### PR TITLE
fix: Migrate From brews to homebrew_casks in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,25 +74,26 @@ release:
 
     https://release-{{ replace .Tag "." "-" }}.pipelines-as-code.pages.dev
 
-brews:
+homebrew_casks:
   - name: tektoncd-pac
     repository:
       owner: openshift-pipelines
       name: homebrew-pipelines-as-code
     directory: Formula
     dependencies:
-      - name: tektoncd-cli
-        type: optional
-      - name: git
+      - formula: tektoncd-cli
+      - formula: git
     homepage: "https://pipelinesascode.com"
     description: tkn-pac - A command line interface for interacting with Pipelines as Code
-    install: |
-      bin.install "tkn-pac" => "tkn-pac"
-      output = Utils.popen_read("SHELL=bash #{bin}/tkn-pac completion bash")
-      (bash_completion/"tkn-pac").write output
-      output = Utils.popen_read("SHELL=zsh #{bin}/tkn-pac completion zsh")
-      (zsh_completion/"_tkn-pac").write output
-      prefix.install_metafiles
+    hooks:
+      pre:
+        install: |
+          bin.install "tkn-pac" => "tkn-pac"
+          output = Utils.popen_read("SHELL=bash #{bin}/tkn-pac completion bash")
+          (bash_completion/"tkn-pac").write output
+          output = Utils.popen_read("SHELL=zsh #{bin}/tkn-pac completion zsh")
+          (zsh_completion/"_tkn-pac").write output
+          prefix.install_metafiles
 nfpms:
   - file_name_template: >-
       tkn-pac-


### PR DESCRIPTION
made changes to goreleaser to use homebrews_casks instead of brews

confirmed with `goreleaser check` locally
```
zashaikh@zashaikh-thinkpadp1gen4i:~/go-projects/pipelines-as-code$ goreleaser check 
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).
