### PR TITLE
fix(gitlab): trigger PipelineRun only on label change

### DIFF
--- a/pkg/provider/gitlab/detect_test.go
+++ b/pkg/provider/gitlab/detect_test.go
@@ -73,6 +73,20 @@ func TestProvider_Detect(t *testing.T) {
 			processReq: true,
 		},
 		{
+			name:       "good/mergeRequest update Event with title",
+			event:      sample.MREventAsJSON("update", `"title": "test"`),
+			eventType:  gitlab.EventTypeMergeRequest,
+			isGL:       true,
+			processReq: false,
+		},
+		{
+			name:       "good/mergeRequest update Event with description",
+			event:      sample.MREventAsJSON("update", `"description": "test pac"`),
+			eventType:  gitlab.EventTypeMergeRequest,
+			isGL:       true,
+			processReq: false,
+		},
+		{
 			name:       "good/note event",
 			event:      sample.NoteEventAsJSON("abc"),
 			eventType:  gitlab.EventTypeNote,


### PR DESCRIPTION
* Before this patch pipeline was triggered on any merge request update, regardless of what changed such as title, description or assigne changes

* With the current change, pipeline will be triggered only when labels are added or removed

* Fixes: https://issues.redhat.com/browse/SRVKP-7383

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [x] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [x] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [x] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
