### PR TITLE
Revert "Adding logs whenever client uses token which is security best practice"

### DIFF
--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -203,16 +203,12 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, event *info.Eve
 		return fmt.Errorf("no git_provider.user has been in repo crd")
 	}
 	v.bbClient = bitbucket.NewBasicAuth(event.Provider.User, event.Provider.Token)
-	// Added log for security audit purposes to log client access when a token is used
-	v.Logger.Infof("bitbucket-cloud: initialized client with provided token for user=%s", event.Provider.User)
-
 	v.Token = &event.Provider.Token
 	v.Username = &event.Provider.User
 	v.run = run
 	v.eventEmitter = eventEmitter
 	v.repo = repo
 	v.triggerEvent = event.EventType
-
 	return nil
 }
 

--- a/pkg/provider/bitbucketcloud/bitbucket_test.go
+++ b/pkg/provider/bitbucketcloud/bitbucket_test.go
@@ -137,9 +137,7 @@ func TestSetClient(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
-			observer, _ := zapobserver.New(zap.InfoLevel)
-			logger := zap.New(observer).Sugar()
-			v := Provider{Logger: logger}
+			v := Provider{}
 			err := v.SetClient(ctx, nil, tt.event, nil, nil)
 			if tt.wantErrSubstr != "" {
 				assert.ErrorContains(t, err, tt.wantErrSubstr)

--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
@@ -307,9 +307,6 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 			},
 		}
 		v.client = client
-
-		// Added for security audit purposes to log client access when a token is used
-		v.Logger.Infof("bitbucket-datacenter: initialized client with provided token for user=%s providerURL=%s", event.Provider.User, event.Provider.URL)
 	}
 	v.run = run
 	v.repo = repo

--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter_test.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter_test.go
@@ -362,15 +362,13 @@ func TestSetClient(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			observer, _ := zapobserver.New(zap.InfoLevel)
-			logger := zap.New(observer).Sugar()
 			ctx, _ := rtesting.SetupFakeContext(t)
 			client, mux, tearDown, tURL := bbtest.SetupBBDataCenterClient()
 			defer tearDown()
 			if tt.muxUser != nil {
 				mux.HandleFunc("/users/foo", tt.muxUser)
 			}
-			v := &Provider{client: client, baseURL: tURL, Logger: logger}
+			v := &Provider{client: client, baseURL: tURL}
 			err := v.SetClient(ctx, nil, tt.opts, nil, nil)
 			if tt.wantErrSubstr != "" {
 				assert.ErrorContains(t, err, tt.wantErrSubstr)

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -159,10 +159,6 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.
 	if err != nil {
 		return err
 	}
-
-	// Added log for security audit purposes to log client access when a token is used
-	v.Logger.Infof("gitea: initialized API client with provided credentials user=%s providerURL=%s", runevent.Provider.User, apiURL)
-
 	v.giteaInstanceURL = runevent.Provider.URL
 	v.eventEmitter = emitter
 	v.repo = repo

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -301,13 +301,6 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 		return fmt.Errorf("no github client has been initialized")
 	}
 
-	// Added log for security audit purposes to log client access when a token is used
-	integration := "github-webhook"
-	if event.InstallationID != 0 {
-		integration = "github-app"
-	}
-	v.Logger.Infof(integration+": initialized OAuth2 client for providerName=%s providerURL=%s", v.providerName, event.Provider.URL)
-
 	v.APIURL = apiURL
 
 	if event.Provider.WebhookSecretFromRepo {

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -663,9 +663,7 @@ func TestGithubSetClient(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
-			observer, _ := zapobserver.New(zap.InfoLevel)
-			logger := zap.New(observer).Sugar()
-			v := Provider{Logger: logger}
+			v := Provider{}
 			err := v.SetClient(ctx, nil, tt.event, nil, nil)
 			assert.NilError(t, err)
 			assert.Equal(t, tt.expectedURL, *v.APIURL)

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -201,7 +201,6 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.
 	}
 	v.Token = &runevent.Provider.Token
 
-	v.Logger.Infof("gitlab: initialized for client with token for apiURL=%s, org=%s, repo=%s)", apiURL, runevent.Organization, runevent.Repository)
 	// In a scenario where the source repository is forked and a merge request (MR) is created on the upstream
 	// repository, runevent.SourceProjectID will not be 0 when SetClient is called from the pac-watcher code.
 	// This is because, in the controller, SourceProjectID is set in the annotation of the pull request,

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -260,14 +260,12 @@ func TestGetConfig(t *testing.T) {
 
 func TestSetClient(t *testing.T) {
 	ctx, _ := rtesting.SetupFakeContext(t)
-	observer, _ := zapobserver.New(zap.InfoLevel)
-	fakelogger := zap.New(observer).Sugar()
 	v := &Provider{}
 	assert.Assert(t, v.SetClient(ctx, nil, info.NewEvent(), nil, nil) != nil)
 
 	client, _, tearDown := thelp.Setup(t)
 	defer tearDown()
-	vv := &Provider{gitlabClient: client, Logger: fakelogger}
+	vv := &Provider{gitlabClient: client}
 	err := vv.SetClient(ctx, nil, &info.Event{
 		Provider: &info.Provider{
 			Token: "hello",
@@ -279,8 +277,6 @@ func TestSetClient(t *testing.T) {
 
 func TestSetClientDetectAPIURL(t *testing.T) {
 	ctx, _ := rtesting.SetupFakeContext(t)
-	observer, _ := zapobserver.New(zap.InfoLevel)
-	fakelogger := zap.New(observer).Sugar()
 	mockClient, _, tearDown := thelp.Setup(t)
 	defer tearDown()
 
@@ -385,7 +381,6 @@ func TestSetClientDetectAPIURL(t *testing.T) {
 				gitlabClient:      mockClient, // Use the shared mock client
 				repoURL:           tc.repoURL,
 				pathWithNamespace: tc.pathWithNamespace,
-				Logger:            fakelogger,
 			}
 			event := info.NewEvent()
 			event.Provider.Token = tc.providerToken

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -66,8 +66,7 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 	defer teardown()
 
 	vcx := &ghprovider.Provider{
-		Token:  github.Ptr("None"),
-		Logger: fakelogger,
+		Token: github.Ptr("None"),
 	}
 
 	vcx.SetGithubClient(fakeclient)


### PR DESCRIPTION
Reverts openshift-pipelines/pipelines-as-code#2111

this commit was causing panic in E2E tests after it is merged into main
https://github.com/openshift-pipelines/pipelines-as-code/actions/runs/15610481372/job/43969965809?pr=2122
