### PR TITLE
fix(bitbucketdatacenter): ignore branch deletion events in ParsePayload

### DIFF
--- a/pkg/provider/bitbucketdatacenter/parse_payload.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload.go
@@ -164,6 +164,13 @@ func (v *Provider) ParsePayload(_ context.Context, run *params.Run, request *htt
 			return nil, fmt.Errorf("push event contains no commits under 'changes'; cannot proceed")
 		}
 
+		// Check for branch deletion - if any change is a DELETE type with zero hash, skip processing
+		for _, change := range e.Changes {
+			if provider.IsZeroSHA(change.ToHash) && change.Type == "DELETE" {
+				return nil, fmt.Errorf("branch delete event is not supported; cannot proceed")
+			}
+		}
+
 		if len(e.Commits) == 0 {
 			return nil, fmt.Errorf("push event contains no commits; cannot proceed")
 		}


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
When a branch is deleted in Bitbucket Data Center, the `repo:refs_changed` webhook event contains a `toHash` with a zero SHA (`0000000000000000000000000000000000000000`). Previously, Pipelines as Code would attempt to process this event as a push, resulting in commit validation failures and noisy logs.
This patch updates the `ParsePayload` function to detect and ignore such events early, returning `(nil, nil)` when a branch deletion is detected. This ensures branch deletions are not processed like standard push events.
Fixes #2035
/kind bug



# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [x] Bitbucket Data Center

  (update the provider documentation accordingly)
