### PR TITLE
fix: Use Correct Event Type in Log Message in GetTektonDir func

### DIFF
--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -171,7 +171,7 @@ func (v *Provider) getDir(event *info.Event, path string) ([]bitbucket.Repositor
 		revision = event.DefaultBranch
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", event.DefaultBranch)
 	} else {
-		v.Logger.Infof("Using PipelineRun definition from source pull request SHA: %s", event.SHA)
+		v.Logger.Infof("Using PipelineRun definition from source %s commit SHA: %s", event.TriggerTarget.String(), event.SHA)
 	}
 	repoFileOpts := &bitbucket.RepositoryFilesOptions{
 		Owner:    event.Organization,

--- a/pkg/provider/bitbucketcloud/bitbucket_test.go
+++ b/pkg/provider/bitbucketcloud/bitbucket_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	bbcloudtest "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/test"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
@@ -35,11 +36,18 @@ func TestGetTektonDir(t *testing.T) {
 		filterMessageSnippet string
 	}{
 		{
-			name:                 "Get Tekton Directory",
-			event:                bbcloudtest.MakeEvent(nil),
+			name:                 "Get Tekton Directory on pull request",
+			event:                bbcloudtest.MakeEvent(&info.Event{TriggerTarget: triggertype.PullRequest}),
 			testDirPath:          "../../pipelineascode/testdata/pull_request/.tekton",
 			contentContains:      "kind: PipelineRun",
-			filterMessageSnippet: "Using PipelineRun definition from source pull request SHA",
+			filterMessageSnippet: "Using PipelineRun definition from source pull_request commit SHA",
+		},
+		{
+			name:                 "Get Tekton Directory on push",
+			event:                bbcloudtest.MakeEvent(&info.Event{TriggerTarget: triggertype.Push}),
+			testDirPath:          "../../pipelineascode/testdata/pull_request/.tekton",
+			contentContains:      "kind: PipelineRun",
+			filterMessageSnippet: "Using PipelineRun definition from source push commit SHA",
 		},
 		{
 			name:                 "Get Tekton Directory Mainbranch",

--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
@@ -212,7 +212,7 @@ func (v *Provider) GetTektonDir(ctx context.Context, event *info.Event, path, pr
 	at := ""
 	if v.provenance == "source" {
 		at = event.SHA
-		v.Logger.Infof("Using PipelineRun definition from source pull request SHA: %s", event.SHA)
+		v.Logger.Infof("Using PipelineRun definition from source %s commit SHA: %s", event.TriggerTarget.String(), event.SHA)
 	} else {
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", event.DefaultBranch)
 	}

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -254,7 +254,7 @@ func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, prov
 		revision = event.DefaultBranch
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", event.DefaultBranch)
 	} else {
-		v.Logger.Infof("Using PipelineRun definition from source pull request SHA: %s", event.SHA)
+		v.Logger.Infof("Using PipelineRun definition from source %s commit SHA: %s", event.TriggerTarget.String(), event.SHA)
 	}
 
 	tektonDirSha := ""

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -324,7 +324,11 @@ func (v *Provider) GetTektonDir(ctx context.Context, runevent *info.Event, path,
 		revision = runevent.DefaultBranch
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", runevent.DefaultBranch)
 	} else {
-		v.Logger.Infof("Using PipelineRun definition from source pull request %s/%s#%d SHA on %s", runevent.Organization, runevent.Repository, runevent.PullRequestNumber, runevent.SHA)
+		prInfo := ""
+		if runevent.TriggerTarget == triggertype.PullRequest {
+			prInfo = fmt.Sprintf("%s/%s#%d", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
+		}
+		v.Logger.Infof("Using PipelineRun definition from source %s %s on commit SHA %s", runevent.TriggerTarget.String(), prInfo, runevent.SHA)
 	}
 
 	rootobjects, _, err := v.Client().Git.GetTree(ctx, runevent.Organization, runevent.Repository, revision, false)

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -240,15 +240,32 @@ func TestGetTektonDir(t *testing.T) {
 		expectedGHApiCalls   int64
 	}{
 		{
-			name: "test no subtree",
+			name: "test no subtree on pull request",
 			event: &info.Event{
-				Organization: "tekton",
-				Repository:   "cat",
-				SHA:          "123",
+				Organization:  "tekton",
+				Repository:    "cat",
+				SHA:           "123",
+				TriggerTarget: triggertype.PullRequest,
 			},
 			expectedString:       "PipelineRun",
 			treepath:             "testdata/tree/simple",
-			filterMessageSnippet: "Using PipelineRun definition from source pull request tekton/cat#0",
+			filterMessageSnippet: "Using PipelineRun definition from source pull_request tekton/cat#0",
+			// 1. Get Repo root objects
+			// 2. Get Tekton Dir objects
+			// 3/4. Get object content for each object (pipelinerun.yaml, pipeline.yaml)
+			expectedGHApiCalls: 4,
+		},
+		{
+			name: "test no subtree on push",
+			event: &info.Event{
+				Organization:  "tekton",
+				Repository:    "cat",
+				SHA:           "123",
+				TriggerTarget: triggertype.Push,
+			},
+			expectedString:       "PipelineRun",
+			treepath:             "testdata/tree/simple",
+			filterMessageSnippet: "Using PipelineRun definition from source push",
 			// 1. Get Repo root objects
 			// 2. Get Tekton Dir objects
 			// 3/4. Get object content for each object (pipelinerun.yaml, pipeline.yaml)
@@ -302,13 +319,14 @@ func TestGetTektonDir(t *testing.T) {
 		{
 			name: "test no tekton directory",
 			event: &info.Event{
-				Organization: "tekton",
-				Repository:   "cat",
-				SHA:          "123",
+				Organization:  "tekton",
+				Repository:    "cat",
+				SHA:           "123",
+				TriggerTarget: triggertype.PullRequest,
 			},
 			expectedString:       "",
 			treepath:             "testdata/tree/notektondir",
-			filterMessageSnippet: "Using PipelineRun definition from source pull request tekton/cat#0",
+			filterMessageSnippet: "Using PipelineRun definition from source pull_request tekton/cat#0",
 			// 1. Get Repo root objects
 			// _. No tekton dir to fetch
 			expectedGHApiCalls: 1,

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -329,7 +329,11 @@ func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, prov
 		revision = event.DefaultBranch
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", event.DefaultBranch)
 	} else {
-		v.Logger.Infof("Using PipelineRun definition from source merge request SHA: %s", event.SHA)
+		trigger := event.TriggerTarget.String()
+		if event.TriggerTarget == triggertype.PullRequest {
+			trigger = "merge request"
+		}
+		v.Logger.Infof("Using PipelineRun definition from source %s on commit SHA: %s", trigger, event.SHA)
 	}
 
 	opt := &gitlab.ListTreeOptions{

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	thelp "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab/test"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
@@ -460,12 +461,13 @@ func TestGetTektonDir(t *testing.T) {
 			wantErr:   "error unmarshalling yaml file pr.yaml: yaml: line 4: could not find expected ':'",
 		},
 		{
-			name:      "list tekton dir",
+			name:      "list tekton dir on pull request",
 			prcontent: string(samplePR),
 			args: args{
 				path: ".tekton",
 				event: &info.Event{
-					HeadBranch: "main",
+					HeadBranch:    "main",
+					TriggerTarget: triggertype.PullRequest,
 				},
 			},
 			fields: fields{
@@ -473,7 +475,24 @@ func TestGetTektonDir(t *testing.T) {
 			},
 			wantClient:           true,
 			wantStr:              "kind: PipelineRun",
-			filterMessageSnippet: `Using PipelineRun definition from source merge request SHA`,
+			filterMessageSnippet: `Using PipelineRun definition from source merge request on commit SHA`,
+		},
+		{
+			name:      "list tekton dir on push",
+			prcontent: string(samplePR),
+			args: args{
+				path: ".tekton",
+				event: &info.Event{
+					HeadBranch:    "main",
+					TriggerTarget: triggertype.Push,
+				},
+			},
+			fields: fields{
+				sourceProjectID: 100,
+			},
+			wantClient:           true,
+			wantStr:              "kind: PipelineRun",
+			filterMessageSnippet: `Using PipelineRun definition from source push on commit SHA`,
 		},
 		{
 			name:      "list tekton dir on default_branch",


### PR DESCRIPTION
this fixes logs message in GetTektonDir func for event type.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- If adding a provider feature, fill in the following details:

  - [x] GitHub App
  - [x] GitHub Webhook
  - [x] Gitea/Forgejo
  - [x] GitLab
  - [x] Bitbucket Cloud
  - [x] Bitbucket Data Center

  (update the provider documentation accordingly)
