### PR TITLE
enhance: Clarify commit-info error & add unit tests for verifyRepoAndUser

### DIFF
--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -137,7 +137,7 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	// Get the SHA commit info, we want to get the URL and commit title
 	err = p.vcx.GetCommitInfo(ctx, p.event)
 	if err != nil {
-		return repo, err
+		return repo, fmt.Errorf("could not find commit info: %w", err)
 	}
 
 	// Verify whether the sender of the GitOps command (e.g., /test) has the appropriate permissions to

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -1,6 +1,11 @@
 package pipelineascode
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -9,10 +14,12 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	ghprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
@@ -278,6 +285,266 @@ func TestGetPipelineRunsFromRepo(t *testing.T) {
 				assert.Assert(t, logCatcher.FilterMessageSnippet(tt.logSnippet).Len() > 0, logCatcher.All())
 			}
 			assert.Equal(t, len(matchedPRNames), tt.expectedNumberOfPruns)
+		})
+	}
+}
+
+func TestVerifyRepoAndUser(t *testing.T) {
+	observerCore, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observerCore).Sugar()
+
+	payload := []byte(`{"key": "value"}`)
+	mac := hmac.New(sha256.New, []byte("secret"))
+	mac.Write(payload)
+	sha256secret := hex.EncodeToString(mac.Sum(nil))
+
+	header := make(http.Header)
+	header.Set(github.SHA256SignatureHeader, fmt.Sprintf("sha256=%s", sha256secret))
+
+	request := &info.Request{
+		Header:  header,
+		Payload: payload,
+	}
+
+	tests := []struct {
+		name          string
+		runevent      info.Event
+		repositories  []*v1alpha1.Repository
+		webhookSecret string
+		wantRepoNil   bool
+		wantErr       bool
+		wantErrMsg    string
+	}{
+		{
+			name: "no repository match",
+			runevent: info.Event{
+				Organization:  "owner",
+				Repository:    "repo",
+				URL:           "https://example.com/owner/repo",
+				SHA:           "123abc",
+				EventType:     triggertype.PullRequest.String(),
+				TriggerTarget: triggertype.PullRequest,
+			},
+			wantRepoNil: true,
+			wantErr:     false,
+		},
+		{
+			name: "missing git_provider section",
+			runevent: info.Event{
+				Organization:  "owner",
+				Repository:    "repo",
+				URL:           "https://example.com/owner/repo",
+				SHA:           "123abc",
+				EventType:     triggertype.PullRequest.String(),
+				TriggerTarget: triggertype.PullRequest,
+			},
+			repositories: []*v1alpha1.Repository{{
+				ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "ns"},
+				Spec:       v1alpha1.RepositorySpec{URL: "https://example.com/owner/repo"},
+			}},
+			wantRepoNil: false,
+			wantErr:     true,
+			wantErrMsg:  "cannot get secret from repository: failed to find git_provider details in repository spec: ns/repo",
+		},
+		{
+			name: "webhook validation failure",
+			runevent: info.Event{
+				Organization:   "owner",
+				Repository:     "repo",
+				URL:            "https://example.com/owner/repo",
+				SHA:            "123abc",
+				EventType:      triggertype.PullRequest.String(),
+				TriggerTarget:  triggertype.PullRequest,
+				InstallationID: 1,
+				Request:        &info.Request{Header: http.Header{}},
+			},
+			repositories: []*v1alpha1.Repository{{
+				ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "ns"},
+				Spec:       v1alpha1.RepositorySpec{URL: "https://example.com/owner/repo"},
+			}},
+			wantRepoNil: false,
+			wantErr:     true,
+			wantErrMsg:  "could not validate payload, check your webhook secret?: no signature has been detected, for security reason we are not allowing webhooks that has no secret",
+		},
+		{
+			name: "webhook secret is not set",
+			runevent: info.Event{
+				Organization:   "owner",
+				Repository:     "repo",
+				URL:            "https://example.com/owner/repo",
+				SHA:            "123abc",
+				EventType:      triggertype.PullRequest.String(),
+				TriggerTarget:  triggertype.PullRequest,
+				InstallationID: 1,
+				Request:        request,
+			},
+			repositories: []*v1alpha1.Repository{{
+				ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "ns"},
+				Spec:       v1alpha1.RepositorySpec{URL: "https://example.com/owner/repo"},
+			}},
+			wantRepoNil: false,
+			wantErr:     true,
+			wantErrMsg:  "could not validate payload, check your webhook secret?: no webhook secret has been set, in repository CR or secret",
+		},
+		{
+			name: "permission denied push comment",
+			runevent: info.Event{
+				Organization:   "owner",
+				Repository:     "repo",
+				URL:            "https://example.com/owner/repo",
+				SHA:            "123abc",
+				EventType:      opscomments.TestAllCommentEventType.String(),
+				TriggerTarget:  triggertype.Push,
+				Sender:         "intruder",
+				InstallationID: 1,
+				Request:        request,
+			},
+			repositories: []*v1alpha1.Repository{{
+				ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "ns"},
+				Spec:       v1alpha1.RepositorySpec{URL: "https://example.com/owner/repo"},
+			}},
+			webhookSecret: "secret",
+			wantRepoNil:   true,
+			wantErr:       true,
+			wantErrMsg:    "failed to run create status, user is not allowed to run the CI",
+		},
+		{
+			name: "permission denied pull_request comment pending approval",
+			runevent: info.Event{
+				Organization:   "owner",
+				Repository:     "repo",
+				URL:            "https://example.com/owner/repo",
+				SHA:            "123abc",
+				EventType:      triggertype.PullRequest.String(),
+				TriggerTarget:  triggertype.PullRequest,
+				Sender:         "outsider",
+				InstallationID: 1,
+				Request:        request,
+			},
+			repositories: []*v1alpha1.Repository{{
+				ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "ns"},
+				Spec:       v1alpha1.RepositorySpec{URL: "https://example.com/owner/repo"},
+			}},
+			webhookSecret: "secret",
+			wantRepoNil:   true,
+			wantErr:       true,
+			wantErrMsg:    "failed to run create status, user is not allowed to run the CI",
+		},
+		{
+			name: "commit not found",
+			runevent: info.Event{
+				Organization:   "owner",
+				Repository:     "repo",
+				URL:            "https://example.com/owner/repo",
+				SHA:            "",
+				EventType:      triggertype.PullRequest.String(),
+				TriggerTarget:  triggertype.PullRequest,
+				InstallationID: 1,
+				Sender:         "owner",
+				Request:        request,
+			},
+			repositories: []*v1alpha1.Repository{{
+				ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "ns"},
+				Spec:       v1alpha1.RepositorySpec{URL: "https://example.com/owner/repo"},
+			}},
+			webhookSecret: "secret",
+			wantRepoNil:   false,
+			wantErr:       true,
+			wantErrMsg:    "could not find commit info",
+		},
+		{
+			name: "happy path",
+			runevent: info.Event{
+				Organization:   "owner",
+				Repository:     "repo",
+				URL:            "https://example.com/owner/repo",
+				SHA:            "123abc",
+				EventType:      triggertype.PullRequest.String(),
+				TriggerTarget:  triggertype.PullRequest,
+				InstallationID: 1,
+				Sender:         "owner",
+				Request:        request,
+			},
+			repositories: []*v1alpha1.Repository{{
+				ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "ns"},
+				Spec:       v1alpha1.RepositorySpec{URL: "https://example.com/owner/repo"},
+			}},
+			webhookSecret: "secret",
+			wantRepoNil:   false,
+			wantErr:       false,
+		},
+	}
+
+	pacInfo := &info.PacOpts{Settings: settings.DefaultSettings()}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseCtx, _ := rtesting.SetupFakeContext(t)
+			ctx := info.StoreNS(baseCtx, "pac")
+
+			ghClient, mux, _, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+
+			// commit endpoint
+			commitPath := fmt.Sprintf("/repos/%s/%s/git/commits/%s", tt.runevent.Organization, tt.runevent.Repository, tt.runevent.SHA)
+			mux.HandleFunc(commitPath, func(rw http.ResponseWriter, _ *http.Request) {
+				if tt.runevent.SHA == "" {
+					rw.WriteHeader(http.StatusNotFound)
+					return
+				}
+				fmt.Fprint(rw, `{"sha":"123abc","html_url":"https://example.com/commit/123abc","message":"msg"}`)
+			})
+
+			// org members empty
+			mux.HandleFunc(fmt.Sprintf("/orgs/%s/members", tt.runevent.Organization), func(rw http.ResponseWriter, _ *http.Request) { fmt.Fprint(rw, `[]`) })
+			// collaborator check – return 404 for non‐collaborator sender when defined
+			if tt.runevent.Sender != "" && tt.runevent.Sender != tt.runevent.Organization {
+				mux.HandleFunc(
+					fmt.Sprintf("/repos/%s/%s/collaborators/%s", tt.runevent.Organization, tt.runevent.Repository, tt.runevent.Sender),
+					func(rw http.ResponseWriter, _ *http.Request) { rw.WriteHeader(http.StatusNotFound) },
+				)
+			}
+			// status endpoint stub (used when CreateStatus is called)
+			mux.HandleFunc(
+				fmt.Sprintf("/repos/%s/%s/statuses/%s", tt.runevent.Organization, tt.runevent.Repository, tt.runevent.SHA),
+				func(rw http.ResponseWriter, _ *http.Request) { fmt.Fprint(rw, `{}`) },
+			)
+
+			vcx := &ghprovider.Provider{Token: github.Ptr("token"), Logger: logger}
+			vcx.SetGithubClient(ghClient)
+			vcx.SetPacInfo(pacInfo)
+
+			k8int := &kitesthelper.KinterfaceTest{GetSecretResult: map[string]string{"pipelines-as-code-secret": tt.webhookSecret}}
+
+			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{Repositories: tt.repositories /*Secret: []*corev1.Secret{secret}*/})
+			in := info.NewInfo()
+			cs := &params.Run{
+				Info: in,
+				Clients: clients.Clients{
+					PipelineAsCode: stdata.PipelineAsCode,
+					Kube:           stdata.Kube,
+					Tekton:         stdata.Pipeline,
+					Log:            logger,
+				},
+			}
+			cs.Clients.SetConsoleUI(consoleui.FallBackConsole{})
+
+			ev := tt.runevent
+			ev.Provider = &info.Provider{Token: "token", WebhookSecret: tt.webhookSecret}
+
+			p := NewPacs(&ev, vcx, cs, pacInfo, k8int, logger, nil)
+			repo, err := p.verifyRepoAndUser(ctx)
+			assert.Assert(t, (err != nil) == tt.wantErr)
+
+			if tt.wantErr {
+				assert.ErrorContains(t, err, tt.wantErrMsg)
+			}
+
+			if tt.wantRepoNil {
+				assert.Assert(t, repo == nil)
+			} else {
+				assert.Assert(t, repo != nil)
+			}
 		})
 	}
 }


### PR DESCRIPTION
- Wrap “commit not found” in verifyRepoAndUser with a contextual error.

- Add targeted unit tests for verifyRepoAndUser func covering repo lookup, webhook validation, permissions, and the happy path.

Assisted-by: AI

PS: Initial code is generated by cursor and refined and written as per need.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
