### PR TITLE
fix(github): guard checkWebhookSecretValidity against nil response

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -258,7 +258,7 @@ func parseTS(headerTS string) (time.Time, error) {
 // the issue was.
 func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.Clock) error {
 	rl, resp, err := v.Client().RateLimit.Get(ctx)
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		v.Logger.Info("skipping checking if token has expired, rate_limit api is not enabled on token")
 		return nil
 	}
@@ -266,16 +266,23 @@ func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.
 	if err != nil {
 		return fmt.Errorf("error making request to the GitHub API checking rate limit: %w", err)
 	}
-	if resp.Header.Get("GitHub-Authentication-Token-Expiration") != "" {
+
+	if resp != nil && resp.Header.Get("GitHub-Authentication-Token-Expiration") != "" {
 		ts, err := parseTS(resp.Header.Get("GitHub-Authentication-Token-Expiration"))
 		if err != nil {
 			return fmt.Errorf("error parsing token expiration date: %w", err)
 		}
 
 		if cw.Now().After(ts) {
-			errm := fmt.Sprintf("token has expired at %s", resp.TokenExpiration.Format(time.RFC1123))
-			return fmt.Errorf("%s", errm)
+			errMsg := fmt.Sprintf("token has expired at %s", resp.TokenExpiration.Format(time.RFC1123))
+			return fmt.Errorf("%s", errMsg)
 		}
+	}
+
+	// Guard against nil rl or rl.SCIM which could lead to a panic.
+	if rl == nil || rl.SCIM == nil {
+		v.Logger.Info("skipping token expiration check, SCIM rate limit API is not available for this token")
+		return nil
 	}
 
 	if rl.SCIM.Remaining == 0 {


### PR DESCRIPTION
Fix nil-pointer panic when /rate_limit returns success without SCIM data or when the HTTP response itself is nil.
Add early err/resp checks and ensure rl and rl.SCIM are non-nil before accessing them.

Jira: https://issues.redhat.com/browse/SRVKP-8075

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- If adding a provider feature, fill in the following details:

  - [x] GitHub App
  - [x] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
