### PR TITLE
fix: Ignore non-Tekton resources errors reporting

### DIFF
--- a/pkg/pipelineascode/errors.go
+++ b/pkg/pipelineascode/errors.go
@@ -1,0 +1,69 @@
+package pipelineascode
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	pacerrors "github.com/openshift-pipelines/pipelines-as-code/pkg/errors"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.uber.org/zap"
+)
+
+const validationErrorTemplate = `> [!CAUTION]
+> There are some errors in your PipelineRun template.
+
+| PipelineRun | Error |
+|------|-------|`
+
+var regexpIgnoreErrors = regexp.MustCompile(`.*no kind.*is registered for version.*in scheme.*`)
+
+func (p *PacRun) checkAccessOrErrror(ctx context.Context, repo *v1alpha1.Repository, status provider.StatusOpts, viamsg string) (bool, error) {
+	allowed, err := p.vcx.IsAllowed(ctx, p.event)
+	if err != nil {
+		return false, fmt.Errorf("unable to verify event authorization: %w", err)
+	}
+	if allowed {
+		return true, nil
+	}
+	msg := fmt.Sprintf("User %s is not allowed to trigger CI %s in this repo.", p.event.Sender, viamsg)
+	if p.event.AccountID != "" {
+		msg = fmt.Sprintf("User: %s AccountID: %s is not allowed to trigger CI %s in this repo.", p.event.Sender, p.event.AccountID, viamsg)
+	}
+	p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryPermissionDenied", msg)
+	status.Text = msg
+
+	if err := p.vcx.CreateStatus(ctx, p.event, status); err != nil {
+		return false, fmt.Errorf("failed to run create status, user is not allowed to run the CI:: %w", err)
+	}
+	return false, nil
+}
+
+// reportValidationErrors reports validation errors found in PipelineRuns by:
+// 1. Creating error messages for each validation error
+// 2. Emitting error messages to the event system
+// 3. Creating a markdown formatted comment on the repository with all errors.
+func (p *PacRun) reportValidationErrors(ctx context.Context, repo *v1alpha1.Repository, validationErrors []*pacerrors.PacYamlValidations) {
+	errorRows := make([]string, 0, len(validationErrors))
+	for _, err := range validationErrors {
+		// if the error is a TektonConversionError, we don't want to report it since it may be a file that is not a tekton resource
+		// and we don't want to report it as a validation error.
+		if !regexpIgnoreErrors.MatchString(err.Err.Error()) && (strings.HasPrefix(err.Schema, tektonv1.SchemeGroupVersion.Group) || err.Schema == pacerrors.GenericBadYAMLValidation) {
+			errorRows = append(errorRows, fmt.Sprintf("| %s | `%s` |", err.Name, err.Err.Error()))
+		}
+		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "PipelineRunValidationErrors",
+			fmt.Sprintf("cannot read the PipelineRun: %s, error: %s", err.Name, err.Err.Error()))
+	}
+	if len(errorRows) == 0 {
+		return
+	}
+	markdownErrMessage := fmt.Sprintf(`%s
+%s`, validationErrorTemplate, strings.Join(errorRows, "\n"))
+	if err := p.vcx.CreateComment(ctx, p.event, markdownErrMessage, validationErrorTemplate); err != nil {
+		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "PipelineRunCommentCreationError",
+			fmt.Sprintf("failed to create comment: %s", err.Error()))
+	}
+}

--- a/pkg/pipelineascode/errors_test.go
+++ b/pkg/pipelineascode/errors_test.go
@@ -1,0 +1,217 @@
+package pipelineascode
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	pacerrors "github.com/openshift-pipelines/pipelines-as-code/pkg/errors"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	testprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/test/provider"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestCheckAccessOrErrror(t *testing.T) {
+	tests := []struct {
+		name              string
+		allowIt           bool
+		sender            string
+		accountID         string
+		createStatusError bool
+		expectedErr       bool
+		expectedAllowed   bool
+		expectedErrMsg    string
+	}{
+		{
+			name:            "user is allowed",
+			allowIt:         true,
+			expectedAllowed: true,
+		},
+		{
+			name:            "user is not allowed - no account ID",
+			allowIt:         false,
+			sender:          "johndoe",
+			expectedAllowed: false,
+		},
+		{
+			name:            "user is not allowed - with account ID",
+			allowIt:         false,
+			sender:          "johndoe",
+			accountID:       "user123",
+			expectedAllowed: false,
+		},
+		{
+			name:              "create status error",
+			allowIt:           false,
+			sender:            "johndoe",
+			createStatusError: true,
+			expectedErr:       true,
+			expectedErrMsg:    "failed to run create status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup observer to capture logs
+			observerCore, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observerCore).Sugar()
+
+			// Create test event
+			testEvent := &info.Event{
+				Sender:    tt.sender,
+				AccountID: tt.accountID,
+			}
+
+			// Create mock provider
+			prov := &testprovider.TestProviderImp{
+				AllowIT: tt.allowIt,
+			}
+
+			// Set createStatus error if needed
+			if tt.createStatusError {
+				prov.CreateStatusErorring = true
+			}
+
+			ctx, _ := rtesting.SetupFakeContext(t)
+			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+			// Create mock event emitter
+			eventEmitter := events.NewEventEmitter(stdata.Kube, logger)
+
+			// Create PacRun
+			p := &PacRun{
+				event:        testEvent,
+				vcx:          prov,
+				logger:       logger,
+				eventEmitter: eventEmitter,
+			}
+
+			// Call the function
+			repo := &v1alpha1.Repository{}
+			status := provider.StatusOpts{}
+			allowed, err := p.checkAccessOrErrror(context.Background(), repo, status, "via test")
+
+			// Verify results
+			if tt.expectedErr {
+				assert.Assert(t, err != nil, "Expected error but got nil")
+				if tt.expectedErrMsg != "" {
+					assert.Assert(t, err.Error() != "", "Expected error message but got empty string")
+					assert.ErrorContains(t, err, tt.expectedErrMsg)
+				}
+			} else {
+				assert.NilError(t, err)
+			}
+
+			assert.Equal(t, tt.expectedAllowed, allowed)
+		})
+	}
+}
+
+func TestReportValidationErrors(t *testing.T) {
+	tests := []struct {
+		name                  string
+		validationErrors      []*pacerrors.PacYamlValidations
+		expectCommentCreation bool
+	}{
+		{
+			name:                  "no validation errors",
+			validationErrors:      []*pacerrors.PacYamlValidations{},
+			expectCommentCreation: false,
+		},
+		{
+			name: "tekton validation errors",
+			validationErrors: []*pacerrors.PacYamlValidations{
+				{
+					Name:   "test-pipeline-1",
+					Err:    errors.New("invalid pipeline spec"),
+					Schema: "tekton.dev",
+				},
+			},
+			expectCommentCreation: true,
+		},
+		{
+			name: "non-tekton schema errors",
+			validationErrors: []*pacerrors.PacYamlValidations{
+				{
+					Name:   "test-other",
+					Err:    errors.New("some error"),
+					Schema: "other.schema",
+				},
+			},
+			expectCommentCreation: false,
+		},
+		{
+			name: "ignored errors by regex",
+			validationErrors: []*pacerrors.PacYamlValidations{
+				{
+					Name:   "test-ignored",
+					Err:    errors.New("no kind test is registered for version v1 in scheme"),
+					Schema: "tekton.dev",
+				},
+			},
+			expectCommentCreation: false,
+		},
+		{
+			name: "create comment error",
+			validationErrors: []*pacerrors.PacYamlValidations{
+				{
+					Name:   "test-pipeline",
+					Err:    errors.New("validation error"),
+					Schema: "tekton.dev",
+				},
+			},
+			expectCommentCreation: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup observer to capture logs
+			observerCore, logs := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observerCore).Sugar()
+			ctx, _ := rtesting.SetupFakeContext(t)
+
+			// Create test event
+			testEvent := &info.Event{}
+
+			// Create mock provider
+			prov := &testprovider.TestProviderImp{}
+
+			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+
+			// Create mock event emitter
+			eventEmitter := events.NewEventEmitter(stdata.Kube, logger)
+			// Create PacRun
+			p := &PacRun{
+				event:        testEvent,
+				vcx:          prov,
+				logger:       logger,
+				eventEmitter: eventEmitter,
+			}
+
+			// Call the function
+			repo := &v1alpha1.Repository{}
+			p.reportValidationErrors(context.Background(), repo, tt.validationErrors)
+
+			// Verify results
+			// Verify log messages for validation errors
+			logEntries := logs.All()
+			errorLogCount := 0
+			for _, entry := range logEntries {
+				if entry.Level == zap.ErrorLevel {
+					errorLogCount++
+				}
+			}
+
+			// We should have at least one error log per validation error
+			assert.Assert(t, errorLogCount >= len(tt.validationErrors),
+				"Expected at least %d error logs, got %d", len(tt.validationErrors), errorLogCount)
+		})
+	}
+}

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -22,12 +22,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const validationErrorTemplate = `> [!CAUTION]
-> There are some errors in your PipelineRun template.
-
-| PipelineRun | Error |
-|------|-------|`
-
 func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Repository, error) {
 	repo, err := p.verifyRepoAndUser(ctx)
 	if err != nil {
@@ -432,27 +426,6 @@ func (p *PacRun) checkNeedUpdate(_ string) (string, bool) {
 	return "", false
 }
 
-func (p *PacRun) checkAccessOrErrror(ctx context.Context, repo *v1alpha1.Repository, status provider.StatusOpts, viamsg string) (bool, error) {
-	allowed, err := p.vcx.IsAllowed(ctx, p.event)
-	if err != nil {
-		return false, fmt.Errorf("unable to verify event authorization: %w", err)
-	}
-	if allowed {
-		return true, nil
-	}
-	msg := fmt.Sprintf("User %s is not allowed to trigger CI %s in this repo.", p.event.Sender, viamsg)
-	if p.event.AccountID != "" {
-		msg = fmt.Sprintf("User: %s AccountID: %s is not allowed to trigger CI %s in this repo.", p.event.Sender, p.event.AccountID, viamsg)
-	}
-	p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryPermissionDenied", msg)
-	status.Text = msg
-
-	if err := p.vcx.CreateStatus(ctx, p.event, status); err != nil {
-		return false, fmt.Errorf("failed to run create status, user is not allowed to run the CI:: %w", err)
-	}
-	return false, nil
-}
-
 func (p *PacRun) createNeutralStatus(ctx context.Context) error {
 	status := provider.StatusOpts{
 		Status:     CompletedStatus,
@@ -466,30 +439,4 @@ func (p *PacRun) createNeutralStatus(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-// reportValidationErrors reports validation errors found in PipelineRuns by:
-// 1. Creating error messages for each validation error
-// 2. Emitting error messages to the event system
-// 3. Creating a markdown formatted comment on the repository with all errors.
-func (p *PacRun) reportValidationErrors(ctx context.Context, repo *v1alpha1.Repository, validationErrors []*pacerrors.PacYamlValidations) {
-	errorRows := make([]string, 0, len(validationErrors))
-	for _, err := range validationErrors {
-		// if the error is a TektonConversionError, we don't want to report it since it may be a file that is not a tekton resource
-		// and we don't want to report it as a validation error.
-		if strings.HasPrefix(err.Schema, tektonv1.SchemeGroupVersion.Group) || err.Schema == pacerrors.GenericBadYAMLValidation {
-			errorRows = append(errorRows, fmt.Sprintf("| %s | `%s` |", err.Name, err.Err.Error()))
-		}
-		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "PipelineRunValidationErrors",
-			fmt.Sprintf("cannot read the PipelineRun: %s, error: %s", err.Name, err.Err.Error()))
-	}
-	if len(errorRows) == 0 {
-		return
-	}
-	markdownErrMessage := fmt.Sprintf(`%s
-%s`, validationErrorTemplate, strings.Join(errorRows, "\n"))
-	if err := p.vcx.CreateComment(ctx, p.event, markdownErrMessage, validationErrorTemplate); err != nil {
-		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "PipelineRunCommentCreationError",
-			fmt.Sprintf("failed to create comment: %s", err.Error()))
-	}
 }


### PR DESCRIPTION
## 📝 Description of the Change

unmarshal non-Tekton custom resources, such as `ImageDigestMirrorSet`, or `StepActions` as PipelineRuns. This caused the PaC bot to post misleading "PipelineRun failure" comments on pull requests, even when all CI jobs were successful.

This change updates the parsing logic to specifically check for and ignore non-Tekton resources found within the `.tekton` directory. By skipping these files, we prevent erroneous parsing errors and stop the bot from posting false-positive comments.

This resolves the issue where developers were confused by failure notifications on otherwise successful PRs, improving the overall developer experience by reducing unnecessary noise. The fix ensures that comments are only posted for legitimate PipelineRun failures.



<!--- Take all comments into account and provide a detailed description of the change. -->

## 🔗 Linked GitHub Issue

Fixes #

## 👨🏻‍ Linked Jira
[SRVKP-8112](https://issues.redhat.com/browse/SRVKP-8112) 

## 🚀 Type of Change

- [X] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)

<!-- (update the title of the Pull Request accordingly) -->

## 🧪 Testing Strategy

- [X] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing - https://github.com/chmouel/scratchmyback/pull/366
- [ ] Not Applicable

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
