### PR TITLE
🪞 [MIRRORED] refactor(triggertype): rename LabelUpdate to pull_request_labeled

### DIFF
--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -266,7 +266,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 		// If the event is a pull_request and the event type is label_update, but the PipelineRun
 		// does not contain an 'on-label' annotation, do not match this PipelineRun, as it is not intended for this event.
 		_, ok := prun.GetObjectMeta().GetAnnotations()[keys.OnLabel]
-		if event.TriggerTarget == triggertype.PullRequest && event.EventType == string(triggertype.LabelUpdate) && !ok {
+		if event.TriggerTarget == triggertype.PullRequest && event.EventType == string(triggertype.PullRequestLabeled) && !ok {
 			logger.Infof("label update event, PipelineRun %s does not have a on-label for any of those labels: %s", prName, strings.Join(event.PullRequestLabel, "|"))
 			continue
 		}

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -1693,7 +1693,7 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 				runevent: info.Event{
 					URL:               "https://hello/moto",
 					TriggerTarget:     triggertype.PullRequest,
-					EventType:         string(triggertype.LabelUpdate),
+					EventType:         string(triggertype.PullRequestLabeled),
 					HeadBranch:        "source",
 					BaseBranch:        "main",
 					PullRequestNumber: 10,

--- a/pkg/params/triggertype/types.go
+++ b/pkg/params/triggertype/types.go
@@ -8,7 +8,7 @@ type (
 func IsPullRequestType(s string) Trigger {
 	eventType := s
 	switch s {
-	case PullRequest.String(), OkToTest.String(), Retest.String(), Cancel.String(), LabelUpdate.String():
+	case PullRequest.String(), OkToTest.String(), Retest.String(), Cancel.String(), PullRequestLabeled.String():
 		eventType = PullRequest.String()
 	}
 	return Trigger(eventType)
@@ -38,6 +38,8 @@ func StringToType(s string) Trigger {
 		return Incoming
 	case Comment.String():
 		return Comment
+	case PullRequestLabeled.String():
+		return PullRequestLabeled
 	}
 	return ""
 }
@@ -48,7 +50,7 @@ const (
 	CheckSuiteRerequested Trigger = "check-suite-rerequested"
 	Comment               Trigger = "comment"
 	Incoming              Trigger = "incoming"
-	LabelUpdate           Trigger = "label_update"
+	PullRequestLabeled    Trigger = "pull_request_labeled"
 	OkToTest              Trigger = "ok-to-test"
 	PullRequestClosed     Trigger = "pull_request_closed"
 	PullRequest           Trigger = "pull_request" // it's should be "pull_request_opened_updated" but let's keep it simple.

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -45,7 +45,7 @@ func (p *Policy) checkAllowed(ctx context.Context, tType triggertype.Trigger) (R
 		sType = settings.Policy.OkToTest
 	// apply the same policy for PullRequest and comment
 	// we don't support comments on PRs yet but if we do on the future we will need our own policy
-	case triggertype.PullRequest, triggertype.Comment, triggertype.LabelUpdate, triggertype.PullRequestClosed:
+	case triggertype.PullRequest, triggertype.Comment, triggertype.PullRequestLabeled, triggertype.PullRequestClosed:
 		sType = settings.Policy.PullRequest
 	// NOTE: not supported yet, will imp if it gets requested and reasonable to implement
 	case triggertype.Push, triggertype.Cancel, triggertype.CheckSuiteRerequested, triggertype.CheckRunRerequested, triggertype.Incoming:

--- a/pkg/provider/gitea/parse_payload.go
+++ b/pkg/provider/gitea/parse_payload.go
@@ -52,7 +52,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.TriggerTarget = triggertype.PullRequest
 		processedEvent.EventType = triggertype.PullRequest.String()
 		if provider.Valid(string(gitEvent.Action), []string{pullRequestLabelUpdated}) {
-			processedEvent.EventType = string(triggertype.LabelUpdate)
+			processedEvent.EventType = string(triggertype.PullRequestLabeled)
 		}
 		for _, label := range gitEvent.PullRequest.Labels {
 			processedEvent.PullRequestLabel = append(processedEvent.PullRequestLabel, label.Name)

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -393,7 +393,7 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		v.userType = gitEvent.GetPullRequest().GetUser().GetType()
 
 		if gitEvent.Action != nil && provider.Valid(*gitEvent.Action, pullRequestLabelEvent) {
-			processedEvent.EventType = string(triggertype.LabelUpdate)
+			processedEvent.EventType = string(triggertype.PullRequestLabeled)
 		}
 
 		if gitEvent.GetAction() == "closed" {

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -70,7 +70,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 
 		// This is a label update, like adding or removing a label from a MR.
 		if gitEvent.Changes.Labels.Current != nil {
-			processedEvent.EventType = triggertype.LabelUpdate.String()
+			processedEvent.EventType = triggertype.PullRequestLabeled.String()
 		}
 		for _, label := range gitEvent.Labels {
 			processedEvent.PullRequestLabel = append(processedEvent.PullRequestLabel, label.Title)

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -99,7 +99,7 @@ func TestGithubPullRequestOnLabel(t *testing.T) {
 
 	sopt := twait.SuccessOpt{
 		Title:           g.CommitTitle,
-		OnEvent:         triggertype.LabelUpdate.String(),
+		OnEvent:         triggertype.PullRequestLabeled.String(),
 		TargetNS:        g.TargetNamespace,
 		NumberofPRMatch: len(g.YamlFiles),
 		SHA:             g.SHA,

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -199,7 +199,7 @@ func TestGitlabOnLabel(t *testing.T) {
 	repo, err := twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
 	assert.NilError(t, err)
 	assert.Assert(t, len(repo.Status) > 0)
-	assert.Equal(t, *repo.Status[0].EventType, triggertype.LabelUpdate.String())
+	assert.Equal(t, *repo.Status[0].EventType, triggertype.PullRequestLabeled.String())
 }
 
 func TestGitlabOnComment(t *testing.T) {


### PR DESCRIPTION
🔄 Mirrors https://github.com/openshift-pipelines/pipelines-as-code/pull/2187 to run E2E tests. Original author: @infernus01