### PR TITLE
fix!: Disable PipelineRun status comment in GitLab

### DIFF
--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -2,6 +2,7 @@
 title: Repository CR
 weight: 1
 ---
+
 # Repository CR
 
 The Repository CR serves the following purposes:
@@ -137,6 +138,8 @@ spec:
 ```
 
 When you set the value of `comment_strategy` to `disable_all` it will not add any comment on the merge request for the start and the end of PipelineRun
+
+Note: For GitLab, Pipelines-as-Code only adds a PipelineRun status comment if updating the commit status via the API fails (e.g., due to insufficient token permissions). If the commit status is updated successfully, no comment is posted, and the `comment_strategy` setting is ignored.
 
 ## Disabling all comments for PipelineRuns in GitHub Pull Requests on GitHub Webhook Setup
 

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -290,6 +290,10 @@ func (v *Provider) CreateStatus(_ context.Context, event *info.Event, statusOpts
 	if _, _, err := v.Client().Commits.SetCommitStatus(event.SourceProjectID, event.SHA, opt); err != nil {
 		v.eventEmitter.EmitMessage(v.repo, zap.ErrorLevel, "FailedToSetCommitStatus",
 			"cannot set status with the GitLab token because of: "+err.Error())
+	} else {
+		v.eventEmitter.EmitMessage(v.repo, zap.InfoLevel, "SetCommitStatus",
+			"successfully set status with the GitLab token")
+		return nil
 	}
 
 	eventType := triggertype.IsPullRequestType(event.EventType)

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package test
 
 import (
@@ -11,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
-
 	"github.com/google/go-github/v71/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
@@ -20,7 +15,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -117,19 +111,7 @@ func TestGitlabMergeRequest(t *testing.T) {
 		NumberofPRMatch: 5, // this is the max we get in repos status
 		SHA:             "",
 	}
-	runcnx.Clients.Log.Info("Checking that PAC has posted successful comments for all PR that has been tested")
 	twait.Succeeded(ctx, t, runcnx, opts, sopt)
-
-	notes, _, err := glprovider.Client().Notes.ListMergeRequestNotes(opts.ProjectID, mrID, nil)
-	assert.NilError(t, err)
-	successCommentsPost := 0
-	for _, n := range notes {
-		if successRegexp.MatchString(n.Body) {
-			successCommentsPost++
-		}
-	}
-	// we get 2 PRS initially, 2 prs from the push update and 2 prs from the /retest == 6
-	assert.Equal(t, 6, successCommentsPost)
 }
 
 func TestGitlabOnLabel(t *testing.T) {
@@ -498,122 +480,6 @@ func TestGitlabIssueGitopsComment(t *testing.T) {
 		NumberofPRMatch: 1,
 	}
 	twait.Succeeded(ctx, t, runcnx, opts, sopt)
-}
-
-func TestGitlabDisableCommentsOnMR(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing with Gitlab")
-
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
-	}
-
-	settings := v1alpha1.Settings{
-		Gitlab: &v1alpha1.GitlabSettings{
-			CommentStrategy: "disable_all",
-		},
-	}
-	opts.Settings = settings
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
-
-	entries, err := payload.GetEntries(map[string]string{
-		".tekton/pipelinerun.yaml": "testdata/pipelinerun.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
-		triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-
-	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
-	commitTitle := "Committing files from test on " + targetRefName
-	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		CommitTitle:   commitTitle,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
-	}
-	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetRefName)
-	mrTitle := "TestMergeRequest - " + targetRefName
-	mrID, err := tgitlab.CreateMR(glprovider.Client(), opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, mrID, targetRefName, targetNS, opts.ProjectID)
-
-	sopt := twait.SuccessOpt{
-		Title:           commitTitle,
-		OnEvent:         "Merge Request",
-		TargetNS:        targetNS,
-		NumberofPRMatch: 1,
-		SHA:             "",
-	}
-	twait.Succeeded(ctx, t, runcnx, opts, sopt)
-	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
-	assert.NilError(t, err)
-	assert.Assert(t, len(prsNew.Items) == 1)
-
-	// No comments will be added related to pipelineruns info
-	notes, _, err := glprovider.Client().Notes.ListMergeRequestNotes(opts.ProjectID, mrID, nil)
-
-	commentRegexp := regexp.MustCompile(`.*Pipelines as Code CI/*`)
-	assert.NilError(t, err)
-	successCommentsPost := 0
-	for _, n := range notes {
-		if commentRegexp.MatchString(n.Body) {
-			successCommentsPost++
-		}
-	}
-	// Since Gitlab comment strategy is disabled,
-	// no comments will be posted related to pipelineruns
-	assert.Equal(t, 0, successCommentsPost)
-
-	// Update the repo setting to nil, and comment /retest to restart the pipelinerun
-	// and now comments will be added on the MR
-	waitOpts := twait.Opts{
-		RepoName:  targetNS,
-		Namespace: targetNS,
-		TargetSHA: "",
-	}
-
-	runcnx.Clients.Log.Info("Updating Gitlab Comment Strategy to nil...")
-	err = repository.UpdateRepo(ctx, waitOpts.Namespace, waitOpts.RepoName, runcnx.Clients)
-	assert.NilError(t, err)
-
-	runcnx.Clients.Log.Infof("Sending /retest comment on MergeRequest %s/-/merge_requests/%d", projectinfo.WebURL, mrID)
-	_, _, err = glprovider.Client().Notes.CreateMergeRequestNote(opts.ProjectID, mrID, &clientGitlab.CreateMergeRequestNoteOptions{
-		Body: clientGitlab.Ptr("/retest"),
-	})
-	assert.NilError(t, err)
-
-	sopt = twait.SuccessOpt{
-		Title:           commitTitle,
-		OnEvent:         opscomments.RetestAllCommentEventType.String(),
-		TargetNS:        targetNS,
-		NumberofPRMatch: 2, // this is the max we get in repos status
-		SHA:             "",
-	}
-	runcnx.Clients.Log.Info("Checking that PAC has posted successful comments for all PR that has been tested")
-	twait.Succeeded(ctx, t, runcnx, opts, sopt)
-
-	notes, _, err = glprovider.Client().Notes.ListMergeRequestNotes(opts.ProjectID, mrID, nil)
-	assert.NilError(t, err)
-	successCommentsPost = 0
-	for _, n := range notes {
-		if commentRegexp.MatchString(n.Body) {
-			successCommentsPost++
-		}
-	}
-	assert.Equal(t, 2, successCommentsPost)
 }
 
 func TestGitlabMergeRequestOnUpdateAtAndLabelChange(t *testing.T) {


### PR DESCRIPTION
disabled PipelineRun status comment in GitLab when commit status API call succeed. it is last resort to let know users about PipelineRun status when commit status API fails. Deleted the E2E tests which was required PipelineRun status comment existence.

## 📝 Description of the Change

<!--- Take all comments into account and provide a detailed description of the change. -->

## 🔗 Linked GitHub Issue

Fixes #

## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-8553

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [x] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

<!-- (update the title of the Pull Request accordingly) -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [x] Not Applicable

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [x] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
