### PR TITLE
fix: Re-enable tests for Global config changes

### DIFF
--- a/test/gitea_access_control_test.go
+++ b/test/gitea_access_control_test.go
@@ -270,8 +270,6 @@ func TestGiteaACLCommentsAllowing(t *testing.T) {
 // the status of CI shows as success. Now non authorized user pushes to PR, the CI will again go to pending
 // and require /ok-to-test again from authorized user.
 func TestGiteaACLCommentsAllowingRememberOkToTestFalse(t *testing.T) {
-	t.Skip("Skipping test changing the global config map for now")
-
 	ctx := context.Background()
 	topts := &tgitea.TestOpts{
 		TargetEvent: triggertype.PullRequest.String(),

--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -79,7 +79,6 @@ func TestGiteaParamsStandardCheckForPushAndPullEvent(t *testing.T) {
 }
 
 func TestGiteaParamsOnRepoCRWithCustomConsole(t *testing.T) {
-	t.Skip("Skipping test changing the global config map for now")
 	ctx := context.Background()
 	topts := &tgitea.TestOpts{
 		CheckForStatus:  "success",

--- a/test/github_scope_token_to_list_of_private_public_repos_test.go
+++ b/test/github_scope_token_to_list_of_private_public_repos_test.go
@@ -55,7 +55,6 @@ func TestGithubPullRequestScopeTokenToListOfRepos(t *testing.T) {
 }
 
 func TestGithubPullRequestScopeTokenToListOfReposByGlobalConfiguration(t *testing.T) {
-	t.Skip("Skipping test changing the global config map for now")
 	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
 		t.Skip("Skipping test since only enabled for nightly")
 	}
@@ -183,6 +182,7 @@ func verifyGHTokenScope(t *testing.T, remoteTaskURL, remoteTaskName string, data
 	runcnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
 	repo, err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
 	assert.NilError(t, err)
+	assert.Assert(t, len(repo.Status) > 0, "Repository status is empty, no status found")
 	laststatus := repo.Status[len(repo.Status)-1]
 	assert.Equal(t, corev1.ConditionTrue, laststatus.Conditions[0].Status)
 	assert.Equal(t, sha, *laststatus.SHA)


### PR DESCRIPTION
Previously, tests that modified the global config were skipped due to flakiness. However, the flakes were unrelated, and other tests also modify the global config.

Let's re-enable these tests and try them on.

## 📝 Description of the Change

<!--- Take all comments into account and provide a detailed description of the change. -->

## 🔗 Linked GitHub Issue

Fixes #

## 👨🏻‍ Linked Jira

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [x] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

<!-- (update the title of the Pull Request accordingly) -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [x] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
