### PR TITLE
revert: "fix: Re-enable tests for Global config changes"

### DIFF
--- a/test/gitea_access_control_test.go
+++ b/test/gitea_access_control_test.go
@@ -270,6 +270,8 @@ func TestGiteaACLCommentsAllowing(t *testing.T) {
 // the status of CI shows as success. Now non authorized user pushes to PR, the CI will again go to pending
 // and require /ok-to-test again from authorized user.
 func TestGiteaACLCommentsAllowingRememberOkToTestFalse(t *testing.T) {
+	t.Skip("Skipping test changing the global config map for now")
+
 	ctx := context.Background()
 	topts := &tgitea.TestOpts{
 		TargetEvent: triggertype.PullRequest.String(),

--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -79,6 +79,7 @@ func TestGiteaParamsStandardCheckForPushAndPullEvent(t *testing.T) {
 }
 
 func TestGiteaParamsOnRepoCRWithCustomConsole(t *testing.T) {
+	t.Skip("Skipping test changing the global config map for now")
 	ctx := context.Background()
 	topts := &tgitea.TestOpts{
 		CheckForStatus:  "success",

--- a/test/github_scope_token_to_list_of_private_public_repos_test.go
+++ b/test/github_scope_token_to_list_of_private_public_repos_test.go
@@ -55,6 +55,7 @@ func TestGithubPullRequestScopeTokenToListOfRepos(t *testing.T) {
 }
 
 func TestGithubPullRequestScopeTokenToListOfReposByGlobalConfiguration(t *testing.T) {
+	t.Skip("Skipping test changing the global config map for now")
 	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
 		t.Skip("Skipping test since only enabled for nightly")
 	}
@@ -182,7 +183,6 @@ func verifyGHTokenScope(t *testing.T, remoteTaskURL, remoteTaskName string, data
 	runcnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
 	repo, err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
 	assert.NilError(t, err)
-	assert.Assert(t, len(repo.Status) > 0, "Repository status is empty, no status found")
 	laststatus := repo.Status[len(repo.Status)-1]
 	assert.Equal(t, corev1.ConditionTrue, laststatus.Conditions[0].Status)
 	assert.Equal(t, sha, *laststatus.SHA)


### PR DESCRIPTION
Reverts openshift-pipelines/pipelines-as-code#2236