### PR TITLE
PoC use merge-commit source-branch parent only for file changes

### DIFF
--- a/pkg/provider/bitbucketdatacenter/parse_payload.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload.go
@@ -175,27 +175,9 @@ func (v *Provider) ParsePayload(_ context.Context, run *params.Run, request *htt
 			return nil, fmt.Errorf("push event contains no commits; cannot proceed")
 		}
 
+		// In the case of a Merge Commit, we still want to ensure the Event's commit SHA is the pushed commit
+		// even if we have to look at the parent commit when listing the changed files.
 		processedEvent.SHA = e.Changes[0].ToHash
-
-		// In Bitbucket Data Center, when a pull request is merged, it creates two commits in the repository:
-		// 1. A merge commit, which is represented by `changes[0].ToHash`.
-		// 2. The actual commit containing the changes from the source branch.
-		//
-		// However, the merge commit often does not contain any file changes itself,
-		// which can cause issues when determining whether file modifications should trigger PipelineRuns.
-		//
-		// Typically, a regular (non-merge) commit has a single parent, but a merge commit has two parents:
-		// - The first parent is the previous HEAD of the destination branch (the branch into which the PR was merged).
-		// - The second parent is the HEAD of the source branch (the branch being merged).
-		//
-		// To correctly identify the actual commit that contains the changes (i.e., the source branch's HEAD),
-		// we inspect `e.Commits[0]`, and if it has more than one parent, we take the second parent.
-		// This helps ensure we reference the correct commit.
-		if len(e.Commits) > 1 && len(e.Commits[0].Parents) > 1 {
-			processedEvent.SHA = e.Commits[0].Parents[1].ID
-			run.Clients.Log.Infof("Detected a merge commit as HEAD; "+
-				"using second parent commit SHA %s (source branch HEAD) to target push event", e.Commits[0].Parents[1].ID)
-		}
 
 		processedEvent.URL = e.Repository.Links.Self[0].Href
 		processedEvent.BaseBranch = e.Changes[0].RefID


### PR DESCRIPTION
## 📝 Description of the Change

<!--- Take all comments into account and provide a detailed description of the change. -->

## 🔗 Linked GitHub Issue

Fixes #

## 👨🏻‍ Linked Jira

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

<!-- (update the title of the Pull Request accordingly) -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
