### PR TITLE
feat: Honor gitops in GitLab threads replies

### DIFF
--- a/pkg/provider/gitlab/README.md
+++ b/pkg/provider/gitlab/README.md
@@ -32,7 +32,6 @@
 
 ### Until there is a ask for it
 
-- /ok-to-test in threads comments (only top level comment is supported atm).
 - caching API calls for permissions.
 
 ## NOTES

--- a/pkg/provider/gitlab/acl_test.go
+++ b/pkg/provider/gitlab/acl_test.go
@@ -29,6 +29,7 @@ func TestIsAllowed(t *testing.T) {
 		commentContent  string
 		commentAuthor   string
 		commentAuthorID int
+		threadFirstNote string
 	}{
 		{
 			name:    "check client has been set",
@@ -77,6 +78,23 @@ func TestIsAllowed(t *testing.T) {
 			commentAuthorID: 1111,
 		},
 		{
+			name:       "allowed when /ok-to-test is in a reply note",
+			allowed:    true,
+			wantClient: true,
+			fields: fields{
+				userID:          6666,
+				targetProjectID: 2525,
+			},
+			args: args{
+				event: &info.Event{Sender: "noowner", PullRequestNumber: 2},
+			},
+			allowMemberID:   1111,
+			threadFirstNote: "random comment",
+			commentContent:  "/ok-to-test",
+			commentAuthor:   "admin",
+			commentAuthorID: 1111,
+		},
+		{
 			name:       "disallowed from non authorized note",
 			wantClient: true,
 			fields: fields{
@@ -111,8 +129,15 @@ func TestIsAllowed(t *testing.T) {
 					thelp.MuxGetFile(mux, tt.fields.targetProjectID, "OWNERS", tt.ownerFile, false)
 				}
 				if tt.commentContent != "" {
-					thelp.MuxDiscussionsNote(mux, tt.fields.targetProjectID,
-						tt.args.event.PullRequestNumber, tt.commentAuthor, tt.commentAuthorID, tt.commentContent)
+					if tt.threadFirstNote != "" {
+						thelp.MuxDiscussionsNoteWithReply(mux, tt.fields.targetProjectID,
+							tt.args.event.PullRequestNumber,
+							"someuser", 2222, tt.threadFirstNote,
+							tt.commentAuthor, tt.commentAuthorID, tt.commentContent)
+					} else {
+						thelp.MuxDiscussionsNote(mux, tt.fields.targetProjectID,
+							tt.args.event.PullRequestNumber, tt.commentAuthor, tt.commentAuthorID, tt.commentContent)
+					}
 				} else {
 					thelp.MuxDiscussionsNoteEmpty(mux, tt.fields.targetProjectID, tt.args.event.PullRequestNumber)
 				}

--- a/pkg/provider/gitlab/test/test.go
+++ b/pkg/provider/gitlab/test/test.go
@@ -124,6 +124,29 @@ func MuxDiscussionsNote(mux *http.ServeMux, pid, mrID int, author string, author
 	})
 }
 
+// MuxDiscussionsNoteWithReply returns a single discussion where the first note
+// does not contain the trigger but a subsequent reply does. This simulates
+// /ok-to-test being posted in a thread reply.
+func MuxDiscussionsNoteWithReply(mux *http.ServeMux, pid, mrID int, firstAuthor string, firstAuthorID int, firstContent, okAuthor string, okAuthorID int, okContent string) {
+	path := fmt.Sprintf("/projects/%d/merge_requests/%d/discussions", pid, mrID)
+	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(rw, `[
+            {
+                "notes": [
+                    {
+                        "body": %q,
+                        "author": {"username": %q, "id": %d}
+                    },
+                    {
+                        "body": %q,
+                        "author": {"username": %q, "id": %d}
+                    }
+                ]
+            }
+        ]`, firstContent, firstAuthor, firstAuthorID, okContent, okAuthor, okAuthorID)
+	})
+}
+
 func MuxGetFile(mux *http.ServeMux, pid int, fname, content string, wantErr bool) {
 	mux.HandleFunc(fmt.Sprintf("/projects/%d/repository/files/%s/raw", pid, fname), func(rw http.ResponseWriter, _ *http.Request) {
 		if wantErr {

--- a/test/gitlab_oktotest_thread_reply_test.go
+++ b/test/gitlab_oktotest_thread_reply_test.go
@@ -1,0 +1,95 @@
+//go:build e2e
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
+	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	clientGitlab "gitlab.com/gitlab-org/api/client-go"
+	"gotest.tools/v3/assert"
+)
+
+// TestGitlabOpsCommentInThreadReply verifies that a /test command placed
+// in a reply within a discussion thread on a Merge Request is honored.
+func TestGitlabOpsCommentInThreadReply(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
+	assert.NilError(t, err)
+	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Info("Testing GitLab /test <PipelineRunName> in thread replies")
+
+	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
+	assert.NilError(t, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	// Create Repository CRD
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
+	assert.NilError(t, err)
+
+	// Create a basic PipelineRun
+	entries, err := payload.GetEntries(map[string]string{
+		".tekton/pipelinerun.yaml": "testdata/pipelinerun.yaml",
+	}, targetNS, projectinfo.DefaultBranch, "pull_request", map[string]string{})
+	assert.NilError(t, err)
+
+	// Create a branch with files and open a merge request
+	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
+	assert.NilError(t, err)
+	commitTitle := "Committing files from test on " + targetRefName
+	scmOpts := &scm.Opts{
+		GitURL:        gitCloneURL,
+		CommitTitle:   commitTitle,
+		Log:           runcnx.Clients.Log,
+		WebURL:        projectinfo.WebURL,
+		TargetRefName: targetRefName,
+		BaseRefName:   projectinfo.DefaultBranch,
+	}
+	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
+	mrTitle := "TestMergeRequest - " + targetRefName
+	mrID, err := tgitlab.CreateMR(glprovider.Client(), opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
+	assert.NilError(t, err)
+	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, mrID, targetRefName, targetNS, opts.ProjectID)
+
+	// Create a discussion thread with an initial note
+	disc, _, err := glprovider.Client().Discussions.CreateMergeRequestDiscussion(opts.ProjectID, mrID, &clientGitlab.CreateMergeRequestDiscussionOptions{
+		Body: clientGitlab.Ptr("random initial note"),
+	})
+	assert.NilError(t, err)
+
+	// Wait for repository status to reflect a successful run triggered by the comment
+	waitOpts := twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       "",
+	}
+	_, err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	runcnx.Clients.Log.Info("Updating discussion with /test comment in a reply thread")
+	// Add a reply to the discussion containing /test
+	_, _, err = glprovider.Client().Discussions.AddMergeRequestDiscussionNote(opts.ProjectID, mrID, disc.ID, &clientGitlab.AddMergeRequestDiscussionNoteOptions{
+		Body: clientGitlab.Ptr("/test"),
+	})
+	assert.NilError(t, err)
+	waitOpts.MinNumberStatus = 2
+	_, err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	runcnx.Clients.Log.Info("Repository status updated after /test comment")
+}


### PR DESCRIPTION
## 📝 Description of the Change

Previously, the GitLab provider only checked the top-level comment of a discussion for the `/ok-to-test` command. This limited where the command could be effectively used. The `/ok-to-test` command is now recognized when posted as a reply within a merge request discussion thread. An E2E test was added to verify this behavior, and the `README.md` was updated to reflect the new capability.

## 👨🏻‍ Linked Jira

Jira: https://issues.redhat.com/browse/SRVKP-8324

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [X] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [X] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
