### PR TITLE
fix(cli): correct namespace flag binding in tkn-pac

### DIFF
--- a/pkg/cmd/tknpac/info/templates/info.tmpl
+++ b/pkg/cmd/tknpac/info/templates/info.tmpl
@@ -14,7 +14,7 @@
  Webhook URL: {{ .Info.HookConfig.URL }}
 {{- end }}
 {{- end }}
-{{- if (gt (len .Repos) 1) }}
+{{- if (gt (len .Repos) 0) }}
 
 {{ $.CS.Underline "Repositories CR" }}: {{ len .Repos  }}
    Namespace	URL

--- a/pkg/params/info/kube.go
+++ b/pkg/params/info/kube.go
@@ -36,7 +36,7 @@ func (k *KubeOpts) AddFlags(cmd *cobra.Command) {
 		fmt.Sprintf("Path to the kubeconfig file to use for CLI requests (default: %s)", envkconfig))
 
 	cmd.PersistentFlags().StringVarP(
-		&k.ConfigPath,
+		&k.Namespace,
 		"namespace", "n", "",
 		"If present, the namespace scope for this CLI request")
 }

--- a/pkg/params/info/kube_test.go
+++ b/pkg/params/info/kube_test.go
@@ -52,6 +52,11 @@ func TestKubeOptsWithEnv(t *testing.T) {
 }
 
 func TestKubeOptsFlags(t *testing.T) {
+	t.Setenv("HOME", "/home/user")
+	t.Setenv("KUBECONFIG", "")
+	defaultKubeconfigPath := "/home/user/.kube/config"
+	customKubeconfigPath := "/custom/kube/config"
+
 	testcases := []struct {
 		name      string
 		flags     []string
@@ -62,31 +67,31 @@ func TestKubeOptsFlags(t *testing.T) {
 			name:      "namespace flag only",
 			flags:     []string{"--namespace", "test-ns"},
 			expectNS:  "test-ns",
-			expectCfg: "",
+			expectCfg: defaultKubeconfigPath,
 		},
 		{
 			name:      "namespace flag short form",
 			flags:     []string{"-n", "test-ns"},
 			expectNS:  "test-ns",
-			expectCfg: "",
+			expectCfg: defaultKubeconfigPath,
 		},
 		{
 			name:      "kubeconfig flag only",
-			flags:     []string{"--kubeconfig", "/home/user/.kube/config"},
+			flags:     []string{"--kubeconfig", customKubeconfigPath},
 			expectNS:  "",
-			expectCfg: "/home/user/.kube/config",
+			expectCfg: customKubeconfigPath,
 		},
 		{
 			name:      "both flags together",
-			flags:     []string{"--namespace", "test-ns", "--kubeconfig", "/home/user/.kube/config"},
+			flags:     []string{"--namespace", "test-ns", "--kubeconfig", customKubeconfigPath},
 			expectNS:  "test-ns",
-			expectCfg: "/home/user/.kube/config",
+			expectCfg: customKubeconfigPath,
 		},
 		{
 			name:      "both flags short form",
-			flags:     []string{"-n", "test-ns", "-k", "/home/user/.kube/config"},
+			flags:     []string{"-n", "test-ns", "-k", customKubeconfigPath},
 			expectNS:  "test-ns",
-			expectCfg: "/home/user/.kube/config",
+			expectCfg: customKubeconfigPath,
 		},
 	}
 	for _, tc := range testcases {
@@ -96,9 +101,7 @@ func TestKubeOptsFlags(t *testing.T) {
 			k.AddFlags(cmd)
 			assert.NilError(t, cmd.ParseFlags(tc.flags))
 			assert.Equal(t, k.Namespace, tc.expectNS, "namespace mismatch")
-			if tc.expectCfg != "" {
-				assert.Equal(t, k.ConfigPath, tc.expectCfg, "config path mismatch")
-			}
+			assert.Equal(t, k.ConfigPath, tc.expectCfg, "config path mismatch")
 		})
 	}
 }

--- a/pkg/params/info/kube_test.go
+++ b/pkg/params/info/kube_test.go
@@ -50,3 +50,55 @@ func TestKubeOptsWithEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestKubeOptsFlags(t *testing.T) {
+	testcases := []struct {
+		name      string
+		flags     []string
+		expectNS  string
+		expectCfg string
+	}{
+		{
+			name:      "namespace flag only",
+			flags:     []string{"--namespace", "test-ns"},
+			expectNS:  "test-ns",
+			expectCfg: "",
+		},
+		{
+			name:      "namespace flag short form",
+			flags:     []string{"-n", "test-ns"},
+			expectNS:  "test-ns",
+			expectCfg: "",
+		},
+		{
+			name:      "kubeconfig flag only",
+			flags:     []string{"--kubeconfig", "/home/user/.kube/config"},
+			expectNS:  "",
+			expectCfg: "/home/user/.kube/config",
+		},
+		{
+			name:      "both flags together",
+			flags:     []string{"--namespace", "test-ns", "--kubeconfig", "/home/user/.kube/config"},
+			expectNS:  "test-ns",
+			expectCfg: "/home/user/.kube/config",
+		},
+		{
+			name:      "both flags short form",
+			flags:     []string{"-n", "test-ns", "-k", "/home/user/.kube/config"},
+			expectNS:  "test-ns",
+			expectCfg: "/home/user/.kube/config",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			k := &KubeOpts{}
+			cmd := &cobra.Command{}
+			k.AddFlags(cmd)
+			assert.NilError(t, cmd.ParseFlags(tc.flags))
+			assert.Equal(t, k.Namespace, tc.expectNS, "namespace mismatch")
+			if tc.expectCfg != "" {
+				assert.Equal(t, k.ConfigPath, tc.expectCfg, "config path mismatch")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 📝 Description of the Change
- The --namespace/-n flag was incorrectly bound to the same variable as --kubeconfig, causing namespace values to overwrite the kubeconfig path
- Fixed template condition to display repos when count > 0
- Added tests for using kube flags with tkn-pac

Tested on local openshift cluster using latest pac and pipelines for issue reproduction 
<img width="1123" height="451" alt="image" src="https://github.com/user-attachments/assets/85153b43-a9a0-4ad9-8184-c563552cc142" />


## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-7152

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [x] Cursor
- [x] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [x] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
