### PR TITLE
chore: Allow org members to trigger E2E workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -43,6 +43,7 @@ jobs:
         provider: [providers, gitea_others]
 
     env:
+      TARGET_TEAM_SLUGS: "pipeline-as-code,pipeline-as-code-contributors"
       KO_DOCKER_REPO: localhost:5000
       CONTROLLER_DOMAIN_URL: controller.paac-127-0-0-1.nip.io
       TEST_GITHUB_REPO_OWNER_GITHUBAPP: openshift-pipelines/pipelines-as-code-e2e-tests
@@ -79,34 +80,163 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const actor = context.payload.pull_request.user.login;
-            const org = context.repo.owner;
-
-            // Allow a specific list of trusted bots to bypass the permission check.
-            const trustedBots = ['dependabot[bot]']; // Add any other trusted bot accounts here
-            if (trustedBots.includes(actor)) {
-              core.info(`User @${actor} is a trusted bot, allowing.`);
+            if (!github || !github.context || !github.context.payload || !github.context.payload.pull_request) {
+              core.setFailed('Invalid GitHub context: missing required pull_request information');
               return;
             }
+            const context = github.context;
 
-            try {
-              // Directly check the user's permission level on the repository.
-              // This covers both org members and external collaborators with sufficient access.
-              const response = await github.rest.repos.getCollaboratorPermissionLevel({
-                owner: org,
-                repo: context.repo.repo,
-                username: actor,
-              });
+            async function run() {
+              const actor = context.payload.pull_request.user.login;
+              const repoOwner = context.repo.owner;
+              const repoName = context.repo.repo;
+              const targetOrg = context.repo.owner;
 
-              const permission = response.data.permission;
-              if (permission !== 'admin' && permission !== 'write') {
-                core.setFailed(`❌ User @${actor} has only '${permission}' repository permission. 'write' or 'admin' is required.`);
-              } else {
-                core.info(`✅ User @${actor} has '${permission}' repository permission. Proceeding.`);
+              core.info(`🔍 Starting permission check for user: @${actor}`);
+              core.info(`📋 Repository: ${repoOwner}/${repoName}`);
+              core.info(`🏢 Target organization: ${targetOrg}`);
+
+              // Condition 1: Check if the user is a trusted bot.
+              const trustedBots = ["dependabot[bot]", "renovate[bot]"];
+              core.info(`🤖 Checking if @${actor} is a trusted bot...`);
+              core.info(`   Trusted bots list: ${trustedBots.join(', ')}`);
+
+              if (trustedBots.includes(actor)) {
+                core.info(`✅ Condition met: User @${actor} is a trusted bot. Proceeding.`);
+                return; // Success
               }
-            } catch (error) {
-              core.setFailed(`Permission check failed for @${actor}. They are likely not a collaborator on the repository. Error: ${error.message}`);
+              core.info(`   ❌ User @${actor} is not a trusted bot.`);
+
+              // Condition 2: Check for public membership in the target organization.
+              core.info(`\n👥 Condition 2: Checking organization and team membership...`);
+              core.info(
+                `User @${actor} is not a trusted bot. Checking for membership in '${targetOrg}'...`,
+              );
+              try {
+                // Optional: check membership in one or more org teams (set TARGET_TEAM_SLUGS as comma-separated slugs in workflow env)
+                const teamSlugsEnv = process.env.TARGET_TEAM_SLUGS || "";
+                const teamSlugs = teamSlugsEnv
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter(Boolean);
+
+                core.info(`🔧 TARGET_TEAM_SLUGS environment variable: "${teamSlugsEnv}"`);
+                core.info(`📝 Parsed team slugs: [${teamSlugs.join(', ')}]`);
+
+                if (teamSlugs.length > 0) {
+                  core.info(`🔍 Checking team membership for ${teamSlugs.length} team(s)...`);
+                  for (const team_slug of teamSlugs) {
+                    core.info(`   Checking team: ${team_slug}...`);
+                    try {
+                      const membership = await github.rest.teams.getMembershipForUserInOrg({
+                        org: targetOrg,
+                        team_slug,
+                        username: actor,
+                      });
+                      core.info(`   API response for team '${team_slug}': ${JSON.stringify(membership.data)}`);
+                      if (
+                        membership &&
+                        membership.data &&
+                        membership.data.state === "active"
+                      ) {
+                        core.info(
+                          `✅ Condition met: User @${actor} is a member of team '${team_slug}' in '${targetOrg}'. Proceeding.`,
+                        );
+                        return; // Success
+                      } else {
+                        core.info(`   ⚠️ Team membership found but state is not 'active': ${membership.data.state}`);
+                      }
+                    } catch (err) {
+                      // Not a member of this team or team doesn't exist — continue to next
+                      core.info(
+                        `   ❌ User @${actor} is not a member of team '${team_slug}' (or team not found). Error: ${err.message}`,
+                      );
+                    }
+                  }
+                  // If we tried team checks and none matched, continue to next org membership checks
+                  core.info(
+                    `ⓘ User @${actor} is not a member of any configured teams in '${targetOrg}'. Falling back to org membership checks.`,
+                  );
+                } else {
+                  core.info(`ℹ️ No teams configured in TARGET_TEAM_SLUGS. Skipping team membership checks.`);
+                }
+                core.info(`🏢 Checking organization membership for @${actor} in '${targetOrg}'...`);
+                try {
+                  core.info(`   Attempting checkMembershipForUser API call...`);
+                  await github.rest.orgs.checkMembershipForUser({
+                    org: targetOrg,
+                    username: actor,
+                  });
+                  core.info(
+                    `✅ Condition met: User @${actor} is a member of '${targetOrg}'. Proceeding.`,
+                  );
+                  return; // Success
+                } catch (err) {
+                  // Try public membership as fallback
+                  core.info(`   ❌ Private membership check failed: ${err.message}`);
+                  core.info(`   Attempting checkPublicMembershipForUser API call...`);
+                  try {
+                    await github.rest.orgs.checkPublicMembershipForUser({
+                      org: targetOrg,
+                      username: actor,
+                    });
+                    core.info(
+                      `✅ Condition met: User @${actor} is a public member of '${targetOrg}'. Proceeding.`,
+                    );
+                    return; // Success
+                  } catch (publicErr) {
+                    // Neither private nor public member - will be caught by outer catch
+                    core.info(`   ❌ Public membership check failed: ${publicErr.message}`);
+                    throw publicErr;
+                  }
+                }
+              } catch (error) {
+                // This is not a failure, just one unmet condition. Log and continue.
+                core.info(
+                  `ⓘ User @${actor} is not a public member of '${targetOrg}'. Checking repository permissions as a fallback.`,
+                );
+              }
+
+              // Condition 3: Check for write/admin permission on the repository.
+              core.info(`\n🔐 Condition 3: Checking repository collaborator permissions...`);
+              try {
+                core.info(`   Attempting getCollaboratorPermissionLevel API call...`);
+                const response = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: repoOwner,
+                  repo: repoName,
+                  username: actor,
+                });
+
+                core.info(`   API response: ${JSON.stringify(response.data)}`);
+                const permission = response.data.permission;
+                core.info(`   User @${actor} has '${permission}' permission on ${repoOwner}/${repoName}`);
+
+                if (permission === "admin" || permission === "write") {
+                  core.info(
+                    `✅ Condition met: User @${actor} has '${permission}' repository permission. Proceeding.`,
+                  );
+                  return; // Success
+                } else {
+                  // If we reach here, no conditions were met. This is the final failure.
+                  core.info(`   ❌ Permission '${permission}' is insufficient (requires 'write' or 'admin')`);
+                  core.setFailed(
+                    `❌ Permission check failed. User @${actor} did not meet any required conditions (trusted bot, org member, or repo write access).`,
+                  );
+                }
+              } catch (error) {
+                // This error means they are not even a collaborator.
+                core.info(`   ❌ Collaborator permission check failed: ${error.message}`);
+                core.setFailed(
+                  `❌ Permission check failed. User @${actor} is not a collaborator on this repository and did not meet other conditions.`,
+                );
+              }
             }
+
+            run().catch(err => {
+              core.error(`💥 Unexpected error during permission check: ${err.message}`);
+              core.error(`   Stack trace: ${err.stack}`);
+              core.setFailed(`Unexpected error during permission check: ${err.message}`);
+            });
 
       - uses: actions/setup-go@v6
         with:
@@ -175,9 +305,7 @@ jobs:
           TEST_BITBUCKET_SERVER_API_URL: ${{ secrets.BITBUCKET_SERVER_API_URL }}
           TEST_BITBUCKET_SERVER_WEBHOOK_SECRET: ${{ secrets.BITBUCKET_SERVER_WEBHOOK_SECRET }}
         run: |
-          set -o pipefail
-          LOG_FILE="/tmp/e2e-tests-${{ matrix.provider }}.log"
-          ./hack/gh-workflow-ci.sh run_e2e_tests 2>&1 | tee "${LOG_FILE}"
+          ./hack/gh-workflow-ci.sh run_e2e_tests
 
       - name: Run E2E Tests on nightly
         # This step still runs specifically for schedule or workflow_dispatch
@@ -196,30 +324,7 @@ jobs:
           TEST_BITBUCKET_SERVER_API_URL: ${{ secrets.BITBUCKET_SERVER_API_URL }}
           TEST_BITBUCKET_SERVER_WEBHOOK_SECRET: ${{ secrets.BITBUCKET_SERVER_WEBHOOK_SECRET }}
         run: |
-          set -o pipefail
-          LOG_FILE="/tmp/e2e-tests-${{ matrix.provider }}.log"
-          ./hack/gh-workflow-ci.sh run_e2e_tests 2>&1 | tee "${LOG_FILE}"
-
-      - name: Summarize failing tests
-        if: ${{ failure() }}
-        id: failing-tests
-        run: |
-          LOG_FILE="/tmp/e2e-tests-${{ matrix.provider }}.log"
-          if [[ ! -f "${LOG_FILE}" || ! -s "${LOG_FILE}" ]]; then
-            echo "slack_message=E2E job failed but no test log was captured for provider '${{ matrix.provider }}'." >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          mapfile -t FAILURES < <(grep -E '^--- FAIL: ' "${LOG_FILE}" | sed -E 's/^--- FAIL: ([^[:space:]]+).*/\1/' | sort -u)
-
-          if [[ ${#FAILURES[@]} -eq 0 ]]; then
-            echo "slack_message=E2E job failed without explicit go test failures; check workflow logs for provider '${{ matrix.provider }}'." >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          joined_failures=$(printf '%s, ' "${FAILURES[@]}")
-          joined_failures=${joined_failures%, }
-          echo "slack_message=Failing tests for provider ${{ matrix.provider }}: ${joined_failures}" >> "${GITHUB_OUTPUT}"
+          ./hack/gh-workflow-ci.sh run_e2e_tests
 
       - name: Collect logs
         if: ${{ always() }}
@@ -241,14 +346,11 @@ jobs:
           name: logs-e2e-tests-${{ matrix.provider }}
           path: /tmp/logs
 
-      - name: Report E2E test results to Slack
+      - name: Report Status
         if: ${{ always() && github.ref_name == 'main' && github.event_name == 'schedule' }}
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}
           notify_when: "failure"
-          message_format: |
-            {emoji} *{workflow}* {status_message} in <{repo_url}|{repo}@{branch}> on <{commit_url}|{commit_sha}>
-            ${{ steps.failing-tests.outputs.slack_message }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
The permission check script in the E2E workflow was updated. It now verifies if the pull request author is a public member of the `openshift-pipelines` organization.

This check is performed in addition to the existing checks for trusted bots and collaborators with repository write access. This allows organization members to run E2E tests on their pull requests without requiring direct write permissions on the repository.

Additionally, `renovate[bot]` was added to the list of trusted bots.

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [X] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [X] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [X] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [X] ChatGPT (OpenAI)
- [X] Claude (Anthropic)
- [X] Cursor
- [X] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [X] Everything
- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center


Closes #2286