### PR TITLE
feat: Add GitOps command support for tags in GitLab

### DIFF
--- a/docs/content/docs/guide/gitops_commands.md
+++ b/docs/content/docs/guide/gitops_commands.md
@@ -124,7 +124,7 @@ The PipelineRun will be restarted regardless of the annotations if the comment `
 
 ### Triggering PipelineRun on Git tags
 
-{{< support_matrix github_app="true" github_webhook="true" gitea="false" gitlab="false" bitbucket_cloud="false" bitbucket_server="false" >}}
+{{< support_matrix github_app="true" github_webhook="true" gitea="false" gitlab="true" bitbucket_cloud="false" bitbucket_server="false" >}}
 
 You can retrigger a PipelineRun against a specific Git tag by commenting on
 the tagged commit using a GitOps command. Pipelines-as-Code will resolve the

--- a/test/gitlab_push_gitops_command_test.go
+++ b/test/gitlab_push_gitops_command_test.go
@@ -166,3 +166,93 @@ func TestGitlabGitOpsCommandCancelOnPush(t *testing.T) {
 	err = wait.UntilPipelineRunHasReason(ctx, runcnx.Clients, v1.PipelineRunReasonCancelled, waitOpts)
 	assert.NilError(t, err)
 }
+
+func TestGitlabGitOpsCommandTestOnTag(t *testing.T) {
+	targetNs := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
+	assert.NilError(t, err)
+	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Info("Testing with Gitlab")
+	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
+	assert.NilError(t, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	tagName := "v1.0.0"
+	comment := "/test tag:" + tagName
+	sha := ""
+	targetBranch := "release-" + tagName
+	numberOfPRs := 1
+
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNs, nil)
+	assert.NilError(t, err)
+
+	runcnx.Clients.Log.Infof("Repository %s has been created successfully", targetNs)
+
+	tag, resp, err := glprovider.Client().Tags.GetTag(opts.ProjectID, tagName)
+	if err != nil && resp.StatusCode == http.StatusNotFound {
+		runcnx.Clients.Log.Infof("Tag %s not found in repository %s", tagName, projectinfo.Name)
+		runcnx.Clients.Log.Infof("Creating tag %s in repository %s", tagName, projectinfo.Name)
+
+		entries, err := payload.GetEntries(map[string]string{
+			".tekton/pipelinerun-on-tag.yaml": "testdata/pipelinerun-on-tag.yaml",
+		}, targetNs, "refs/tags/*", triggertype.Push.String(), map[string]string{})
+		assert.NilError(t, err)
+
+		cloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, "git", *glprovider.Token)
+		assert.NilError(t, err)
+
+		scmOpts := &scm.Opts{
+			GitURL:        cloneURL,
+			Log:           runcnx.Clients.Log,
+			WebURL:        projectinfo.WebURL,
+			TargetRefName: targetBranch,
+			BaseRefName:   projectinfo.DefaultBranch,
+			CommitTitle:   "Test GitOps Commands on Tag - " + targetNs,
+		}
+		_ = scm.PushFilesToRefGit(t, scmOpts, entries)
+
+		branch, _, err := glprovider.Client().Branches.GetBranch(opts.ProjectID, targetBranch)
+		assert.NilError(t, err)
+
+		sha = branch.Commit.ID
+
+		_, _, err = glprovider.Client().Tags.CreateTag(opts.ProjectID, &gitlab.CreateTagOptions{
+			TagName: gitlab.Ptr(tagName),
+			Ref:     gitlab.Ptr(targetBranch),
+		})
+		assert.NilError(t, err)
+
+		// as we're creating a tag, we need to increment the number of PRs
+		// because the tag creation will also trigger a new PipelineRun
+		numberOfPRs++
+	} else {
+		runcnx.Clients.Log.Infof("Tag %s already created in repository %s", tagName, projectinfo.Name)
+		sha = tag.Commit.ID
+	}
+	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, "", targetNs, opts.ProjectID)
+
+	cc, _, err := glprovider.Client().Commits.PostCommitComment(opts.ProjectID, sha, &gitlab.PostCommitCommentOptions{
+		Note: gitlab.Ptr(comment),
+	})
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
+
+	waitOpts := wait.Opts{
+		RepoName:        targetNs,
+		Namespace:       targetNs,
+		MinNumberStatus: numberOfPRs,
+		PollTimeout:     wait.DefaultTimeout,
+		TargetSHA:       sha,
+	}
+
+	err = wait.UntilPipelineRunCreated(ctx, runcnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNs).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, len(prsNew.Items) == numberOfPRs)
+}


### PR DESCRIPTION
This commit introduces the ability to trigger, retest, and cancel pipeline runs on GitLab tags using GitOps comments on commits.

Key features:
- Support `/test tag:<tagname>`, `/retest tag:<tagname>`, and `/cancel tag:<tagname>` GitOps comments on commits
- Validate that the commented commit matches the tag before processing the request
- Enable retriggering pipelines on existing tagged commits without creating new tags

Testing:
- Add comprehensive unit tests covering success and error scenarios
- Add end-to-end test validating the complete workflow from tag creation to pipeline execution

Use cases:
- Release management: retrigger pipelines on tagged releases
- Troubleshooting: re-run failed pipelines on existing tags
- Flexible CI/CD workflows for version-specific builds

## 📝 Description of the Change

## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-8612

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [x] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [x] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [x] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
