### PR TITLE
fix: prevent stale failure statuses on commits

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,6 +3,7 @@ ignore: |
   .git
   test/testdata/failures/pipeline_bad_format.yaml
   test/testdata/failures/bad-yaml.yaml
+  test/testdata/failures/bad-pipelinerun.yaml
   *badyaml.yaml
   .github/workflows/*
 

--- a/pkg/consoleui/openshift.go
+++ b/pkg/consoleui/openshift.go
@@ -13,8 +13,8 @@ import (
 const (
 	openShiftConsoleNS                = "openshift-console"
 	openShiftConsoleRouteName         = "console"
-	openShiftPipelineNamespaceViewURL = "https://%s/pipelines/ns/%s/pipeline-runs"
-	openShiftPipelineDetailViewURL    = "https://%s/k8s/ns/%s/tekton.dev~v1~PipelineRun/%s"
+	openShiftPipelineNamespaceViewURL = "%s/pipelines/ns/%s/pipeline-runs"
+	openShiftPipelineDetailViewURL    = "%s/k8s/ns/%s/tekton.dev~v1~PipelineRun/%s"
 	openShiftPipelineTaskLogURL       = "%s/logs/%s"
 	openShiftRouteGroup               = "route.openshift.io"
 	openShiftRouteVersion             = "v1"
@@ -34,11 +34,14 @@ func (o *OpenshiftConsole) GetName() string {
 }
 
 func (o *OpenshiftConsole) URL() string {
+	if o.host == "" {
+		return "https://openshift.url.is.not.configured"
+	}
 	return "https://" + o.host
 }
 
 func (o *OpenshiftConsole) DetailURL(pr *tektonv1.PipelineRun) string {
-	return fmt.Sprintf(openShiftPipelineDetailViewURL, o.host, pr.GetNamespace(), pr.GetName())
+	return fmt.Sprintf(openShiftPipelineDetailViewURL, o.URL(), pr.GetNamespace(), pr.GetName())
 }
 
 func (o *OpenshiftConsole) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *tektonv1.PipelineRunTaskRunStatus) string {
@@ -46,7 +49,7 @@ func (o *OpenshiftConsole) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *t
 }
 
 func (o *OpenshiftConsole) NamespaceURL(pr *tektonv1.PipelineRun) string {
-	return fmt.Sprintf(openShiftPipelineNamespaceViewURL, o.host, pr.GetNamespace())
+	return fmt.Sprintf(openShiftPipelineNamespaceViewURL, o.URL(), pr.GetNamespace())
 }
 
 // UI use dynamic client to get the route of the openshift

--- a/pkg/consoleui/openshift_test.go
+++ b/pkg/consoleui/openshift_test.go
@@ -127,4 +127,10 @@ func TestOpenshiftConsoleURLs(t *testing.T) {
 	assert.Equal(t, o.DetailURL(pr), "https://fakeconsole/k8s/ns/theNS/tekton.dev~v1~PipelineRun/pr")
 	assert.Equal(t, o.TaskLogURL(pr, trStatus), "https://fakeconsole/k8s/ns/theNS/tekton.dev~v1~PipelineRun/pr/logs/task")
 	assert.Equal(t, o.NamespaceURL(pr), "https://fakeconsole/pipelines/ns/theNS/pipeline-runs")
+
+	emptyHost := OpenshiftConsole{host: ""}
+	assert.Equal(t, emptyHost.URL(), "https://openshift.url.is.not.configured")
+	assert.Equal(t, emptyHost.DetailURL(pr), "https://openshift.url.is.not.configured/k8s/ns/theNS/tekton.dev~v1~PipelineRun/pr")
+	assert.Equal(t, emptyHost.TaskLogURL(pr, trStatus), "https://openshift.url.is.not.configured/k8s/ns/theNS/tekton.dev~v1~PipelineRun/pr/logs/task")
+	assert.Equal(t, emptyHost.NamespaceURL(pr), "https://openshift.url.is.not.configured/pipelines/ns/theNS/pipeline-runs")
 }

--- a/pkg/consoleui/tektondashboard.go
+++ b/pkg/consoleui/tektondashboard.go
@@ -19,7 +19,7 @@ func (t *TektonDashboard) GetName() string {
 }
 
 func (t *TektonDashboard) DetailURL(pr *tektonv1.PipelineRun) string {
-	return fmt.Sprintf("%s/#/namespaces/%s/pipelineruns/%s", t.BaseURL, pr.GetNamespace(), pr.GetName())
+	return fmt.Sprintf("%s/#/namespaces/%s/pipelineruns/%s", t.URL(), pr.GetNamespace(), pr.GetName())
 }
 
 func (t *TektonDashboard) NamespaceURL(pr *tektonv1.PipelineRun) string {
@@ -31,6 +31,10 @@ func (t *TektonDashboard) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *te
 }
 
 func (t *TektonDashboard) URL() string {
+	// if BaseURL is not provided, return fake URL
+	if t.BaseURL == "" || t.BaseURL == "http://" || t.BaseURL == "https://" {
+		return "https://dashboard.url.is.not.configured"
+	}
 	return t.BaseURL
 }
 

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -121,6 +121,9 @@ func (p *PacRun) Run(ctx context.Context) error {
 				errMsgM := fmt.Sprintf("There was an error creating the PipelineRun: <b>%s</b>\n\n%s", match.PipelineRun.GetGenerateName(), err.Error())
 				p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryPipelineRun", errMsg)
 				createStatusErr := p.vcx.CreateStatus(ctx, p.event, provider.StatusOpts{
+					PipelineRunName:          match.PipelineRun.GetName(),
+					PipelineRun:              match.PipelineRun,
+					OriginalPipelineRunName:  match.PipelineRun.GetAnnotations()[keys.OriginalPRName],
 					Status:                   CompletedStatus,
 					Conclusion:               failureConclusion,
 					Text:                     errMsgM,

--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package test
 
 import (

--- a/test/testdata/always-good-pipelinerun.yaml
+++ b/test/testdata/always-good-pipelinerun.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: always-good-pipelinerun
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        displayName: "The Task name is Task"
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "HELLOMOTO"]

--- a/test/testdata/bad-converts-good-pipelinerun.yaml
+++ b/test/testdata/bad-converts-good-pipelinerun.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: bad-converts-good-pipelinerun  # it will be converted to be a good boy pipelinerun
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        displayName: "The Task name is Task"
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "HELLOMOTO"]

--- a/test/testdata/failures/bad-pipelinerun.yaml
+++ b/test/testdata/failures/bad-pipelinerun.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: bad-converts-good-pipelinerun
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineRef:


### PR DESCRIPTION
Ensures a consistent context key is used for all GitLab commit statuses, allowing failures from invalid PipelineRuns to be correctly overwritten on subsequent runs.

### The Problem:
When a repository contained multiple PipelineRun definitions and one was invalid (e.g., due to a validation error), the initial commit would correctly report a "failed" status to GitLab for that invalid run. However, the context key for this failure was generic  (e.g., "ApplicationName") because a full PipelineRun wasn't provided.

After a developer fixed the invalid PipelineRun and pushed a new commit, the now-successful run would post its status with a more specific context key (e.g., "ApplicationName/PipelineRunName").

Because the GitLab API does not allow deleting commit pipeline jobs, the original, generic "failed" status remained on the commit forever. This resulted in the overall commit pipeline being permanently and incorrectly marked as "failed," even though all pipelines eventually succeeded.

### The Solution:
this commit provides PipelineRun name from "OriginalPRName" annotation so that contextKey is uniform for "success" PipelineRun and failed PipelineRuns due to validation.

### Before
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/8c7838d4-69dd-43ca-8bcf-52db87915ffa" />


### After
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/0249cb0a-ecd6-43be-b209-c732cad66c5a" />


### After Fixing the PipelineRun syntax error here is how the status is update with correct job name
<img width="500" height="300" alt="image" src="https://github.com/user-attachments/assets/033cd074-c027-4657-8078-9833271b94ca" />


## 📝 Description of the Change

## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-9044

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [x] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [x] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
