### PR TITLE
feat(incoming): Set default secret key for incoming webhooks

### DIFF
--- a/docs/content/docs/guide/incoming_webhook.md
+++ b/docs/content/docs/guide/incoming_webhook.md
@@ -59,6 +59,8 @@ spec:
       type: webhook-url
 ```
 
+**Note:** If no secret key is specified in the Repository CR, the default key `secret` will be used to retrieve the secret value from the `repo-incoming-secret` Secret resource.
+
 ### Glob Pattern Matching in Targets
 
 The `targets` field supports both exact string matching and glob patterns, allowing you to match multiple branches with a single rule.

--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -23,6 +23,10 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	defaultIncomingWebhookSecretKey = "secret"
+)
+
 func compareSecret(incomingSecret, secretValue string) bool {
 	return subtle.ConstantTimeCompare([]byte(incomingSecret), []byte(secretValue)) != 0
 }
@@ -122,6 +126,11 @@ func (l *listener) detectIncoming(ctx context.Context, req *http.Request, payloa
 		Name:      hook.Secret.Name,
 		Key:       hook.Secret.Key,
 	}
+
+	if secretOpts.Key == "" {
+		secretOpts.Key = defaultIncomingWebhookSecretKey
+	}
+
 	secretValue, err := l.kint.GetSecret(ctx, secretOpts)
 	if err != nil {
 		return false, nil, fmt.Errorf("error getting secret referenced in incoming-webhook: %w", err)

--- a/pkg/adapter/incoming_test.go
+++ b/pkg/adapter/incoming_test.go
@@ -233,6 +233,43 @@ func Test_listener_detectIncoming(t *testing.T) {
 			},
 		},
 		{
+			name: "good/incoming with default secret key",
+			want: true,
+			args: args{
+				secretResult: map[string]string{"incoming-secret": "verysecrete"},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-default-key",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								Incomings: &[]v1alpha1.Incoming{
+									{
+										Targets: []string{"main"},
+										Secret: v1alpha1.Secret{
+											Name: "incoming-secret",
+											// Key is not specified, should default to "secret"
+										},
+									},
+								},
+								GitProvider: &v1alpha1.GitProvider{
+									Type: "github",
+								},
+							},
+						},
+					},
+				},
+				method:           http.MethodPost,
+				queryURL:         "/incoming",
+				queryRepository:  "test-default-key",
+				querySecret:      "verysecrete",
+				queryPipelineRun: "pipelinerun1",
+				queryBranch:      "main",
+			},
+		},
+		{
 			name: "invalid incoming body",
 			args: args{
 				method:           http.MethodPost,


### PR DESCRIPTION
When no secret key is specified in the Repository CR's incoming webhook configuration, the system now defaults to using "secret" as the key name when retrieving the secret value from the Secret resource.

Changes:
- Add default key fallback logic in incoming webhook adapter
- Document the default "secret" key behavior in incoming webhook guide

This simplifies configuration by not requiring users to explicitly specify the secret key when using the standard "secret" key name.

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [x] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
