### PR TITLE
feat: Exclude tag push events from skip-pr-commits logic

### DIFF
--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -164,6 +164,9 @@ There are a few things you can configure through the ConfigMap
 
   Default: `true`
 
+  **Note:** This setting does not apply to git tag push events. Tag push events will always trigger
+  pipeline runs regardless of whether the tagged commit is part of an open pull request.
+
 {{< support_matrix github_app="true" github_webhook="true" gitea="false" gitlab="false" bitbucket_cloud="false" bitbucket_datacenter="false" >}}
 
 ### Global Cancel In Progress Settings

--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package test
 
 import (

--- a/test/github_tag_gitops_test.go
+++ b/test/github_tag_gitops_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package test
 
 import (

--- a/test/pkg/github/tag.go
+++ b/test/pkg/github/tag.go
@@ -29,8 +29,6 @@ func CreateTag(ctx context.Context, t *testing.T, runcnx *params.Run, ghcnx *pac
 	tag, _, err := ghcnx.Client().Git.CreateTag(ctx, opts.Organization, opts.Repo, tag)
 	assert.NilError(t, err)
 
-	runcnx.Clients.Log.Infof("Tag %s has been created successfully", *tag.SHA)
-
 	refToCreate := &github.Reference{
 		Ref:    github.Ptr("refs/tags/" + tagName),
 		Object: &github.GitObject{SHA: tag.SHA},
@@ -40,4 +38,9 @@ func CreateTag(ctx context.Context, t *testing.T, runcnx *params.Run, ghcnx *pac
 	runcnx.Clients.Log.Infof("Tag %s has been created successfully", tag.GetTag())
 
 	return tag, nil
+}
+
+func DeleteTag(ctx context.Context, ghcnx *pacgithub.Provider, opts options.E2E, tagName string) error {
+	_, err := ghcnx.Client().Git.DeleteRef(ctx, opts.Organization, opts.Repo, "refs/tags/"+tagName)
+	return err
 }


### PR DESCRIPTION
When the skip-pr-commits setting is enabled, the system skips push events for commits that are part of an open pull request to avoid duplicate pipeline runs. However, this should not apply to tag push events, as tags represent important release points that should always trigger pipelines regardless of PR status.

Changes:
- Detect tag push events by checking if ref starts with "refs/tags/"
- Exclude tag push events from skip logic even when skip-pr-commits setting is enabled
- Add test case verifying tag push events are not skipped
- Add test case verifying regular push events are still skipped when commit is part of a PR

This ensures that tagging a commit (e.g., for releases) always triggers the associated pipeline runs, while still avoiding duplicate runs for regular branch commits that are part of pull requests.

## 📝 Description of the Change

## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-9111

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [x] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [x] GitHub App
  - [x] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
