### PR TITLE
fix(gitlab): check permission according to RememberOkToTest setting

### DIFF
--- a/pkg/provider/gitlab/acl_test.go
+++ b/pkg/provider/gitlab/acl_test.go
@@ -1,12 +1,16 @@
 package gitlab
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	thelp "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab/test"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
@@ -19,19 +23,38 @@ func TestIsAllowed(t *testing.T) {
 	type args struct {
 		event *info.Event
 	}
+
+	testEvent := thelp.TEvent{
+		UserID:          1111,
+		TargetProjectID: 2525,
+		NoteID:          1111,
+		Username:        "admin",
+		DefaultBranch:   "main",
+		URL:             "https://gitlab.com/admin/testrepo",
+		SHA:             "sha",
+		SHAurl:          "https://url",
+		SHAtitle:        "commit it",
+		Headbranch:      "branch",
+		Basebranch:      "main",
+		HeadURL:         "https://url",
+		BaseURL:         "https://url",
+	}
+
 	tests := []struct {
-		name            string
-		fields          fields
-		args            args
-		allowed         bool
-		wantErr         bool
-		wantClient      bool
-		allowMemberID   int
-		ownerFile       string
-		commentContent  string
-		commentAuthor   string
-		commentAuthorID int
-		threadFirstNote string
+		name             string
+		fields           fields
+		args             args
+		allowed          bool
+		wantErr          bool
+		wantClient       bool
+		allowMemberID    int
+		ownerFile        string
+		commentContent   string
+		commentAuthor    string
+		commentAuthorID  int
+		threadFirstNote  string
+		rememberOKToTest bool
+		wantEventStruct  bool
 	}{
 		{
 			name:    "check client has been set",
@@ -64,7 +87,7 @@ func TestIsAllowed(t *testing.T) {
 			ownerFile: "---\n approvers:\n  - allowmeplease\n",
 		},
 		{
-			name:       "allowed from ok-to-test",
+			name:       "allowed from ok-to-test with RememberOKToTest enabled",
 			allowed:    true,
 			wantClient: true,
 			fields: fields{
@@ -74,10 +97,30 @@ func TestIsAllowed(t *testing.T) {
 			args: args{
 				event: &info.Event{Sender: "noowner", PullRequestNumber: 1},
 			},
-			allowMemberID:   1111,
-			commentContent:  "/ok-to-test",
-			commentAuthor:   "admin",
-			commentAuthorID: 1111,
+			allowMemberID:    1111,
+			commentContent:   "/ok-to-test",
+			commentAuthor:    "admin",
+			commentAuthorID:  1111,
+			wantEventStruct:  true,
+			rememberOKToTest: true,
+		},
+		{
+			name:       "allowed from ok-to-test with RememberOKToTest disabled",
+			allowed:    true,
+			wantClient: true,
+			fields: fields{
+				userID:          6666,
+				targetProjectID: 2525,
+			},
+			args: args{
+				event: &info.Event{Sender: "noowner", PullRequestNumber: 1},
+			},
+			allowMemberID:    1111,
+			commentContent:   "/ok-to-test",
+			commentAuthor:    "admin",
+			commentAuthorID:  1111,
+			wantEventStruct:  true,
+			rememberOKToTest: false, // make it disabled explicitly to indicate what we're testing 🙃
 		},
 		{
 			name:       "allowed when /ok-to-test is in a reply note",
@@ -90,11 +133,13 @@ func TestIsAllowed(t *testing.T) {
 			args: args{
 				event: &info.Event{Sender: "noowner", PullRequestNumber: 2},
 			},
-			allowMemberID:   1111,
-			threadFirstNote: "random comment",
-			commentContent:  "/ok-to-test",
-			commentAuthor:   "admin",
-			commentAuthorID: 1111,
+			allowMemberID:    1111,
+			threadFirstNote:  "random comment",
+			commentContent:   "/ok-to-test",
+			commentAuthor:    "admin",
+			commentAuthorID:  1111,
+			wantEventStruct:  true,
+			rememberOKToTest: true,
 		},
 		{
 			name:       "disallowed from non authorized note",
@@ -113,16 +158,20 @@ func TestIsAllowed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
+			logger, _ := logger.GetLogger()
 
 			v := &Provider{
 				targetProjectID: tt.fields.targetProjectID,
 				sourceProjectID: tt.fields.sourceProjectID,
 				userID:          tt.fields.userID,
+				Logger:          logger,
+				pacInfo:         &info.PacOpts{Settings: settings.Settings{RememberOKToTest: tt.rememberOKToTest}},
 			}
 			if tt.wantClient {
 				client, mux, tearDown := thelp.Setup(t)
 				v.gitlabClient = client
 				if tt.allowMemberID != 0 {
+					v.userID = tt.allowMemberID
 					thelp.MuxAllowUserID(mux, tt.fields.targetProjectID, tt.allowMemberID)
 				} else {
 					thelp.MuxDisallowUserID(mux, tt.fields.targetProjectID, tt.allowMemberID)
@@ -143,9 +192,22 @@ func TestIsAllowed(t *testing.T) {
 				} else {
 					thelp.MuxDiscussionsNoteEmpty(mux, tt.fields.targetProjectID, tt.args.event.PullRequestNumber)
 				}
+				if tt.commentContent != "" {
+					thelp.MuxMergeRequestNote(mux, tt.fields.targetProjectID, tt.args.event.PullRequestNumber, testEvent.NoteID, testEvent.UserID, tt.commentContent, testEvent.Username)
+				}
 
 				defer tearDown()
 			}
+
+			if tt.wantEventStruct {
+				glEvent := &gitlab.MergeCommentEvent{}
+				err := json.Unmarshal([]byte(testEvent.MergeCommentEventAsJSON(tt.commentContent)), glEvent)
+				if err != nil {
+					t.Fatalf("failed to unmarshal event: %v", err)
+				}
+				tt.args.event.Event = glEvent
+			}
+
 			got, err := v.IsAllowed(ctx, tt.args.event)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("IsAllowed() error = %v, wantErr %v", err, tt.wantErr)
@@ -203,10 +265,12 @@ func TestMembershipCaching(t *testing.T) {
 
 func TestMembershipAPIFailureDoesNotCacheApiError(t *testing.T) {
 	ctx, _ := rtesting.SetupFakeContext(t)
+	logger, _ := logger.GetLogger()
 
 	v := &Provider{
 		targetProjectID: 3030,
 		userID:          4242,
+		Logger:          logger,
 	}
 
 	client, mux, tearDown := thelp.Setup(t)


### PR DESCRIPTION
Refactor ACL check to properly handle RememberOKToTest setting:
- When RememberOKToTest is disabled for MergeEvent, skip checking all discussion notes and return false early
- When RememberOKToTest is disabled for MergeCommentEvent, check only the current comment instead of all discussion history
- Add aclAllowedOkToTestCurrentComment function to validate the specific comment that triggered the event

This avoids checking all comments for /ok-to-test regardless of RememberOkToTest setting and optimizes the ACL check by avoiding unnecessary API calls to fetch all discussion notes when RememberOKToTest is disabled.

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

https://issues.redhat.com/browse/SRVKP-9200

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [x] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
