### PR TITLE
fix(cel): add nil checks to prevent panics in webhook parsers

### DIFF
--- a/pkg/cmd/tknpac/cel/parser_test.go
+++ b/pkg/cmd/tknpac/cel/parser_test.go
@@ -1,0 +1,448 @@
+package cel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"gotest.tools/v3/assert"
+)
+
+func TestGitHubParserWithMissingFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		wantErr bool
+		checks  func(t *testing.T, event *info.Event)
+	}{
+		{
+			name: "missing repository field",
+			payload: `{
+				"action": "opened",
+				"pull_request": {
+					"number": 1,
+					"title": "Test PR",
+					"head": {"ref": "feature", "sha": "abc123"},
+					"base": {"ref": "main"}
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.Organization, "")
+				assert.Equal(t, event.Repository, "")
+				assert.Equal(t, event.Sender, "testuser")
+				assert.Equal(t, event.PullRequestNumber, 1)
+			},
+		},
+		{
+			name: "missing pull request field",
+			payload: `{
+				"action": "opened",
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"},
+					"html_url": "https://github.com/test-org/test-repo"
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.Organization, "test-org")
+				assert.Equal(t, event.Repository, "test-repo")
+				assert.Equal(t, event.Sender, "testuser")
+				assert.Equal(t, event.SHA, "")
+				assert.Equal(t, event.PullRequestNumber, 0)
+			},
+		},
+		{
+			name: "missing sender field",
+			payload: `{
+				"action": "opened",
+				"pull_request": {
+					"number": 1,
+					"title": "Test PR",
+					"head": {"ref": "feature", "sha": "abc123"},
+					"base": {"ref": "main"}
+				},
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"}
+				}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.Sender, "")
+				assert.Equal(t, event.Organization, "test-org")
+			},
+		},
+		{
+			name: "missing owner in repository",
+			payload: `{
+				"action": "opened",
+				"pull_request": {
+					"number": 1,
+					"title": "Test PR",
+					"head": {"ref": "feature", "sha": "abc123"},
+					"base": {"ref": "main"}
+				},
+				"repository": {"name": "test-repo"},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.Organization, "")
+				assert.Equal(t, event.Repository, "test-repo")
+			},
+		},
+		{
+			name: "missing head in pull request",
+			payload: `{
+				"action": "opened",
+				"pull_request": {
+					"number": 1,
+					"title": "Test PR",
+					"base": {"ref": "main"}
+				},
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"}
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.SHA, "")
+				assert.Equal(t, event.HeadBranch, "")
+				assert.Equal(t, event.BaseBranch, "main")
+			},
+		},
+		{
+			name: "missing base in pull request",
+			payload: `{
+				"action": "opened",
+				"pull_request": {
+					"number": 1,
+					"title": "Test PR",
+					"head": {"ref": "feature", "sha": "abc123"}
+				},
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"}
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.HeadBranch, "feature")
+				assert.Equal(t, event.BaseBranch, "")
+			},
+		},
+		{
+			name: "missing head repo in pull request",
+			payload: `{
+				"action": "opened",
+				"pull_request": {
+					"number": 1,
+					"title": "Test PR",
+					"head": {"ref": "feature", "sha": "abc123"},
+					"base": {"ref": "main"}
+				},
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"}
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.HeadURL, "")
+			},
+		},
+		{
+			name: "push event missing head commit",
+			payload: `{
+				"ref": "refs/heads/main",
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"},
+					"html_url": "https://github.com/test-org/test-repo"
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.SHA, "")
+				assert.Equal(t, event.SHAURL, "")
+				assert.Equal(t, event.Organization, "test-org")
+				assert.Equal(t, event.HeadBranch, "refs/heads/main")
+			},
+		},
+		{
+			name: "issue comment with issue but no pull request links",
+			payload: `{
+				"action": "created",
+				"issue": {
+					"number": 1
+				},
+				"comment": {"body": "/retest"},
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"}
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: true,
+		},
+		{
+			name: "commit comment event missing comment",
+			payload: `{
+				"action": "created",
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"}
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.SHA, "")
+				assert.Equal(t, event.TriggerComment, "")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers := map[string]string{
+				"X-GitHub-Event": "pull_request",
+			}
+			// Determine event type from payload based on test name
+			switch {
+			case strings.Contains(tt.name, "push"):
+				headers["X-GitHub-Event"] = "push"
+			case strings.Contains(tt.name, "issue comment"):
+				headers["X-GitHub-Event"] = "issue_comment"
+			case strings.Contains(tt.name, "commit comment"):
+				headers["X-GitHub-Event"] = "commit_comment"
+			}
+
+			event, err := eventFromGitHub([]byte(tt.payload), headers)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Assert(t, event != nil)
+			if tt.checks != nil {
+				tt.checks(t, event)
+			}
+		})
+	}
+}
+
+func TestGiteaParserWithMissingFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		wantErr bool
+		checks  func(t *testing.T, event *info.Event)
+	}{
+		{
+			name: "pull request with missing repository",
+			payload: `{
+				"action": "opened",
+				"number": 1,
+				"pull_request": {
+					"title": "Test PR",
+					"head": {"ref": "feature", "sha": "abc123"},
+					"base": {"ref": "main"}
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.Organization, "")
+				assert.Equal(t, event.Repository, "")
+				assert.Equal(t, event.Sender, "testuser")
+			},
+		},
+		{
+			name: "pull request with missing sender",
+			payload: `{
+				"action": "opened",
+				"number": 1,
+				"pull_request": {
+					"title": "Test PR",
+					"head": {"ref": "feature", "sha": "abc123"},
+					"base": {"ref": "main"}
+				},
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"}
+				}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.Sender, "")
+				assert.Equal(t, event.Repository, "test-repo")
+			},
+		},
+		{
+			name: "pull request with missing pull request field",
+			payload: `{
+				"action": "opened",
+				"number": 1,
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"}
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.SHA, "")
+				assert.Equal(t, event.HeadBranch, "")
+			},
+		},
+		{
+			name: "pull request with missing owner",
+			payload: `{
+				"action": "opened",
+				"number": 1,
+				"pull_request": {
+					"title": "Test PR",
+					"head": {"ref": "feature", "sha": "abc123"},
+					"base": {"ref": "main"}
+				},
+				"repository": {"name": "test-repo"},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.Organization, "")
+				assert.Equal(t, event.Repository, "test-repo")
+			},
+		},
+		{
+			name: "push with missing repo",
+			payload: `{
+				"ref": "refs/heads/main",
+				"head_commit": {
+					"id": "abc123",
+					"message": "Test commit"
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.Organization, "")
+				assert.Equal(t, event.Repository, "")
+				assert.Equal(t, event.SHA, "abc123")
+			},
+		},
+		{
+			name: "push with missing head commit",
+			payload: `{
+				"ref": "refs/heads/main",
+				"before": "def456",
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"}
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.SHA, "def456")
+				assert.Equal(t, event.SHAURL, "")
+			},
+		},
+		{
+			name: "issue comment with issue but no pull request",
+			payload: `{
+				"action": "created",
+				"issue": {"number": 1},
+				"comment": {"body": "/retest"},
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"}
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: true,
+		},
+		{
+			name: "issue comment with missing comment",
+			payload: `{
+				"action": "created",
+				"issue": {
+					"number": 1,
+					"pull_request": {}
+				},
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"}
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.TriggerComment, "")
+			},
+		},
+		{
+			name: "pull request with missing head repository",
+			payload: `{
+				"action": "opened",
+				"number": 1,
+				"pull_request": {
+					"title": "Test PR",
+					"head": {"ref": "feature", "sha": "abc123"},
+					"base": {
+						"ref": "main",
+						"repo": {"html_url": "https://gitea.com/test-org/test-repo"}
+					},
+					"html_url": "https://gitea.com/test-org/test-repo/pulls/1"
+				},
+				"repository": {
+					"name": "test-repo",
+					"owner": {"login": "test-org"}
+				},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: false,
+			checks: func(t *testing.T, event *info.Event) {
+				assert.Equal(t, event.HeadURL, "")
+				assert.Equal(t, event.BaseURL, "https://gitea.com/test-org/test-repo")
+				assert.Equal(t, event.SHAURL, "https://gitea.com/test-org/test-repo/pulls/1/commit/abc123")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers := map[string]string{
+				"X-Gitea-Event-Type": "pull_request",
+			}
+			// Determine event type based on test name
+			switch {
+			case strings.Contains(tt.name, "push"):
+				headers["X-Gitea-Event-Type"] = "push"
+			case strings.Contains(tt.name, "issue comment"):
+				headers["X-Gitea-Event-Type"] = "issue_comment"
+			}
+
+			event, err := eventFromGitea([]byte(tt.payload), headers)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Assert(t, event != nil)
+			if tt.checks != nil {
+				tt.checks(t, event)
+			}
+		})
+	}
+}


### PR DESCRIPTION


## 📝 Description of the Change
Add comprehensive nil pointer checks in PopulateEvent methods for webhook parsers to prevent panics when accessing nested fields that may be nil or missing from webhook payloads.

## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-9396

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [ x I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [x] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [x] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
