### PR TITLE
fix: report cancelled status when PipelineRun is deleted

### DIFF
--- a/pkg/reconciler/finalizer.go
+++ b/pkg/reconciler/finalizer.go
@@ -2,11 +2,13 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +39,13 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *tektonv1.PipelineRun)
 		if err != nil {
 			return err
 		}
+
+		// report the PipelineRun as cancelled as it was queued or started but it is deleted
+		// but its status is still in progress or queued on git provider
+		if err := r.reportPipelineRunAsCancelled(ctx, repo, pr); err != nil {
+			logger.Errorf("failed to report deleted pipeline run as cancelled: %w", err)
+		}
+
 		r.secretNS = repo.GetNamespace()
 		if r.globalRepo, err = r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && r.globalRepo != nil {
 			if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && r.globalRepo.Spec.GitProvider != nil && r.globalRepo.Spec.GitProvider.Secret != nil {
@@ -60,5 +69,30 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *tektonv1.PipelineRun)
 			return nil
 		}
 	}
+	return nil
+}
+
+func (r *Reconciler) reportPipelineRunAsCancelled(ctx context.Context, repo *v1alpha1.Repository, pr *tektonv1.PipelineRun) error {
+	logger := logging.FromContext(ctx)
+	detectedProvider, event, err := r.initGitProviderClient(ctx, logger, repo, pr)
+	if err != nil {
+		return err
+	}
+
+	consoleURL := r.run.Clients.ConsoleUI().DetailURL(pr)
+	status := provider.StatusOpts{
+		Conclusion:              "cancelled",
+		Text:                    fmt.Sprintf("PipelineRun %s was deleted", pr.GetName()),
+		DetailsURL:              consoleURL,
+		PipelineRunName:         pr.GetName(),
+		PipelineRun:             pr,
+		OriginalPipelineRunName: pr.GetAnnotations()[keys.OriginalPRName],
+	}
+
+	if err := createStatusWithRetry(ctx, logger, detectedProvider, event, status); err != nil {
+		return fmt.Errorf("failed to report cancelled status to provider: %w", err)
+	}
+
+	logger.Infof("updated cancelled status on provider platform for pipelineRun %s", pr.GetName())
 	return nil
 }

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/sync"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
+	testkubernetestint "github.com/openshift-pipelines/pipelines-as-code/pkg/test/kubernetestint"
 	tektontest "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tekton"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.uber.org/zap"
@@ -315,7 +316,7 @@ func TestUpdatePipelineRunState(t *testing.T) {
 
 func TestReconcileKind_SCMReportingLogic(t *testing.T) {
 	observer, _ := zapobserver.New(zap.InfoLevel)
-	_ = zap.New(observer).Sugar()
+	logger := zap.New(observer).Sugar()
 
 	tests := []struct {
 		name                         string
@@ -330,8 +331,12 @@ func TestReconcileKind_SCMReportingLogic(t *testing.T) {
 					Namespace: "test",
 					Name:      "test-pr",
 					Annotations: map[string]string{
-						keys.State:      kubeinteraction.StateQueued,
-						keys.Repository: "test-repo",
+						keys.State:         kubeinteraction.StateQueued,
+						keys.Repository:    "test-repo",
+						keys.GitProvider:   "github",
+						keys.SHA:           "123afc",
+						keys.URLOrg:        "random",
+						keys.URLRepository: "app",
 					},
 				},
 				Spec: tektonv1.PipelineRunSpec{},
@@ -360,6 +365,10 @@ func TestReconcileKind_SCMReportingLogic(t *testing.T) {
 						keys.State:                  kubeinteraction.StateStarted,
 						keys.Repository:             "test-repo",
 						keys.SCMReportingPLRStarted: "true",
+						keys.GitProvider:            "github",
+						keys.SHA:                    "123afc",
+						keys.URLOrg:                 "random",
+						keys.URLRepository:          "app",
 					},
 				},
 				Spec: tektonv1.PipelineRunSpec{},
@@ -385,8 +394,12 @@ func TestReconcileKind_SCMReportingLogic(t *testing.T) {
 					Namespace: "test",
 					Name:      "test-pr",
 					Annotations: map[string]string{
-						keys.State:      kubeinteraction.StateQueued,
-						keys.Repository: "test-repo",
+						keys.State:         kubeinteraction.StateQueued,
+						keys.Repository:    "test-repo",
+						keys.GitProvider:   "github",
+						keys.SHA:           "123afc",
+						keys.URLOrg:        "random",
+						keys.URLRepository: "app",
 					},
 				},
 				Spec: tektonv1.PipelineRunSpec{
@@ -420,6 +433,11 @@ func TestReconcileKind_SCMReportingLogic(t *testing.T) {
 				},
 				Spec: v1alpha1.RepositorySpec{
 					URL: randomURL,
+					GitProvider: &v1alpha1.GitProvider{
+						Secret: &v1alpha1.Secret{
+							Name: "pac-git-basic-auth-owner-repo",
+						},
+					},
 				},
 			}
 
@@ -432,18 +450,29 @@ func TestReconcileKind_SCMReportingLogic(t *testing.T) {
 			// Track if updatePipelineRunToInProgress was called by checking state changes
 			originalState := tt.pipelineRun.GetAnnotations()[keys.State]
 
-			r := &Reconciler{
-				repoLister: informers.Repository.Lister(),
-				run: &params.Run{
-					Clients: clients.Clients{
-						Tekton: stdata.Pipeline,
-					},
-					Info: info.Info{
-						Pac: &info.PacOpts{
-							Settings: settings.Settings{},
-						},
+			kinterfaceTest := &testkubernetestint.KinterfaceTest{
+				GetSecretResult: map[string]string{
+					"pac-git-basic-auth-owner-repo": "https://whateveryousayboss",
+				},
+			}
+
+			cs := &params.Run{
+				Clients: clients.Clients{
+					Tekton: stdata.Pipeline,
+					Log:    logger,
+				},
+				Info: info.Info{
+					Pac: &info.PacOpts{
+						Settings: settings.Settings{},
 					},
 				},
+			}
+			cs.Clients.SetConsoleUI(consoleui.FallBackConsole{})
+
+			r := &Reconciler{
+				repoLister: informers.Repository.Lister(),
+				run:        cs,
+				kinteract:  kinterfaceTest,
 			}
 
 			err := r.ReconcileKind(ctx, tt.pipelineRun)


### PR DESCRIPTION
When a PipelineRun is deleted while it is in 'Running' or 'Queued' state (i.e., not yet completed), the status on the Git provider (e.g., GitHub) remained stuck in 'Pending' or 'Running'.

This commit adds logic to the Finalizer to detect when a PipelineRun is being deleted (finalized) while in an active state. It now:
1. Reports a "cancelled" status to the Git provider, ensuring the commit status is correctly updated to "cancelled" instead of hanging.
2. Added unit test case to confirm that status is reported cancelled.

This improves the user experience by accurately reflecting the PipelineRun lifecycle events on the Git provider UI.

https://issues.redhat.com/browse/SRVKP-8318

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
