### PR TITLE
fix(matcher): prevent CEL from matching label events unintentionally

### DIFF
--- a/pkg/matcher/cel.go
+++ b/pkg/matcher/cel.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/gobwas/glob"
@@ -21,32 +20,10 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	reChangedFilesTags = `files\.`
-)
-
 func celEvaluate(ctx context.Context, expr string, event *info.Event, vcx provider.Interface, customParams map[string]string, eventEmitter *events.EventEmitter, repo *apipac.Repository) (ref.Val, error) {
 	eventTitle := event.PullRequestTitle
 	if event.TriggerTarget == triggertype.Push {
 		eventTitle = event.SHATitle
-		// For push event the target_branch & source_branch info coming from payload have refs/heads/
-		// but user may or mayn't provide refs/heads/ info while giving target_branch or source_branch in CEL expression
-		// ex:  pipelinesascode.tekton.dev/on-cel-expression: |
-		//        event == "push" && target_branch == "main" && "frontend/***".pathChanged()
-		// This logic will handle such case.
-		splittedValue := strings.Split(expr, "&&")
-		for i := range splittedValue {
-			if strings.Contains(splittedValue[i], "target_branch") {
-				if !strings.Contains(splittedValue[i], "refs/heads/") {
-					event.BaseBranch = strings.TrimPrefix(event.BaseBranch, "refs/heads/")
-				}
-			}
-			if strings.Contains(splittedValue[i], "source_branch") {
-				if !strings.Contains(splittedValue[i], "refs/heads/") {
-					event.HeadBranch = strings.TrimPrefix(event.HeadBranch, "refs/heads/")
-				}
-			}
-		}
 	}
 
 	nbody, err := json.Marshal(event.Event)
@@ -63,13 +40,94 @@ func celEvaluate(ctx context.Context, expr string, event *info.Event, vcx provid
 		headerMap[strings.ToLower(k)] = v[0]
 	}
 
-	r := regexp.MustCompile(reChangedFilesTags)
-	changedFiles := changedfiles.ChangedFiles{}
+	standardParams := map[string]bool{
+		"event": true, "event_type": true, "headers": true, "body": true,
+		"event_title": true, "target_branch": true, "source_branch": true,
+		"target_url": true, "source_url": true, "files": true,
+	}
 
-	if r.MatchString(expr) {
+	varDecls := []cel.EnvOption{
+		cel.Lib(celPac{vcx, ctx, event}),
+		cel.VariableDecls(
+			decls.NewVariable("event", types.StringType),
+			decls.NewVariable("event_type", types.StringType),
+			decls.NewVariable("headers", types.NewMapType(types.StringType, types.DynType)),
+			decls.NewVariable("body", types.NewMapType(types.StringType, types.DynType)),
+			decls.NewVariable("event_title", types.StringType),
+			decls.NewVariable("target_branch", types.StringType),
+			decls.NewVariable("source_branch", types.StringType),
+			decls.NewVariable("target_url", types.StringType),
+			decls.NewVariable("source_url", types.StringType),
+			decls.NewVariable("files", types.NewMapType(types.StringType, types.DynType)),
+		),
+	}
+
+	for k := range customParams {
+		if !standardParams[k] {
+			varDecls = append(varDecls, cel.VariableDecls(decls.NewVariable(k, types.StringType)))
+		}
+	}
+
+	env, err := cel.NewEnv(varDecls...)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed, issues := env.Parse(expr)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("failed to parse expression %#v: %w", expr, issues.Err())
+	}
+
+	checked, issues := env.Check(parsed)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("expression %#v check failed: %w", expr, issues.Err())
+	}
+
+	// Convert AST for inspection
+	checkedExpr, err := cel.AstToCheckedExpr(checked)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert AST: %w", err)
+	}
+	astRoot := checkedExpr.GetExpr()
+
+	// For push events, handle refs/heads/ prefix stripping for target_branch and source_branch.
+	// We use AST inspection to detect if these variables are referenced, rather than string parsing.
+	if event.TriggerTarget == triggertype.Push {
+		// Check if expression uses target_branch and doesn't contain refs/heads/ literal
+		if walkExprAST(astRoot, matchIdentifier("target_branch")) {
+			if !containsRefsHeadsLiteral(astRoot) {
+				event.BaseBranch = strings.TrimPrefix(event.BaseBranch, "refs/heads/")
+			}
+		}
+		// Check if expression uses source_branch and doesn't contain refs/heads/ literal
+		if walkExprAST(astRoot, matchIdentifier("source_branch")) {
+			if !containsRefsHeadsLiteral(astRoot) {
+				event.HeadBranch = strings.TrimPrefix(event.HeadBranch, "refs/heads/")
+			}
+		}
+	}
+
+	// Fetch changed files only if the expression references the "files" variable.
+	// This avoids unnecessary API calls when files aren't used in the expression.
+	changedFiles := changedfiles.ChangedFiles{}
+	if walkExprAST(astRoot, matchIdentifier("files")) {
 		changedFiles, err = vcx.GetFiles(ctx, event)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	// For label events, check if the expression references labels or event_type.
+	// If not, return False to skip matching - this prevents generic "event == pull_request"
+	// expressions from unintentionally matching on label add/remove events.
+	if event.TriggerTarget == triggertype.PullRequest && event.EventType == string(triggertype.PullRequestLabeled) {
+		labelMatcher := combinedMatcher(
+			matchIdentifier("event_type"),
+			matchFieldAccess("labels", "pull_request_labels"),
+			matchBracketAccess("labels", "pull_request_labels"),
+		)
+		if !walkExprAST(astRoot, labelMatcher) {
+			return types.False, nil
 		}
 	}
 
@@ -92,46 +150,13 @@ func celEvaluate(ctx context.Context, expr string, event *info.Event, vcx provid
 		},
 	}
 
-	varDecls := []cel.EnvOption{
-		cel.Lib(celPac{vcx, ctx, event}),
-		cel.VariableDecls(
-			decls.NewVariable("event", types.StringType),
-			decls.NewVariable("event_type", types.StringType),
-			decls.NewVariable("headers", types.NewMapType(types.StringType, types.DynType)),
-			decls.NewVariable("body", types.NewMapType(types.StringType, types.DynType)),
-			decls.NewVariable("event_title", types.StringType),
-			decls.NewVariable("target_branch", types.StringType),
-			decls.NewVariable("source_branch", types.StringType),
-			decls.NewVariable("target_url", types.StringType),
-			decls.NewVariable("source_url", types.StringType),
-			decls.NewVariable("files", types.NewMapType(types.StringType, types.DynType)),
-		),
-	}
-	// Add declarations for custom params (all as strings)
 	for k, v := range customParams {
-		// Don't overwrite standard params
-		if _, ok := data[k]; !ok {
+		if !standardParams[k] {
 			data[k] = v
-			varDecls = append(varDecls, cel.VariableDecls(decls.NewVariable(k, types.StringType)))
 		} else if eventEmitter != nil && repo != nil {
 			eventEmitter.EmitMessage(repo, zap.WarnLevel, "CELParamConflict",
 				fmt.Sprintf("custom parameter '%s' conflicts with standard CEL variable and was ignored", k))
 		}
-	}
-
-	env, err := cel.NewEnv(varDecls...)
-	if err != nil {
-		return nil, err
-	}
-
-	parsed, issues := env.Parse(expr)
-	if issues != nil && issues.Err() != nil {
-		return nil, fmt.Errorf("failed to parse expression %#v: %w", expr, issues.Err())
-	}
-
-	checked, issues := env.Check(parsed)
-	if issues != nil && issues.Err() != nil {
-		return nil, fmt.Errorf("expression %#v check failed: %w", expr, issues.Err())
 	}
 
 	prg, err := env.Program(checked)

--- a/pkg/matcher/cel_ast.go
+++ b/pkg/matcher/cel_ast.go
@@ -1,0 +1,169 @@
+package matcher
+
+import (
+	"strings"
+
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+)
+
+// NodeMatcher is a predicate function that inspects a CEL AST node.
+// It returns true if the node matches the criteria being searched for.
+type NodeMatcher func(expr *exprpb.Expr) bool
+
+// walkExprAST recursively walks a CEL expression AST and returns true
+// if any node matches the provided matcher function.
+//
+// CEL AST Node Types:
+//   - ConstExpr: Literal constant values (strings, numbers, bools, null, bytes)
+//   - IdentExpr: Variable references (e.g., "event_type", "body")
+//   - SelectExpr: Field access with dot notation (e.g., body.labels)
+//   - CallExpr: Function calls and operators (e.g., size(), _[_] for bracket notation)
+//   - ListExpr: List literals (e.g., [1, 2, 3])
+//   - StructExpr: Map/struct literals (e.g., {"key": "value"})
+//   - ComprehensionExpr: List operations (e.g., list.exists(x, condition))
+func walkExprAST(expr *exprpb.Expr, matcher NodeMatcher) bool {
+	if expr == nil {
+		return false
+	}
+
+	// Check current node first
+	if matcher(expr) {
+		return true
+	}
+
+	// Recurse into children based on node type
+	switch e := expr.GetExprKind().(type) {
+	case *exprpb.Expr_ConstExpr:
+		// Constants have no children
+		return false
+
+	case *exprpb.Expr_IdentExpr:
+		// Identifiers have no children
+		return false
+
+	case *exprpb.Expr_SelectExpr:
+		return walkExprAST(e.SelectExpr.GetOperand(), matcher)
+
+	case *exprpb.Expr_CallExpr:
+		if walkExprAST(e.CallExpr.GetTarget(), matcher) {
+			return true
+		}
+		for _, arg := range e.CallExpr.GetArgs() {
+			if walkExprAST(arg, matcher) {
+				return true
+			}
+		}
+
+	case *exprpb.Expr_ListExpr:
+		for _, elem := range e.ListExpr.GetElements() {
+			if walkExprAST(elem, matcher) {
+				return true
+			}
+		}
+
+	case *exprpb.Expr_StructExpr:
+		for _, entry := range e.StructExpr.GetEntries() {
+			if walkExprAST(entry.GetMapKey(), matcher) {
+				return true
+			}
+			if walkExprAST(entry.GetValue(), matcher) {
+				return true
+			}
+		}
+
+	case *exprpb.Expr_ComprehensionExpr:
+		comp := e.ComprehensionExpr
+		if walkExprAST(comp.GetIterRange(), matcher) {
+			return true
+		}
+		if walkExprAST(comp.GetAccuInit(), matcher) {
+			return true
+		}
+		if walkExprAST(comp.GetLoopCondition(), matcher) {
+			return true
+		}
+		if walkExprAST(comp.GetLoopStep(), matcher) {
+			return true
+		}
+		if walkExprAST(comp.GetResult(), matcher) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchIdentifier returns a NodeMatcher that matches IdentExpr nodes
+// with the specified variable name.
+func matchIdentifier(name string) NodeMatcher {
+	return func(expr *exprpb.Expr) bool {
+		if ident := expr.GetIdentExpr(); ident != nil {
+			return ident.GetName() == name
+		}
+		return false
+	}
+}
+
+// matchFieldAccess returns a NodeMatcher that matches SelectExpr nodes
+// (dot notation field access) with any of the specified field names.
+// Example: body.labels matches field "labels".
+func matchFieldAccess(fieldNames ...string) NodeMatcher {
+	fieldSet := make(map[string]bool, len(fieldNames))
+	for _, f := range fieldNames {
+		fieldSet[f] = true
+	}
+	return func(expr *exprpb.Expr) bool {
+		if sel := expr.GetSelectExpr(); sel != nil {
+			return fieldSet[sel.GetField()]
+		}
+		return false
+	}
+}
+
+// matchBracketAccess returns a NodeMatcher that matches bracket notation
+// field access (body["labels"]) with any of the specified key names.
+// In CEL AST, bracket notation is represented as CallExpr with function "_[_]".
+func matchBracketAccess(keyNames ...string) NodeMatcher {
+	keySet := make(map[string]bool, len(keyNames))
+	for _, k := range keyNames {
+		keySet[k] = true
+	}
+	return func(expr *exprpb.Expr) bool {
+		call := expr.GetCallExpr()
+		if call == nil || call.GetFunction() != "_[_]" || len(call.GetArgs()) != 2 {
+			return false
+		}
+		// Check if the key (second argument) is a string literal matching our keys
+		if keyExpr := call.GetArgs()[1]; keyExpr != nil {
+			if constExpr := keyExpr.GetConstExpr(); constExpr != nil {
+				return keySet[constExpr.GetStringValue()]
+			}
+		}
+		return false
+	}
+}
+
+// combinedMatcher returns a NodeMatcher that returns true if any of
+// the provided matchers match.
+func combinedMatcher(matchers ...NodeMatcher) NodeMatcher {
+	return func(expr *exprpb.Expr) bool {
+		for _, m := range matchers {
+			if m(expr) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// containsRefsHeadsLiteral checks if the AST contains a string literal "refs/heads/".
+// This is used to determine if the user explicitly included the refs/heads/ prefix
+// in their CEL expression when comparing branches.
+func containsRefsHeadsLiteral(expr *exprpb.Expr) bool {
+	return walkExprAST(expr, func(e *exprpb.Expr) bool {
+		if constExpr := e.GetConstExpr(); constExpr != nil {
+			return strings.Contains(constExpr.GetStringValue(), "refs/heads/")
+		}
+		return false
+	})
+}

--- a/pkg/matcher/cel_test.go
+++ b/pkg/matcher/cel_test.go
@@ -1,0 +1,197 @@
+package matcher
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/decls"
+	"github.com/google/cel-go/common/types"
+	"gotest.tools/v3/assert"
+)
+
+// parseAndCheckForLabelReferences is a test helper that parses a CEL expression
+// and checks if it references labels or event_type using the AST walker.
+func parseAndCheckForLabelReferences(expr string) bool {
+	env, err := cel.NewEnv(
+		cel.VariableDecls(
+			decls.NewVariable("event", types.StringType),
+			decls.NewVariable("event_type", types.StringType),
+			decls.NewVariable("headers", types.NewMapType(types.StringType, types.DynType)),
+			decls.NewVariable("body", types.NewMapType(types.StringType, types.DynType)),
+			decls.NewVariable("event_title", types.StringType),
+			decls.NewVariable("target_branch", types.StringType),
+			decls.NewVariable("source_branch", types.StringType),
+			decls.NewVariable("target_url", types.StringType),
+			decls.NewVariable("source_url", types.StringType),
+			decls.NewVariable("files", types.NewMapType(types.StringType, types.DynType)),
+		),
+	)
+	if err != nil {
+		return false
+	}
+
+	parsed, issues := env.Parse(expr)
+	if issues != nil && issues.Err() != nil {
+		return false
+	}
+
+	checked, issues := env.Check(parsed)
+	if issues != nil && issues.Err() != nil {
+		return false
+	}
+
+	checkedExpr, err := cel.AstToCheckedExpr(checked)
+	if err != nil {
+		return false
+	}
+
+	// Use the generic walker with combined matchers for label references
+	labelMatcher := combinedMatcher(
+		matchIdentifier("event_type"),
+		matchFieldAccess("labels", "pull_request_labels"),
+		matchBracketAccess("labels", "pull_request_labels"),
+	)
+	return walkExprAST(checkedExpr.GetExpr(), labelMatcher)
+}
+
+func TestWalkExprForLabelReferences(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		expected bool
+	}{
+		{
+			name:     "references event_type directly",
+			expr:     `event_type == "pull_request_labeled"`,
+			expected: true,
+		},
+		{
+			name:     "references event_type in complex expression",
+			expr:     `event == "pull_request" && event_type == "pull_request_labeled"`,
+			expected: true,
+		},
+		{
+			name:     "references body.pull_request.labels (GitHub/Gitea style)",
+			expr:     `body.pull_request.labels.exists(x, x.name == "bug")`,
+			expected: true,
+		},
+		{
+			name:     "references body.labels (GitLab style)",
+			expr:     `body.labels.exists(x, x.title == "bug")`,
+			expected: true,
+		},
+		{
+			name:     "references labels with size check",
+			expr:     `body.pull_request.labels.size() > 0`,
+			expected: true,
+		},
+		{
+			name:     "simple pull_request event check - no labels",
+			expr:     `event == "pull_request"`,
+			expected: false,
+		},
+		{
+			name:     "pull_request with branch check - no labels",
+			expr:     `event == "pull_request" && target_branch == "main"`,
+			expected: false,
+		},
+		{
+			name:     "title contains label word - should NOT match (string literal)",
+			expr:     `event == "pull_request" && event_title == "fix-label-issue"`,
+			expected: false,
+		},
+		{
+			name:     "body.pull_request.title with label in value - should NOT match",
+			expr:     `body.pull_request.title == "Add labels support"`,
+			expected: false,
+		},
+		{
+			name:     "PR title equals 'labels' literally - should NOT match (string literal)",
+			expr:     `event_title == "labels"`,
+			expected: false,
+		},
+		{
+			name:     "PR title contains 'labels' - should NOT match (string method on literal)",
+			expr:     `event_title.contains("labels")`,
+			expected: false,
+		},
+		{
+			name:     "head.label (branch label) - should NOT match",
+			expr:     `body.pull_request.head.label == "feature-branch"`,
+			expected: false,
+		},
+		{
+			name:     "push event - no labels",
+			expr:     `event == "push" && target_branch == "main"`,
+			expected: false,
+		},
+		{
+			name:     "path changed - no labels",
+			expr:     `event == "pull_request" && files.all.exists(x, x.matches("docs/"))`,
+			expected: false,
+		},
+		{
+			name:     "labels in comprehension filter",
+			expr:     `body.pull_request.labels.filter(x, x.name.startsWith("kind/")).size() > 0`,
+			expected: true,
+		},
+		// Bracket notation tests - CEL index operator _[_]
+		{
+			name:     "bracket notation - body[\"labels\"] (GitLab style)",
+			expr:     `body["labels"].size() > 0`,
+			expected: true,
+		},
+		{
+			name:     "bracket notation - body[\"pull_request\"][\"labels\"]",
+			expr:     `body["pull_request"]["labels"].size() > 0`,
+			expected: true,
+		},
+		{
+			name:     "mixed notation - body.pull_request[\"labels\"]",
+			expr:     `body.pull_request["labels"].size() > 0`,
+			expected: true,
+		},
+		{
+			name:     "deeply nested bracket notation",
+			expr:     `body["object"]["pull_request"]["labels"].size() > 0`,
+			expected: true,
+		},
+		{
+			name:     "ternary with labels in condition",
+			expr:     `body.labels.size() > 0 ? true : false`,
+			expected: true,
+		},
+		{
+			name:     "ternary with labels in true branch",
+			expr:     `event == "pull_request" ? body.labels.size() : 0`,
+			expected: true,
+		},
+		{
+			name:     "ternary with labels in false branch",
+			expr:     `event == "push" ? 0 : body.labels.size()`,
+			expected: true,
+		},
+		{
+			name:     "ternary without labels - should NOT match",
+			expr:     `event == "pull_request" ? "pr" : "other"`,
+			expected: false,
+		},
+		{
+			name:     "invalid CEL expression - returns false",
+			expr:     `this is not valid CEL`,
+			expected: false,
+		},
+		{
+			name:     "empty expression - returns false",
+			expr:     ``,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseAndCheckForLabelReferences(tt.expr)
+			assert.Equal(t, tt.expected, result, "expression: %s", tt.expr)
+		})
+	}
+}

--- a/test/testdata/pipelinerun-cel-label-event.yaml
+++ b/test/testdata/pipelinerun-cel-label-event.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "\\ .TargetEvent //" && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "bug")
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: success
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                echo "PR Labels triggered the pipeline!"


### PR DESCRIPTION
## 📝 Description of the Change
Add AST inspection in CEL evaluation to skip label events unless the
expression explicitly references labels or event_type.

Replace string/regexp-based CEL parsing with proper AST inspection.
Add generic walkExprAST function with composable NodeMatcher predicates
for detecting variable usage, field access, and bracket notation. Split
CEL code into cel.go and cel_ast.go for better separation of concerns.

This prevents generic "event == pull_request" CEL expressions unintentionally
matching on label add/remove events.

## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-8491

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [x] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [x] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
