### PR TITLE
feat: add update comment strategy

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -450,12 +450,14 @@ spec:
                       properties:
                         comment_strategy:
                           description: |-
-                            CommentStrategy defines how GitLab comments are handled for pipeline results.
+                            CommentStrategy defines how GitHub comments are handled for pipeline results.
                             Options:
-                            - 'disable_all': Disables all comments on merge requests
+                            - 'disable_all': Disables all comments on pull requests
+                            - 'update': Updates a single comment per PipelineRun instead of creating new ones
                           enum:
                             - ""
                             - disable_all
+                            - update
                           type: string
                       type: object
                     github_app_token_scope_repos:

--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -474,9 +474,11 @@ spec:
                             CommentStrategy defines how GitLab comments are handled for pipeline results.
                             Options:
                             - 'disable_all': Disables all comments on merge requests
+                            - 'update': Updates a single comment per PipelineRun instead of creating new ones
                           enum:
                             - ""
                             - disable_all
+                            - update
                           type: string
                       type: object
                     pipelinerun_provenance:

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -135,16 +135,20 @@ help reduce notification volume for repositories that use long-lasting
 Pull/Merge requests with many PipelineRuns.
 
 Acceptable values for `spec.<provider>.comment_strategy` are `""`
-(default) and `"disable_all"`.
+(default), `"update"` and `"disable_all"`.
+
+Setting `comment_strategy` to `update` adds a single comment for
+each PipelineRun. When the status is updated or the PipelineRun is re-executed,
+this comment is updated with the new status and the associated commit SHA.
 
 When you set the value of `comment_strategy` to `disable_all`, Pipelines
 as Code will not add any comment on the Pull/Merge Request related to
 PipelineRun status.
 
-Note: The `disable_all` strategy applies only to comments about a
-PipelineRun's status (e.g., "started," "succeeded"). Comments may still
-appear if there are errors validating PipelineRuns in the `.tekton`
-directory. (See [Running the PipelineRun docs](../running/#errors-when-parsing-pipelinerun-yaml) for details)
+Note: The `update` and `disable_all` strategy applies only to
+comments about a PipelineRun's status (e.g., "started," "succeeded").
+Comments may still appear if there are errors validating PipelineRuns in
+the `.tekton` directory. (See [Running the PipelineRun docs](../running/#errors-when-parsing-pipelinerun-yaml) for details)
 
 ### GitLab
 

--- a/pkg/apis/pipelinesascode/keys/keys.go
+++ b/pkg/apis/pipelinesascode/keys/keys.go
@@ -61,6 +61,9 @@ const (
 	LogURL                 = pipelinesascode.GroupName + "/log-url"
 	ExecutionOrder         = pipelinesascode.GroupName + "/execution-order"
 	SCMReportingPLRStarted = pipelinesascode.GroupName + "/scm-reporting-plr-started"
+	// StatusCommentID stores the GitHub/GitLab comment ID for status updates.
+	// The actual annotation key will be: StatusCommentID + "-" + OriginalPipelineRunName.
+	StatusCommentID = pipelinesascode.GroupName + "/status-comment-id"
 	// PublicGithubAPIURL default is "https://api.github.com" but it can be overridden by X-GitHub-Enterprise-Host header.
 	PublicGithubAPIURL   = "https://api.github.com"
 	GithubApplicationID  = "github-application-id"

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -177,11 +177,12 @@ type GitlabSettings struct {
 }
 
 type GithubSettings struct {
-	// CommentStrategy defines how GitLab comments are handled for pipeline results.
+	// CommentStrategy defines how GitHub comments are handled for pipeline results.
 	// Options:
-	// - 'disable_all': Disables all comments on merge requests
+	// - 'disable_all': Disables all comments on pull requests
+	// - 'update': Updates a single comment per PipelineRun instead of creating new ones
 	// +optional
-	// +kubebuilder:validation:Enum="";disable_all
+	// +kubebuilder:validation:Enum="";disable_all;update
 	CommentStrategy string `json:"comment_strategy,omitempty"`
 }
 

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -170,8 +170,9 @@ type GitlabSettings struct {
 	// CommentStrategy defines how GitLab comments are handled for pipeline results.
 	// Options:
 	// - 'disable_all': Disables all comments on merge requests
+	// - 'update': Updates a single comment per PipelineRun instead of creating new ones
 	// +optional
-	// +kubebuilder:validation:Enum="";disable_all
+	// +kubebuilder:validation:Enum="";disable_all;update
 	CommentStrategy string `json:"comment_strategy,omitempty"`
 }
 

--- a/pkg/provider/comment/cache.go
+++ b/pkg/provider/comment/cache.go
@@ -1,0 +1,102 @@
+// Package comment provides shared utilities for comment management across providers.
+package comment
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/action"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	psort "github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CacheCommentID stores the comment ID in the PipelineRun annotation for future updates.
+// This enables fast comment updates without listing all PR comments.
+func CacheCommentID(ctx context.Context, logger *zap.SugaredLogger, tektonClient versioned.Interface, pr *tektonv1.PipelineRun, pipelineName string, commentID int64) error {
+	if tektonClient == nil {
+		return fmt.Errorf("kubernetes client not available")
+	}
+
+	commentIDKey := fmt.Sprintf("%s-%s", keys.StatusCommentID, pipelineName)
+	annotations := map[string]string{
+		commentIDKey: strconv.FormatInt(commentID, 10),
+	}
+
+	if _, err := action.PatchPipelineRun(ctx, logger, "cache comment ID", tektonClient, pr, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": annotations,
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to patch pipelinerun: %w", err)
+	}
+
+	logger.Debugf("Cached comment ID %d for pipeline %s", commentID, pipelineName)
+	return nil
+}
+
+// GetCachedCommentID retrieves the cached comment ID from PipelineRun annotations.
+// It first checks the current PipelineRun, then searches sibling PipelineRuns
+// with the same OriginalPRName label AND same Pull Request number, sorted by completion time (newest first).
+// Returns 0 if no cached ID exists.
+func GetCachedCommentID(ctx context.Context, logger *zap.SugaredLogger, tektonClient versioned.Interface, pr *tektonv1.PipelineRun, namespace, pipelineName string, pullRequestNumber int) int64 {
+	commentIDKey := fmt.Sprintf("%s-%s", keys.StatusCommentID, pipelineName)
+
+	// Check the current PipelineRun's annotation
+	if pr != nil {
+		if commentIDStr, ok := pr.GetAnnotations()[commentIDKey]; ok {
+			if commentID, err := strconv.ParseInt(commentIDStr, 10, 64); err == nil {
+				logger.Debugf("Found comment ID %d in current PipelineRun %s", commentID, pr.GetName())
+				return commentID
+			}
+		}
+	}
+
+	if tektonClient == nil {
+		return 0
+	}
+
+	if namespace == "" && pr != nil {
+		namespace = pr.GetNamespace()
+	}
+	if namespace == "" {
+		return 0
+	}
+
+	// Filter by both pipeline name AND pull request number to avoid cross-PR cache hits
+	labelSelector := fmt.Sprintf(
+		"%s=%s,%s=%d",
+		keys.OriginalPRName, formatting.CleanValueKubernetes(pipelineName),
+		keys.PullRequest, pullRequestNumber,
+	)
+
+	pruns, err := tektonClient.TektonV1().PipelineRuns(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		logger.Warnf("Failed to list PipelineRuns for comment ID lookup: %v", err)
+		return 0
+	}
+
+	// Get the most recent cached comment ID
+	psort.PipelineRunSortByCompletionTime(pruns.Items)
+
+	for i := range pruns.Items {
+		prun := &pruns.Items[i]
+		// Skip the current PipelineRun, already checked
+		if pr != nil && prun.GetName() == pr.GetName() {
+			continue
+		}
+		if commentIDStr, ok := prun.GetAnnotations()[commentIDKey]; ok {
+			if commentID, err := strconv.ParseInt(commentIDStr, 10, 64); err == nil {
+				logger.Debugf("Found comment ID %d in PipelineRun %s", commentID, prun.GetName())
+				return commentID
+			}
+		}
+	}
+
+	return 0
+}

--- a/pkg/provider/comment/cache_test.go
+++ b/pkg/provider/comment/cache_test.go
@@ -1,0 +1,156 @@
+package comment
+
+import (
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestGetCachedCommentID(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	testLogger, _ := logger.GetLogger()
+
+	tests := []struct {
+		name         string
+		pr           *tektonv1.PipelineRun
+		pipelineName string
+		want         int64
+	}{
+		{
+			name: "cached comment ID exists in current PipelineRun",
+			pr: &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-run",
+					Namespace: "default",
+					Annotations: map[string]string{
+						keys.StatusCommentID + "-my-pipeline": "12345",
+					},
+				},
+			},
+			pipelineName: "my-pipeline",
+			want:         12345,
+		},
+		{
+			name: "no annotation exists",
+			pr: &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-run",
+					Namespace:   "default",
+					Annotations: map[string]string{},
+				},
+			},
+			pipelineName: "my-pipeline",
+			want:         0,
+		},
+		{
+			name:         "nil PipelineRun",
+			pr:           nil,
+			pipelineName: "my-pipeline",
+			want:         0,
+		},
+		{
+			name: "invalid comment ID format",
+			pr: &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-run",
+					Namespace: "default",
+					Annotations: map[string]string{
+						keys.StatusCommentID + "-my-pipeline": "not-a-number",
+					},
+				},
+			},
+			pipelineName: "my-pipeline",
+			want:         0,
+		},
+		{
+			name: "different pipeline name",
+			pr: &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-run",
+					Namespace: "default",
+					Annotations: map[string]string{
+						keys.StatusCommentID + "-other-pipeline": "99999",
+					},
+				},
+			},
+			pipelineName: "my-pipeline",
+			want:         0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := ""
+			if tt.pr != nil {
+				namespace = tt.pr.GetNamespace()
+			}
+			got := GetCachedCommentID(ctx, testLogger, nil, tt.pr, namespace, tt.pipelineName, 1)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestCacheCommentID(t *testing.T) {
+	testLogger, _ := logger.GetLogger()
+
+	tests := []struct {
+		name         string
+		prName       string
+		pipelineName string
+		commentID    int64
+		wantErr      bool
+	}{
+		{
+			name:         "cache comment ID successfully",
+			prName:       "test-run-1",
+			pipelineName: "my-pipeline",
+			commentID:    54321,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        tt.prName,
+					Namespace:   "default",
+					Annotations: map[string]string{},
+				},
+			}
+
+			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				PipelineRuns: []*tektonv1.PipelineRun{pr},
+			})
+
+			err := CacheCommentID(ctx, testLogger, stdata.Pipeline, pr, tt.pipelineName, tt.commentID)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+		})
+	}
+}
+
+func TestCacheCommentIDWithNilClient(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	testLogger, _ := logger.GetLogger()
+
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-run",
+			Namespace: "default",
+		},
+	}
+
+	err := CacheCommentID(ctx, testLogger, nil, pr, "my-pipeline", 12345)
+	assert.Assert(t, err != nil, "Should return error when tektonClient is nil")
+}

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -1496,18 +1496,19 @@ func TestCreateComment(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
+			log, _ := logger.GetLogger()
 
 			var provider *Provider
 			if !tt.clientNil {
 				fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 				defer teardown()
-				provider = &Provider{ghClient: fakeclient}
+				provider = &Provider{ghClient: fakeclient, Logger: log}
 
 				for pattern, handler := range tt.mockResponses {
 					mux.HandleFunc(pattern, handler)
 				}
 			} else {
-				provider = &Provider{} // nil client
+				provider = &Provider{Logger: log} // nil client
 			}
 
 			err := provider.CreateComment(ctx, tt.event, "comment body", tt.updateMarker)

--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -17,7 +17,7 @@ import (
 
 var universalDeserializer = serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer()
 
-var allowedGitlabDisableCommentStrategyOnMr = sets.NewString("", "disable_all")
+var allowedGitlabDisableCommentStrategyOnMr = sets.NewString("", "disable_all", "update")
 
 // Path implements AdmissionController.
 func (ac *reconciler) Path() string {

--- a/test/gitea_custom_params_cel_test.go
+++ b/test/gitea_custom_params_cel_test.go
@@ -130,7 +130,7 @@ func TestGiteaCustomParamsFromSecretsInCEL(t *testing.T) {
 	// Verify secrets are not leaked in controller logs
 	maxLines := int64(1000)
 	secretLeakRegex := regexp.MustCompile(`super-secret-api-key-12345|deploy-token-xyz-789`)
-	err = twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *secretLeakRegex, 2, "controller", &maxLines)
+	err = twait.RegexpMatchingInPACLog(ctx, topts.ParamsRun, *secretLeakRegex, 2, "controller", &maxLines)
 	if err == nil {
 		t.Fatal("Secret values were found in controller logs - this is a security issue!")
 	}

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -162,7 +162,7 @@ func TestGiteaPullRequestPrivateRepository(t *testing.T) {
 	defer f()
 	reg := regexp.MustCompile(".*successfully fetched git-clone task from default configured catalog Hub")
 	maxLines := int64(100)
-	err := twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *reg, 20, "controller", &maxLines)
+	err := twait.RegexpMatchingInPACLog(ctx, topts.ParamsRun, *reg, 20, "controller", &maxLines)
 	assert.NilError(t, err)
 	tgitea.WaitForSecretDeletion(t, topts, topts.TargetRefName)
 }
@@ -253,7 +253,7 @@ func TestGiteaBadYamlValidation(t *testing.T) {
 	ctx, f := tgitea.TestPR(t, topts)
 	defer f()
 	maxLines := int64(20)
-	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *regexp.MustCompile(
+	assert.NilError(t, twait.RegexpMatchingInPACLog(ctx, topts.ParamsRun, *regexp.MustCompile(
 		"cannot read the PipelineRun: pr-bad-format.yaml, error: yaml validation error: line 3: could not find expected ':'"),
 		10, "controller", &maxLines))
 }
@@ -999,7 +999,7 @@ func TestGiteaBadLinkOfTask(t *testing.T) {
 	defer f()
 	errre := regexp.MustCompile("There was an error starting the PipelineRun")
 	maxLines := int64(20)
-	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *errre, 10, "controller", &maxLines))
+	assert.NilError(t, twait.RegexpMatchingInPACLog(ctx, topts.ParamsRun, *errre, 10, "controller", &maxLines))
 }
 
 // TestGiteaPipelineRunWithSameName checks that we fail properly with the error from the
@@ -1020,7 +1020,7 @@ func TestGiteaPipelineRunWithSameName(t *testing.T) {
 	defer f()
 	errre := regexp.MustCompile("found multiple pipelinerun in .tekton with the same name")
 	maxLines := int64(20)
-	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *errre, 10, "controller", &maxLines))
+	assert.NilError(t, twait.RegexpMatchingInPACLog(ctx, topts.ParamsRun, *errre, 10, "controller", &maxLines))
 }
 
 // TestGiteaProvenanceForDefaultBranch tests the provenance feature of the PipelineRun.

--- a/test/github_pullrequest_one_comment_per_pipeline_test.go
+++ b/test/github_pullrequest_one_comment_per_pipeline_test.go
@@ -1,0 +1,252 @@
+//go:build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v81/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGithubPullRequestSingleCommentStrategyWebhook(t *testing.T) {
+	if os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK") == "" {
+		t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
+	}
+	ctx := context.Background()
+
+	g := &tgithub.PRTest{
+		Label:     "Github Single Comment Strategy Webhook",
+		YamlFiles: []string{"testdata/pipelinerun.yaml"},
+		Webhook:   true,
+	}
+
+	g.Options = options.E2E{
+		Organization:  os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK"),
+		Repo:          os.Getenv("TEST_GITHUB_REPO_NAME_WEBHOOK"),
+		DirectWebhook: true,
+		Settings: v1alpha1.Settings{
+			Github: &v1alpha1.GithubSettings{
+				CommentStrategy: "update",
+			},
+		},
+	}
+
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
+
+	g.Cnx.Clients.Log.Infof("Waiting for PipelineRun to complete")
+	waitOpts := twait.Opts{
+		RepoName:    g.TargetNamespace,
+		Namespace:   g.TargetNamespace,
+		PollTimeout: twait.DefaultTimeout,
+		TargetSHA:   g.SHA,
+	}
+	err := twait.UntilPipelineRunCompleted(ctx, g.Cnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	g.Cnx.Clients.Log.Infof("Verifying status comment created")
+	comments, _, err := g.Provider.Client().Issues.ListComments(
+		ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,
+		&github.IssueListCommentsOptions{})
+	assert.NilError(t, err)
+
+	statusComments := []*github.IssueComment{}
+	for _, comment := range comments {
+		if strings.Contains(comment.GetBody(), "<!-- pac-status-") {
+			statusComments = append(statusComments, comment)
+		}
+	}
+
+	assert.Assert(t, len(statusComments) == 1, "Expected 1 status comment, got nothing")
+
+	initialCommentID := statusComments[0].GetID()
+	initialCommentBody := statusComments[0].GetBody()
+	g.Cnx.Clients.Log.Infof("Found initial comment with ID: %d", initialCommentID)
+
+	assert.Assert(t, strings.Contains(initialCommentBody, "Success"), "Comment should show pipeline status")
+
+	labelSelector := fmt.Sprintf("%s=%s,%s=%d", keys.SHA, g.SHA, keys.PullRequest, g.PRNumber)
+
+	// Get the first PipelineRun to use its name in the log pattern search.
+	pruns, err := g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, len(pruns.Items) >= 1, "Expected at least 1 PipelineRun")
+	firstPRun := pruns.Items[0]
+	firstPRunName := firstPRun.GetName()
+	originalPipelineName := firstPRun.GetAnnotations()[keys.OriginalPRName]
+	assert.Assert(t, originalPipelineName != "", "PipelineRun should have original-prname annotation")
+
+	// Get the PAC install namespace to search for watcher logs
+	pacNS, _, err := params.GetInstallLocation(ctx, g.Cnx)
+	assert.NilError(t, err)
+	ctxWithNS := info.StoreNS(ctx, pacNS)
+
+	// Wait for the watcher to patch the PipelineRun with the cached comment ID
+	// Use a pattern specific to this PipelineRun name to avoid matching other runs
+	g.Cnx.Clients.Log.Infof("Waiting for watcher to cache comment ID for PipelineRun %s", firstPRunName)
+	logLines := int64(100)
+	cacheLogPattern := regexp.MustCompile(fmt.Sprintf(`patched pipelinerun with cache comment ID.*%s`, originalPipelineName))
+	err = twait.RegexpMatchingInPACLog(ctxWithNS, g.Cnx, *cacheLogPattern, 10, "watcher", &logLines)
+	if err != nil {
+		g.Cnx.Clients.Log.Warnf("Watcher log pattern not found (may already be processed): %v", err)
+	}
+
+	g.Cnx.Clients.Log.Infof("Pushing new commit to trigger pipeline again")
+	newSHA, err := tgithub.PushFilesToExistingBranch(ctx, g.Provider.Client(),
+		"Trigger second pipeline run", g.SHA, g.TargetRefName,
+		g.Options.Organization, g.Options.Repo,
+		map[string]string{"dummy.txt": fmt.Sprintf("triggered at %s", time.Now().String())})
+	assert.NilError(t, err)
+	g.Cnx.Clients.Log.Infof("Pushed new commit %s", newSHA)
+
+	g.Cnx.Clients.Log.Infof("Waiting for PipelineRun with new SHA %s to complete", newSHA)
+	waitOpts.TargetSHA = newSHA
+	err = twait.UntilPipelineRunCompleted(ctx, g.Cnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	time.Sleep(5 * time.Second)
+
+	g.Cnx.Clients.Log.Infof("Verifying comment was updated, not recreated")
+	comments, _, err = g.Provider.Client().Issues.ListComments(
+		ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,
+		&github.IssueListCommentsOptions{})
+	assert.NilError(t, err)
+
+	statusComments = []*github.IssueComment{}
+	for _, comment := range comments {
+		if strings.Contains(comment.GetBody(), "<!-- pac-status-") {
+			statusComments = append(statusComments, comment)
+		}
+	}
+
+	assert.Assert(t, len(statusComments) >= 1,
+		"After rerun, expected at least 1 status comment, got %d.",
+		len(statusComments))
+
+	var updatedCommentBody string
+	for _, comment := range statusComments {
+		if comment.GetID() == initialCommentID && updatedCommentBody != initialCommentBody {
+			updatedCommentBody = comment.GetBody()
+			g.Cnx.Clients.Log.Infof("Initial comment (ID %d) found after rerun", initialCommentID)
+			g.Cnx.Clients.Log.Infof("Comment was updated, body changed from initial")
+			break
+		}
+	}
+
+	assert.Assert(t, updatedCommentBody != "",
+		"Initial comment (ID %d) should still exist after retest. Found comment IDs: %v",
+		initialCommentID, func() []int64 {
+			ids := make([]int64, len(statusComments))
+			for i, c := range statusComments {
+				ids[i] = c.GetID()
+			}
+			return ids
+		}())
+
+	assert.Assert(t, strings.Contains(updatedCommentBody, newSHA),
+		"Updated comment should contain new SHA")
+
+	g.Cnx.Clients.Log.Infof("Single comment strategy working correctly")
+}
+
+func TestGithubPullRequestDefaultCommentStrategy(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
+	ctx := context.Background()
+
+	g := &tgithub.PRTest{
+		Label:     "Github Default Comment Strategy",
+		YamlFiles: []string{"testdata/pipelinerun.yaml"},
+		Webhook:   true,
+	}
+
+	g.Options = options.E2E{
+		Organization:  os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK"),
+		Repo:          os.Getenv("TEST_GITHUB_REPO_NAME_WEBHOOK"),
+		DirectWebhook: true,
+		Settings:      v1alpha1.Settings{},
+	}
+
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
+
+	waitOpts := twait.Opts{
+		RepoName:        g.TargetNamespace,
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       g.SHA,
+	}
+	_, err := twait.UntilRepositoryUpdated(ctx, g.Cnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	comments, _, err := g.Provider.Client().Issues.ListComments(
+		ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,
+		&github.IssueListCommentsOptions{})
+	assert.NilError(t, err)
+
+	initialCommentCount := 0
+	for _, comment := range comments {
+		body := comment.GetBody()
+		if strings.Contains(body, "PipelineRun") {
+			initialCommentCount++
+		}
+	}
+
+	g.Cnx.Clients.Log.Infof("Initial comment count: %d", initialCommentCount)
+	assert.Assert(t, initialCommentCount > 0, "Should have at least one comment")
+
+	g.Cnx.Clients.Log.Infof("Pushing new commit to trigger pipeline again")
+	newSHA, err := tgithub.PushFilesToExistingBranch(ctx, g.Provider.Client(),
+		"Trigger second pipeline run", g.SHA, g.TargetRefName,
+		g.Options.Organization, g.Options.Repo,
+		map[string]string{"dummy.txt": fmt.Sprintf("triggered at %s", time.Now().String())})
+	assert.NilError(t, err)
+	g.Cnx.Clients.Log.Infof("Pushed new commit %s", newSHA)
+
+	g.Cnx.Clients.Log.Infof("Waiting for PipelineRun with new SHA %s to complete", newSHA)
+	waitOpts.TargetSHA = newSHA
+	err = twait.UntilPipelineRunCompleted(ctx, g.Cnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	time.Sleep(5 * time.Second)
+
+	commentsAfterRetest, _, err := g.Provider.Client().Issues.ListComments(
+		ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,
+		&github.IssueListCommentsOptions{})
+	assert.NilError(t, err)
+
+	finalCommentCount := 0
+	for _, comment := range commentsAfterRetest {
+		body := comment.GetBody()
+		if strings.Contains(body, "PipelineRun") {
+			finalCommentCount++
+		}
+	}
+
+	g.Cnx.Clients.Log.Infof("Final comment count: %d", finalCommentCount)
+
+	assert.Assert(t, finalCommentCount > initialCommentCount,
+		"Default behaviour should create new comments, not update. Expected more than %d comments, got %d",
+		initialCommentCount, finalCommentCount)
+
+	g.Cnx.Clients.Log.Infof("Default behavior verified: creates new comments as expected")
+}

--- a/test/github_pullrequest_privaterepository_test.go
+++ b/test/github_pullrequest_privaterepository_test.go
@@ -29,7 +29,7 @@ func TestGithubPullRequestGitClone(t *testing.T) {
 	assert.NilError(t, err)
 
 	maxLines := int64(50)
-	assert.NilError(t, wait.RegexpMatchingInControllerLog(ctx, g.Cnx, *regexp.MustCompile(".*fetched git-clone task"),
+	assert.NilError(t, wait.RegexpMatchingInPACLog(ctx, g.Cnx, *regexp.MustCompile(".*fetched git-clone task"),
 		10, "controller", &maxLines), "Error while checking the logs of the pipelines-as-code controller pod")
 	defer g.TearDown(ctx, t)
 }

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -684,7 +684,7 @@ func TestGithubPullandPushMatchTriggerOnlyPull(t *testing.T) {
 
 	reg := regexp.MustCompile(fmt.Sprintf("Skipping push event for commit.*as it belongs to pull request #%d", g.PRNumber))
 	maxLines := int64(100)
-	err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *reg, 20, "controller", &maxLines)
+	err = twait.RegexpMatchingInPACLog(ctx, g.Cnx, *reg, 20, "controller", &maxLines)
 	assert.NilError(t, err)
 }
 
@@ -744,7 +744,7 @@ func TestGithubIgnoreTagPushCommitsFromSkipPushEventsSetting(t *testing.T) {
 
 	reg := regexp.MustCompile(fmt.Sprintf("Processing tag push event for commit %s despite skip-push-events-for-pr-commits being enabled.*", g.SHA))
 	maxLines := int64(100)
-	err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *reg, 20, "controller", &maxLines)
+	err = twait.RegexpMatchingInPACLog(ctx, g.Cnx, *reg, 20, "controller", &maxLines)
 	assert.NilError(t, err)
 
 	g.Cnx.Clients.Log.Infof("Deleting tag %s", tag)

--- a/test/github_push_retest_test.go
+++ b/test/github_push_retest_test.go
@@ -194,7 +194,7 @@ func TestGithubPushRequestGitOpsCommentCancel(t *testing.T) {
 	if !cancelled {
 		numLines := int64(20)
 		reg := regexp.MustCompile(".*pipelinerun.*skipping cancelling pipelinerun.*on-push.*already done.*")
-		err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *reg, 10, "controller", &numLines)
+		err = twait.RegexpMatchingInPACLog(ctx, g.Cnx, *reg, 10, "controller", &numLines)
 		if err != nil {
 			t.Errorf("neither a cancelled pipelinerun in repo status or a request to skip the cancellation in the controller log was found: %s", err.Error())
 		}

--- a/test/github_skip_ci_test.go
+++ b/test/github_skip_ci_test.go
@@ -40,7 +40,7 @@ func verifySkipCI(ctx context.Context, t *testing.T, g *tgithub.PRTest, eventTyp
 	// Verify controller logs mention skip command detection
 	numLines := int64(100)
 	skipLogRegex := regexp.MustCompile(fmt.Sprintf("CI skipped for %s event.*contains skip command in message", eventType))
-	err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *skipLogRegex, 10, "controller", &numLines)
+	err = twait.RegexpMatchingInPACLog(ctx, g.Cnx, *skipLogRegex, 10, "controller", &numLines)
 	assert.NilError(t, err, "Expected controller logs to mention CI skip due to skip command")
 
 	g.Cnx.Clients.Log.Infof("✓ Verified controller logs mention skip command detection")
@@ -108,7 +108,7 @@ func TestGithubSkipCITestCommand(t *testing.T) {
 	// Verify controller logs mention skip command detection
 	numLines := int64(100)
 	skipLogRegex := regexp.MustCompile("CI skipped for pull request event.*contains skip command in message")
-	err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *skipLogRegex, 10, "controller", &numLines)
+	err = twait.RegexpMatchingInPACLog(ctx, g.Cnx, *skipLogRegex, 10, "controller", &numLines)
 	assert.NilError(t, err, "Expected controller logs to mention CI skip due to skip command")
 
 	g.Cnx.Clients.Log.Infof("✓ Verified controller logs mention skip command detection")

--- a/test/gitlab_delete_tag_event_test.go
+++ b/test/gitlab_delete_tag_event_test.go
@@ -48,7 +48,7 @@ func TestGitlabDeleteTagEvent(t *testing.T) {
 
 	logLinesToCheck := int64(100)
 	reg := regexp.MustCompile("event Delete Tag Push Hook is not supported*")
-	err = twait.RegexpMatchingInControllerLog(ctx, runcnx, *reg, 10, "controller", &logLinesToCheck)
+	err = twait.RegexpMatchingInPACLog(ctx, runcnx, *reg, 10, "controller", &logLinesToCheck)
 	assert.NilError(t, err)
 }
 

--- a/test/pkg/wait/logs.go
+++ b/test/pkg/wait/logs.go
@@ -15,9 +15,9 @@ import (
 	"gotest.tools/v3/golden"
 )
 
-func RegexpMatchingInControllerLog(ctx context.Context, clients *params.Run, reg regexp.Regexp, maxNumberOfLoop int, controllerName string, lines *int64) error {
-	labelselector := fmt.Sprintf("app.kubernetes.io/name=%s", controllerName)
-	containerName := "pac-controller"
+func RegexpMatchingInPACLog(ctx context.Context, clients *params.Run, reg regexp.Regexp, maxNumberOfLoop int, name string, lines *int64) error {
+	labelselector := fmt.Sprintf("app.kubernetes.io/name=%s", name)
+	containerName := fmt.Sprintf("pac-%s", name)
 	ns := info.GetNS(ctx)
 	clients.Clients.Log.Infof(`looking for regexp "%s" in %s for label "%s" container "%s" namespace "%s"`, reg.String(), ns, labelselector, containerName, ns)
 	for i := 0; i <= maxNumberOfLoop; i++ {


### PR DESCRIPTION
## 📝 Description of the Change
Add comment strategy that updates a single comment per pipeline instead of creating new ones on each retest. Supports GitHub and GitLab with shared caching logic in pkg/provider/comment.

### Commits:
commit d3fe837a333d22d2c983c3eff2168e503d6866c1 (HEAD -> SRVKP-9998-feat-one-per-pipeline-comment-strategy, origin/SRVKP-9998-feat-one-per-pipeline-comment-strategy)
Author: Akshay Pant <akshay.akshaypant@gmail.com>
Date:   Thu Jan 29 09:32:59 2026 +0530

    test: add e2e for update comment strategy
    
    Add GitHub PR tests verifying comment update behavior. Include helpers
    for pushing to existing branches and waiting for PipelineRun completion.
    
    Jira: https://issues.redhat.com/browse/SRVKP-9998
    
    Signed-off-by: Akshay Pant <akshay.akshaypant@gmail.com>

commit baab115aa109eae21f137e22ecd2e574efa4dcbf
Author: Akshay Pant <akshay.akshaypant@gmail.com>
Date:   Thu Jan 29 09:30:35 2026 +0530

    docs(repository): add update comment_strategy option
    
    Jira: https://issues.redhat.com/browse/SRVKP-9998
    
    Signed-off-by: Akshay Pant <akshay.akshaypant@gmail.com>

commit 15a623c5206a56c23fd405fc73119e36ce56031e
Author: Akshay Pant <akshay.akshaypant@gmail.com>
Date:   Thu Jan 29 09:28:51 2026 +0530

    refactor(test): generalize PAC log matching
    
    Rename RegexpMatchingInControllerLog to RegexpMatchingInPACLog
    and make it work with any PAC component, not just the controller.
    
    Signed-off-by: Akshay Pant <akshay.akshaypant@gmail.com>

commit e11c5a8fd1db498a3f0107734625f40ca7f739e3
Author: Akshay Pant <akshay.akshaypant@gmail.com>
Date:   Thu Jan 29 09:24:32 2026 +0530

    feat(github): add update comment strategy
    Add comment strategy that updates a single comment per pipeline
    instead of creating new ones on each retest.
    
    Jira: https://issues.redhat.com/browse/SRVKP-9998
    
    Signed-off-by: Akshay Pant <akshay.akshaypant@gmail.com>
    Assisted-by: Claude Opus 4.5

commit be6a69c417838e185439e31edfb6db7ad363ae4b
Author: Akshay Pant <akshay.akshaypant@gmail.com>
Date:   Thu Jan 29 09:22:55 2026 +0530

    feat(gitlab): add update comment strategy
    Add comment strategy that updates a single comment per pipeline
    instead of creating new ones on each retest.
    
    Jira: https://issues.redhat.com/browse/SRVKP-9998
    
    Signed-off-by: Akshay Pant <akshay.akshaypant@gmail.com>
    Assisted-by: Claude Opus 4.5


## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-9998

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [x] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

Gitlab
<img width="1250" height="819" alt="one_per_pipeline_gitlab" src="https://github.com/user-attachments/assets/91c006d5-409a-4ce6-a039-f7cd6da9fe21" />
Github
<img width="830" height="454" alt="one_per_pipeline_github0" src="https://github.com/user-attachments/assets/59d8ef20-31a4-449e-a6e0-bbcc8b975d1e" />
<img width="830" height="454" alt="one_per_pipeline_github1" src="https://github.com/user-attachments/assets/044a6a95-2ecb-4cc0-af27-a453aef3db92" />


## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [x] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [x] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [x] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
