### PR TITLE
fix: kindest/node image version for macOS arm64 stability

### DIFF
--- a/hack/dev/kind/install.sh
+++ b/hack/dev/kind/install.sh
@@ -88,7 +88,14 @@ containerdConfigPatches:
     endpoint = ["http://${REG_NAME}:5000"]
 EOF
 
-  ${SUDO} ${kind} create cluster --name ${KIND_CLUSTER_NAME} --config ${TMPD}/kconfig.yaml
+  kind_args=()
+
+  # Only add the --image flag if the NODE_IMAGE variable is not empty
+  if [[ -n "${NODE_IMAGE:-}" ]]; then
+    echo "Using custom node image: $NODE_IMAGE"
+    kind_args+=(--image "$NODE_IMAGE")
+  fi
+  ${SUDO} ${kind} create cluster --name ${KIND_CLUSTER_NAME} --config ${TMPD}/kconfig.yaml "${kind_args[@]}"
   mkdir -p $(dirname ${KUBECONFIG})
   ${SUDO} ${kind} --name ${KIND_CLUSTER_NAME} get kubeconfig >${KUBECONFIG}
 


### PR DESCRIPTION
PROBLEM
The default image (which is kindest/node:v1.35.0 at the moment) in [install script](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/hack/dev/kind/install.sh) fails on Apple Silicon M4 Pro Chip (arm64) due to a CRI API mismatch between kubelet and containerd. This results in an Unimplemented rpc error, preventing the control-plane from starting and blocking cluster creation.

SOLUTION
Downgrading the default node image to v1.31.12 fixes the issue, which contains a compatible container runtime for ARM64 architecture. The script is modified to allow devs to use image image version of their choice while via NODE_IMAGE environment variable.

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [x] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [x] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [x] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
