### PR TITLE
fix: Add retry logic for PR lookup on merge commits

### DIFF
--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	ghinstallation "github.com/bradleyfalzon/ghinstallation/v2"
 	github75 "github.com/google/go-github/v75/github"
@@ -22,6 +23,12 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	maxRetriesForMergeCommit = 3
+	githubNoreplyEmail       = "noreply@github.com"
+	githubWebFlowUser        = "web-flow"
 )
 
 // GetAppIDAndPrivateKey retrieves the GitHub application ID and private key from a secret in the specified namespace.
@@ -191,7 +198,9 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 }
 
 // getPullRequestsWithCommit lists the all pull requests associated with given commit.
-func (v *Provider) getPullRequestsWithCommit(ctx context.Context, sha, org, repo string) ([]*github.PullRequest, error) {
+// It implements retry logic with exponential backoff to handle cases where GitHub's API
+// hasn't yet indexed the PR-to-commit association (e.g., immediately after a merge commit).
+func (v *Provider) getPullRequestsWithCommit(ctx context.Context, sha, org, repo string, isMergeCommit bool) ([]*github.PullRequest, error) {
 	if v.ghClient == nil {
 		return nil, fmt.Errorf("github client is not initialized")
 	}
@@ -207,33 +216,65 @@ func (v *Provider) getPullRequestsWithCommit(ctx context.Context, sha, org, repo
 		return nil, fmt.Errorf("repository cannot be empty")
 	}
 
-	opts := &github.ListOptions{
-		PerPage: 100, // GitHub's maximum per page
+	// For merge commits, retry the API call to handle potential delays in GitHub's API indexing the PR-to-commit association.
+	maxRetries := 0
+
+	if isMergeCommit {
+		maxRetries = maxRetriesForMergeCommit
 	}
 
-	pullRequests := []*github.PullRequest{}
+	const initialBackoff = 1 * time.Second
 
-	for {
-		// Use the "List pull requests associated with a commit" API to check if the commit is part of any open PR
-		prs, resp, err := wrapAPI(v, "list_pull_requests_with_commit", func() ([]*github.PullRequest, *github.Response, error) {
-			return v.Client().PullRequests.ListPullRequestsWithCommit(ctx, org, repo, sha, opts)
-		})
-		if err != nil {
-			// Log the error for debugging purposes
-			v.Logger.Debugf("Failed to list pull requests for commit %s in %s/%s: %v", sha, org, repo, err)
-			return nil, fmt.Errorf("failed to list pull requests for commit %s: %w", sha, err)
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		opts := &github.ListOptions{
+			PerPage: 100, // GitHub's maximum per page
 		}
 
-		pullRequests = append(pullRequests, prs...)
+		pullRequests := []*github.PullRequest{}
 
-		// Check if there are more pages
-		if resp.NextPage == 0 {
-			break
+		for {
+			// Use the "List pull requests associated with a commit" API to check if the commit is part of any open PR
+			prs, resp, err := wrapAPI(v, "list_pull_requests_with_commit", func() ([]*github.PullRequest, *github.Response, error) {
+				return v.Client().PullRequests.ListPullRequestsWithCommit(ctx, org, repo, sha, opts)
+			})
+			if err != nil {
+				// Log the error for debugging purposes
+				v.Logger.Debugf("Failed to list pull requests for commit %s in %s/%s: %v", sha, org, repo, err)
+				return nil, fmt.Errorf("failed to list pull requests for commit %s: %w", sha, err)
+			}
+
+			pullRequests = append(pullRequests, prs...)
+
+			// Check if there are more pages
+			if resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
 		}
-		opts.Page = resp.NextPage
+
+		// If we found pull requests, return them immediately
+		if len(pullRequests) > 0 {
+			return pullRequests, nil
+		}
+
+		// If this is not the last attempt and we got an empty result, retry with exponential backoff
+		// This handles the case where GitHub's API hasn't indexed the PR-to-commit association yet
+		// (common when a PR is merged via Merge Commit strategy)
+		if attempt < maxRetries {
+			backoff := time.Duration(1<<uint(attempt)) * initialBackoff // #nosec G115
+			v.Logger.Debugf("No pull requests found for commit %s in %s/%s (attempt %d/%d), retrying after %v", sha, org, repo, attempt+1, maxRetries+1, backoff)
+
+			// Wait with exponential backoff, but respect context cancellation
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
 	}
 
-	return pullRequests, nil
+	// After all retries, return empty list (no error, as this is a valid state)
+	return []*github.PullRequest{}, nil
 }
 
 // isCommitPartOfPullRequest checks if the commit from a push event is part of an open pull request
@@ -319,10 +360,14 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		org := gitEvent.GetRepo().GetOwner().GetLogin()
 		repoName := gitEvent.GetRepo().GetName()
 
+		// when the commit is a merge commit, either email is 'noreply@github.com' or name is 'web-flow'
+		isMergeCommit := gitEvent.GetHeadCommit().GetCommitter().GetEmail() == githubNoreplyEmail ||
+			gitEvent.GetHeadCommit().GetCommitter().GetName() == githubWebFlowUser
+
 		// First get all the pull requests associated with this commit so that we can reuse the output to check
 		// whether the commit is included in any PR or not, and if this push is generated on PR merge event, we can
 		// assign PR number to `pull_request_number` variable.
-		prs, err := v.getPullRequestsWithCommit(ctx, sha, org, repoName)
+		prs, err := v.getPullRequestsWithCommit(ctx, sha, org, repoName, isMergeCommit)
 		if err != nil {
 			v.Logger.Warnf("Error getting pull requests associated with the commit in this push event: %v", err)
 		}

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -87,15 +87,17 @@ var samplePRAnother = github.PullRequest{
 }
 
 func TestGetPullRequestsWithCommit(t *testing.T) {
+	apiHitCount := 0
 	tests := []struct {
-		name         string
-		sha          string
-		org          string
-		repo         string
-		hasClient    bool
-		mockAPIs     map[string]func(rw http.ResponseWriter, r *http.Request)
-		wantPRsCount int
-		wantErr      bool
+		name          string
+		sha           string
+		org           string
+		repo          string
+		hasClient     bool
+		mockAPIs      map[string]func(rw http.ResponseWriter, r *http.Request)
+		wantPRsCount  int
+		isMergeCommit bool
+		wantErr       bool
 	}{
 		{
 			name:      "nil client returns error",
@@ -212,6 +214,27 @@ func TestGetPullRequestsWithCommit(t *testing.T) {
 			wantPRsCount: 2,
 			wantErr:      false,
 		},
+		{
+			name:      "commit is part of one PR and is a merge commit",
+			sha:       "abc123",
+			org:       "testorg",
+			repo:      "testrepo",
+			hasClient: true,
+			mockAPIs: map[string]func(rw http.ResponseWriter, r *http.Request){
+				"/repos/testorg/testrepo/commits/abc123/pulls": func(rw http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, r.Method, http.MethodGet)
+					apiHitCount++
+					if apiHitCount == 3 {
+						fmt.Fprint(rw, `[{"number": 42, "state": "closed"}]`)
+					} else {
+						fmt.Fprint(rw, `[]`)
+					}
+				},
+			},
+			wantPRsCount:  1,
+			isMergeCommit: true,
+			wantErr:       false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -240,9 +263,13 @@ func TestGetPullRequestsWithCommit(t *testing.T) {
 				}
 			}
 
-			prs, err := provider.getPullRequestsWithCommit(ctx, tt.sha, tt.org, tt.repo)
+			prs, err := provider.getPullRequestsWithCommit(ctx, tt.sha, tt.org, tt.repo, tt.isMergeCommit)
 			assert.Equal(t, err != nil, tt.wantErr)
 			assert.Equal(t, len(prs), tt.wantPRsCount)
+
+			if tt.isMergeCommit {
+				assert.Equal(t, apiHitCount, 3)
+			}
 
 			if tt.wantErr && err != nil {
 				// Verify error messages for validation cases


### PR DESCRIPTION
Implement exponential backoff retry mechanism in
getPullRequestsWithCommit to handle cases where GitHub's API hasn't yet indexed the PR-to-commit association immediately after a merge commit is created.

The issue occurs when a pull request is merged via Merge Commit strategy and PaC receives a push event for that merge commit. GitHub's database may not have the PR-to-commit association indexed yet, causing the API call to return an empty list.

Changes:
- Add isMergeCommit parameter to detect merge commits by checking committer email (noreply@github.com) or name (web-flow)
- Implement retry logic with exponential backoff (1s, 2s, 4s) for merge commits, with up to 3 retries
- Add context cancellation support during backoff waits
- Update tests to verify retry behavior for merge commit scenario

This ensures pull_request_number dynamic variable is correctly populated even when GitHub's API hasn't finished indexing the merge commit association.

https://issues.redhat.com/browse/SRVKP-9474


Assisted-by: Auto (via Cursor)

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [x] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [x] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [x] GitHub App
  - [x] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
