### PR TITLE
feat(github): add glob pattern support for token scope repos

### DIFF
--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -240,6 +240,7 @@ This setting enables the scoping of the GitHub token to private and public repos
 ### Scoping the GitHub token using Global configuration
 
 You can use the global configuration to use as a list of repositories used from any Repository CR in any namespace.
+You can specify repositories using exact names or glob patterns (e.g., `myorg/*` to match all repositories under an organization where the app is installed).
 
 To set the global configuration, in the `pipelines-as-code` configmap, set the `secret-github-app-scope-extra-repos` key, as in the following example:
 
@@ -250,13 +251,14 @@ To set the global configuration, in the `pipelines-as-code` configmap, set the `
     name: pipelines-as-code
     namespace: pipelines-as-code
   data:
-    secret-github-app-scope-extra-repos: "owner2/project2, owner3/project3"
+    secret-github-app-scope-extra-repos: "owner2/project2, owner3/*"
   ```
 
 ### Scoping the GitHub token using Repository level configuration
 
 You can use the `Repository` custom resource to scope the generated GitHub token to a list of repositories.
 The repositories can be public or private, but must reside in the same namespace as the repository with which the `Repository` resource is associated.
+You can specify repositories using exact names or glob patterns (e.g., `myorg/*` to match all repositories under an organization which have the GitHub app installed).
 
 Set the `github_app_token_scope_repos` spec configuration within the `Repository` custom resource, as in the following example:
 
@@ -271,18 +273,18 @@ Set the `github_app_token_scope_repos` spec configuration within the `Repository
     settings:
       github_app_token_scope_repos:
       - "owner/project"
-      - "owner1/project1"
+      - "owner1/*"
   ```
 
 In this example, the `Repository` custom resource is associated with the `linda/project` repository in the `test-repo` namespace.
-The scope of the generated GitHub token is extended to the `owner/project` and `owner1/project1` repositories, as well as the `linda/project` repository. These repositories must exist under the `test-repo` namespace.
+The scope of the generated GitHub token is extended to the `owner/project` repository, all repositories matching `owner1/*`, as well as the `linda/project` repository. These repositories must exist under the `test-repo` namespace.
 
 **Note:**
 
-If any of the repositories do not exist in the namespace, the scoping of the GitHub token fails with an error message as in the following example:
+If any of the repositories or patterns do not match any repository in the namespace, the scoping of the GitHub token fails with an error message as in the following example:
 
 ```console
-failed to scope GitHub token as repo owner1/project1 does not exist in namespace test-repo
+failed to scope GitHub token as repo with pattern owner1/project1 does not exist in namespace test-repo
 ```
 
 ### Combining global and repository level configuration
@@ -335,10 +337,10 @@ creation of the GitHub token fails with the following error message:
     ```
 
 - If the scoping of the GitHub token to the repositories set in global or repository level configuration fails for any reason,
-the CI process does not run. This includes cases where the same repository is listed in the global or repository level configuration,
+the CI process does not run. This includes cases where the same repository is listed (or matched) in the global or repository level configuration,
 and the scoping fails for the repository level configuration because the repository is not in the same namespace as the `Repository` custom resource.
 
-  In the following example, the `owner5/project5` repository is listed in both the global configuration and in the repository level configuration:
+  In the following example, the `owner5/project5` repository is listed in the global configuration and matches the pattern in the repository level configuration:
 
   ```yaml
   apiVersion: v1
@@ -360,11 +362,11 @@ and the scoping fails for the repository level configuration because the reposit
     url: "https://github.com/linda/project"
     settings:
       github_app_token_scope_repos:
-      - "owner5/project5"
+      - "owner5/*"
   ```
 
-  In this example, if the `owner5/project5` repository is not under the `test-repo` namespace, scoping of the GitHub token fails with the following error message:
+  In this example, if the `owner5/project5` repository (or any other repository satisfying the specified pattern of `owner5/*`) is not under the `test-repo` namespace, scoping of the GitHub token fails with the following error message:
 
   ```yaml
-  failed to scope GitHub token as repo owner5/project5 does not exist in namespace test-repo
+  failed to scope GitHub token as repo with pattern owner5/* does not exist in namespace test-repo
   ```

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gobwas/glob"
 	"github.com/google/go-github/v74/github"
 	"github.com/jonboulle/clockwork"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
@@ -636,7 +637,17 @@ func ListRepos(ctx context.Context, v *Provider) ([]string, error) {
 }
 
 func (v *Provider) CreateToken(ctx context.Context, repository []string, event *info.Event) (string, error) {
+	var appReposCache []*github.Repository
+
 	for _, r := range repository {
+		// Check if this is a glob pattern
+		if strings.ContainsAny(r, "*?[") {
+			if err := v.expandGlobAndAddRepoIDs(ctx, r, &appReposCache); err != nil {
+				v.Logger.Warn("failed to expand glob pattern %q: %v", r, err)
+			}
+			continue
+		}
+
 		split := strings.Split(r, "/")
 		infoData, _, err := wrapAPI(v, "get_repository", func() (*github.Repository, *github.Response, error) {
 			return v.Client().Repositories.Get(ctx, split[0], split[1])
@@ -653,6 +664,52 @@ func (v *Provider) CreateToken(ctx context.Context, repository []string, event *
 		return "", err
 	}
 	return token, nil
+}
+
+func (v *Provider) expandGlobAndAddRepoIDs(ctx context.Context, repoPattern string, cache *[]*github.Repository) error {
+	// We can skip error check here as all the glob compilation has been checked
+	// before this method is called.
+	reposToScope, _ := glob.Compile(repoPattern)
+
+	if *cache == nil {
+		repos, err := v.listAppRepos(ctx)
+		if err != nil {
+			return err
+		}
+		*cache = repos
+	}
+
+	for _, repo := range *cache {
+		repoFullName := repo.GetFullName()
+		if reposToScope.Match(repoFullName) {
+			v.RepositoryIDs = uniqueRepositoryID(v.RepositoryIDs, repo.GetID())
+		}
+	}
+
+	return nil
+}
+
+func (v *Provider) listAppRepos(ctx context.Context) ([]*github.Repository, error) {
+	var allRepos []*github.Repository
+
+	opt := &github.ListOptions{PerPage: v.PaginedNumber}
+	for {
+		repoList, resp, err := wrapAPI(v, "list_app_repos", func() (*github.ListRepositories, *github.Response, error) {
+			return v.Client().Apps.ListRepos(ctx, opt)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list app repos: %w", err)
+		}
+
+		allRepos = append(allRepos, repoList.Repositories...)
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+
+	return allRepos, nil
 }
 
 func uniqueRepositoryID(repoIDs []int64, id int64) []int64 {

--- a/test/github_scope_token_to_list_of_private_public_repos_test.go
+++ b/test/github_scope_token_to_list_of_private_public_repos_test.go
@@ -81,7 +81,8 @@ func TestGithubPullRequestScopeTokenToListOfReposByGlobalConfiguration(t *testin
 		splittedValue = strings.Split(urlData.Path, "/")
 	}
 
-	data := map[string]string{"secret-github-app-scope-extra-repos": splittedValue[1] + "/" + splittedValue[2]}
+	// Use glob pattern to match all repos under the organization
+	data := map[string]string{"secret-github-app-scope-extra-repos": splittedValue[1] + "/*"}
 
 	verifyGHTokenScope(t, remoteTaskURL, remoteTaskName, data)
 }
@@ -116,6 +117,7 @@ func verifyGHTokenScope(t *testing.T, remoteTaskURL, remoteTaskName string, data
 		assert.NilError(t, err)
 		splittedValue = strings.Split(urlData.Path, "/")
 	}
+	// Use glob pattern to match all repos under the organization
 	repository := &pacv1alpha1.Repository{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: targetNS,
@@ -123,7 +125,7 @@ func verifyGHTokenScope(t *testing.T, remoteTaskURL, remoteTaskName string, data
 		Spec: pacv1alpha1.RepositorySpec{
 			URL: repoinfo.GetHTMLURL(),
 			Settings: &pacv1alpha1.Settings{
-				GithubAppTokenScopeRepos: []string{splittedValue[1] + "/" + splittedValue[2]},
+				GithubAppTokenScopeRepos: []string{splittedValue[1] + "/*"},
 			},
 		},
 	}


### PR DESCRIPTION
## 📝 Description of the Change
Add support for glob patterns when specifying repositories for GitHub App token scoping in both global and repository-level configurations. Users can now use patterns like "myorg/*" to match multiple repos instead of listing each one explicitly.

For global config (secret-github-app-scope-extra-repos), glob patterns are expanded by listing all repositories where the GitHub App is installed. Results are cached to avoid repeated API calls when multiple patterns are specified.

For repository-level config (github_app_token_scope_repos), glob patterns are matched against Repository CRDs in the same namespace, maintaining the existing namespace isolation requirement.

Both exact matches and glob patterns can be combined. Invalid glob patterns are validated early and return clear error messages.

## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-10030

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [x] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

PAC global config
```
akpant@akpant-thinkpadp1gen7:~/code/tekton-pac$ kg cm pipelines-as-code -o yaml | grep extra-repos
  secret-github-app-scope-extra-repos: '*'
```

Repo CR:
```yaml
akpant@akpant-thinkpadp1gen7:~/code/tekton-pac$ kg repo akshay-pac-test-repo -n default -o yaml 
apiVersion: pipelinesascode.tekton.dev/v1alpha1
kind: Repository
metadata:
  name: akshay-pac-test-repo
  namespace: default
  ...
spec:
  settings:
    github_app_token_scope_repos:
    - theakshaypant/*
  url: https://github.com/theakshaypant/akshay-pac-test-repo
```

Controller logs (added logging after
- creation of token
- finding a matching repo in namespace
- finding a matching repo with global wildcard)
```
akpant@akpant-thinkpadp1gen7:~/code/tekton-pac$ klf pipelines-as-code-controller-6d596b9db-544j4 | grep 10030
{"level":"info","ts":"2026-01-10T09:53:38.867Z","logger":"pipelinesascode","caller":"github/scope.go:77","msg":"10030 - Namespace repo permission to: theakshaypant/akshay-pac-test-repo","commit":"fe5bab4-dirty","provider":"github","event-id":"e72e9a6c-ec77-11f0-9e7d-0a3186135045","event-sha":"c4fef65cae96b00f72374825e005b45fdeb927a8","event-type":"push","source-repo-url":"https://github.com/theakshaypant/akshay-pac-test-repo","target-branch":"refs/heads/main"}
{"level":"info","ts":"2026-01-10T09:53:38.868Z","logger":"pipelinesascode","caller":"github/scope.go:77","msg":"10030 - Namespace repo permission to: theakshaypant/webhook-test","commit":"fe5bab4-dirty","provider":"github","event-id":"e72e9a6c-ec77-11f0-9e7d-0a3186135045","event-sha":"c4fef65cae96b00f72374825e005b45fdeb927a8","event-type":"push","source-repo-url":"https://github.com/theakshaypant/akshay-pac-test-repo","target-branch":"refs/heads/main"}
{"level":"info","ts":"2026-01-10T09:53:39.234Z","logger":"pipelinesascode","caller":"github/github.go:687","msg":"10030 - Glob repo permission to: theakshaypant/books-go","commit":"fe5bab4-dirty","provider":"github","event-id":"e72e9a6c-ec77-11f0-9e7d-0a3186135045","event-sha":"c4fef65cae96b00f72374825e005b45fdeb927a8","event-type":"push","source-repo-url":"https://github.com/theakshaypant/akshay-pac-test-repo","target-branch":"refs/heads/main"}
{"level":"info","ts":"2026-01-10T09:53:39.234Z","logger":"pipelinesascode","caller":"github/github.go:687","msg":"10030 - Glob repo permission to: theakshaypant/akshay-pac-test-repo","commit":"fe5bab4-dirty","provider":"github","event-id":"e72e9a6c-ec77-11f0-9e7d-0a3186135045","event-sha":"c4fef65cae96b00f72374825e005b45fdeb927a8","event-type":"push","source-repo-url":"https://github.com/theakshaypant/akshay-pac-test-repo","target-branch":"refs/heads/main"}
{"level":"info","ts":"2026-01-10T09:53:39.234Z","logger":"pipelinesascode","caller":"github/github.go:687","msg":"10030 - Glob repo permission to: theakshaypant/webhook-test","commit":"fe5bab4-dirty","provider":"github","event-id":"e72e9a6c-ec77-11f0-9e7d-0a3186135045","event-sha":"c4fef65cae96b00f72374825e005b45fdeb927a8","event-type":"push","source-repo-url":"https://github.com/theakshaypant/akshay-pac-test-repo","target-branch":"refs/heads/main"}
{"level":"info","ts":"2026-01-10T09:53:39.234Z","logger":"pipelinesascode","caller":"github/github.go:687","msg":"10030 - Glob repo permission to: theakshaypant/pogo-mcp","commit":"fe5bab4-dirty","provider":"github","event-id":"e72e9a6c-ec77-11f0-9e7d-0a3186135045","event-sha":"c4fef65cae96b00f72374825e005b45fdeb927a8","event-type":"push","source-repo-url":"https://github.com/theakshaypant/akshay-pac-test-repo","target-branch":"refs/heads/main"}
{"level":"info","ts":"2026-01-10T09:53:41.357Z","logger":"pipelinesascode","caller":"github/github.go:666","msg":"10030 - Was able to get all the necessary tokens","commit":"fe5bab4-dirty","provider":"github","event-id":"e72e9a6c-ec77-11f0-9e7d-0a3186135045","event-sha":"c4fef65cae96b00f72374825e005b45fdeb927a8","event-type":"push","source-repo-url":"https://github.com/theakshaypant/akshay-pac-test-repo","target-branch":"refs/heads/main"}
```

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [x] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
