### PR TITLE
fix: variables substitution issue on commit comment in GitLab

### DIFF
--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -163,7 +163,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 	case *gitlab.CommitCommentEvent:
 		// need run in fetching repository
 		v.run = run
-		return v.handleCommitCommentEvent(ctx, gitEvent)
+		return v.handleCommitCommentEvent(ctx, gitEvent, processedEvent)
 	default:
 		return nil, fmt.Errorf("event %s is not supported", event)
 	}
@@ -225,9 +225,8 @@ func (v *Provider) initGitLabClient(ctx context.Context, event *info.Event) (*in
 	return event, nil
 }
 
-func (v *Provider) handleCommitCommentEvent(ctx context.Context, event *gitlab.CommitCommentEvent) (*info.Event, error) {
+func (v *Provider) handleCommitCommentEvent(ctx context.Context, event *gitlab.CommitCommentEvent, processedEvent *info.Event) (*info.Event, error) {
 	action := "trigger"
-	processedEvent := info.NewEvent()
 	if event.Repository == nil {
 		return nil, fmt.Errorf("error parse_payload: the repository in event payload must not be nil")
 	}

--- a/pkg/provider/gitlab/parse_payload_test.go
+++ b/pkg/provider/gitlab/parse_payload_test.go
@@ -493,6 +493,7 @@ func TestParsePayload(t *testing.T) {
 			}
 			assert.NilError(t, err)
 			if tt.want != nil {
+				assert.Assert(t, got.Event != nil)
 				assert.Equal(t, tt.want.TriggerTarget, got.TriggerTarget)
 				assert.Equal(t, tt.want.EventType, got.EventType)
 				assert.Equal(t, tt.want.Organization, got.Organization)

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package test
 
 import (
@@ -1028,6 +1030,91 @@ func TestGitlabMergeRequestCelPrefix(t *testing.T) {
 		2,
 	)
 	assert.NilError(t, err)
+}
+
+// TestGitlabMergeRequestVariableSubs tests variable substitution in PipelineRun annotations
+// by pushing a PipelineRun file to a branch, making a comment on the commit, and verifying
+// that the PipelineRun logs contain the commit message.
+func TestGitlabMergeRequestVariableSubs(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
+	assert.NilError(t, err)
+	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Info("Testing variable substitution with GitLab")
+
+	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
+	assert.NilError(t, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
+	assert.NilError(t, err)
+
+	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+
+	entries, err := payload.GetEntries(map[string]string{
+		".tekton/pipelinerun-variable-subs.yaml": "testdata/pipelinerun-variable-subs.yaml",
+	}, targetNS, targetRefName,
+		triggertype.Push.String(), map[string]string{})
+	assert.NilError(t, err)
+
+	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
+	assert.NilError(t, err)
+	commitTitle := "Testing variable substitution on " + targetRefName
+	scmOpts := &scm.Opts{
+		GitURL:        gitCloneURL,
+		CommitTitle:   commitTitle,
+		Log:           runcnx.Clients.Log,
+		WebURL:        projectinfo.WebURL,
+		TargetRefName: targetRefName,
+		BaseRefName:   projectinfo.DefaultBranch,
+	}
+	sha := scm.PushFilesToRefGit(t, scmOpts, entries)
+
+	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files, commit SHA: %s", targetRefName, sha)
+	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, targetRefName, targetNS, opts.ProjectID)
+
+	// Make a comment on the commit
+	runcnx.Clients.Log.Infof("Creating comment /test pipelinerun-variable-subs on commit %s", sha)
+	commentOpts := &clientGitlab.PostCommitCommentOptions{
+		Note: clientGitlab.Ptr(fmt.Sprintf("/test pipelinerun-variable-subs branch:%s", targetRefName)),
+	}
+	cc, _, err := glprovider.Client().Commits.PostCommitComment(opts.ProjectID, sha, commentOpts)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
+
+	// Wait for PipelineRun creation
+	waitOpts := twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 2,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       sha,
+	}
+	err = twait.UntilPipelineRunHasReason(ctx, runcnx.Clients, v1.PipelineRunReasonSuccessful, waitOpts)
+	assert.NilError(t, err)
+
+	// Get the PipelineRun
+	prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, len(prs.Items) >= 1, "Expected at least one PipelineRun, got %d", len(prs.Items))
+
+	// Check that PipelineRun logs contain the commit message
+	err = twait.RegexpMatchingInPodLog(
+		ctx,
+		runcnx,
+		targetNS,
+		fmt.Sprintf("pipelinesascode.tekton.dev/event-type=%s",
+			opscomments.TestSingleCommentEventType.String()),
+		"step-task",
+		*regexp.MustCompile(regexp.QuoteMeta(commitTitle)),
+		"",
+		2,
+	)
+	assert.NilError(t, err, "PipelineRun logs should contain the commit message: %s", commitTitle)
 }
 
 // Local Variables:

--- a/test/pkg/wait/wait.go
+++ b/test/pkg/wait/wait.go
@@ -159,7 +159,7 @@ func UntilPipelineRunHasReason(ctx context.Context, clients clients.Clients, des
 			}
 		}
 
-		clients.Log.Infof("still waiting for pipelinerun to have reason %s in %s namespace", desiredReason.String(), opts.Namespace)
+		clients.Log.Infof("still waiting for %d pipelinerun(s) to have reason %s in %s namespace", opts.MinNumberStatus, desiredReason.String(), opts.Namespace)
 		return len(prsWithReason) >= opts.MinNumberStatus, nil
 	})
 }

--- a/test/testdata/pipelinerun-variable-subs.yaml
+++ b/test/testdata/pipelinerun-variable-subs.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "pipelinerun-variable-subs"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi10/ubi-micro
+              script: |
+                echo "{{ body.commit.title }}"
+                sleep 10
+                exit 0


### PR DESCRIPTION
To make event payload available in `body` variable we've [Event](https://github.com/openshift-pipelines/pipelines-as-code/blob/751f9310d311b1f2b301292099caf817617268ec/pkg/params/info/events.go#L12) field in [Event](https://github.com/openshift-pipelines/pipelines-as-code/blob/751f9310d311b1f2b301292099caf817617268ec/pkg/params/info/events.go#L10) struct to store raw event and be processed by [ReplacePlaceHoldersVariables](https://github.com/openshift-pipelines/pipelines-as-code/blob/751f9310d311b1f2b301292099caf817617268ec/pkg/templates/templating.go#L53C6-L53C34) func but in GitLab where commit comment event is handled Event field is not assigned because Event struct is built inside [handleCommitCommentEvent](https://github.com/openshift-pipelines/pipelines-as-code/blob/751f9310d311b1f2b301292099caf817617268ec/pkg/provider/gitlab/parse_payload.go#L227C20-L227C44) func and created new Event instance while [Event raw field is assigned](https://github.com/openshift-pipelines/pipelines-as-code/blob/751f9310d311b1f2b301292099caf817617268ec/pkg/provider/gitlab/parse_payload.go#L43) early in ParsePayload and it was causing issue that when `body.anyfield` is accessed in commit comment event, they weren't not being substituted at all. this PR uses already [processed event](https://github.com/openshift-pipelines/pipelines-as-code/blob/751f9310d311b1f2b301292099caf817617268ec/pkg/provider/gitlab/parse_payload.go#L41) for Event field to be used further in event processing.

https://issues.redhat.com/browse/SRVKP-9458

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [x] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
