### PR TITLE
fix: show helpful message when /retest has nothing to retest

### DIFF
--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -2,6 +2,7 @@ package matcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -35,6 +36,10 @@ const (
 	// maximum number of characters to display in logs for gitops comments.
 	maxCommentLogLength = 160
 )
+
+// ErrNoFailedPipelineToRetest is returned when /retest or /ok-to-test is used
+// but all matching pipelines have already succeeded for this commit.
+var ErrNoFailedPipelineToRetest = errors.New("All PipelineRuns for this commit have already succeeded. Use `/retest <pipeline-name>` to re-run a specific pipeline or `/test` to re-run all pipelines.")
 
 // prunBranch is value from annotations and baseBranch is event.Base value from event.
 func branchMatch(prunBranch, baseBranch string) bool {
@@ -421,7 +426,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 			logger.Debugf("MatchPipelinerunByAnnotation: filtering successful templates for event_type=%s", event.EventType)
 			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, matchedPRs)
 			if len(filtered) == 0 {
-				return nil, fmt.Errorf("all PipelineRuns for this commit have already succeeded. Use /retest <pipeline-name> to re-run a specific pipeline or /test to re-run all")
+				return nil, ErrNoFailedPipelineToRetest
 			}
 			return filtered, nil
 		}

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -419,7 +419,11 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 		if event.EventType == opscomments.RetestAllCommentEventType.String() ||
 			event.EventType == opscomments.OkToTestCommentEventType.String() {
 			logger.Debugf("MatchPipelinerunByAnnotation: filtering successful templates for event_type=%s", event.EventType)
-			return filterSuccessfulTemplates(ctx, logger, cs, event, repo, matchedPRs), nil
+			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, matchedPRs)
+			if len(filtered) == 0 {
+				return nil, fmt.Errorf("all PipelineRuns for this commit have already succeeded. Use /retest <pipeline-name> to re-run a specific pipeline or /test to re-run all")
+			}
+			return filtered, nil
 		}
 		return matchedPRs, nil
 	}

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -3,6 +3,7 @@ package pipelineascode
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -267,6 +268,15 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 	var matchedPRs []matcher.Match
 	if p.event.TargetTestPipelineRun == "" {
 		if matchedPRs, err = matcher.MatchPipelinerunByAnnotation(ctx, p.logger, pipelineRuns, p.run, p.event, p.vcx, p.eventEmitter, repo, true); err != nil {
+			// Check if all pipelines have already succeeded - post comment so user gets feedback
+			if errors.Is(err, matcher.ErrNoFailedPipelineToRetest) {
+				p.logger.Infof("RepositoryAllPipelinesSucceeded: %s", err.Error())
+				p.eventEmitter.EmitMessage(nil, zap.InfoLevel, "RepositoryAllPipelinesSucceeded", err.Error())
+				if commentErr := p.vcx.CreateComment(ctx, p.event, err.Error(), ""); commentErr != nil {
+					return nil, fmt.Errorf("error adding no pipelineruns to rerun comment: %w", commentErr)
+				}
+				return nil, nil
+			}
 			// Don't fail when you don't have a match between pipeline and annotations
 			p.eventEmitter.EmitMessage(nil, zap.WarnLevel, "RepositoryNoMatch", err.Error())
 			// In a scenario where an external user submits a pull request and the repository owner uses the

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -29,7 +29,10 @@ import (
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	knativeduckv1 "knative.dev/pkg/apis/duck/v1"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
@@ -302,6 +305,18 @@ func TestGetPipelineRunsFromRepo(t *testing.T) {
 		EventType:     "ok-to-test-comment",
 		TriggerTarget: "pull_request",
 	}
+	retestAllEvent := &info.Event{
+		SHA:                "principale",
+		Organization:       "organizationes",
+		Repository:         "lagaffe",
+		URL:                "https://service/documentation",
+		HeadBranch:         "main",
+		BaseBranch:         "main",
+		Sender:             "fantasio",
+		EventType:          opscomments.RetestAllCommentEventType.String(),
+		TriggerTarget:      "pull_request",
+		PullRequestNumber:  10,
+	}
 	testExplicitNoMatchPREvent := &info.Event{
 		SHA:           "principale",
 		Organization:  "organizationes",
@@ -336,6 +351,7 @@ func TestGetPipelineRunsFromRepo(t *testing.T) {
 		event                 *info.Event
 		logSnippet            string
 		wantErr               bool
+		seedData              *testclient.Data
 	}{
 		{
 			name: "more than one pipelinerun in .tekton dir",
@@ -462,6 +478,47 @@ func TestGetPipelineRunsFromRepo(t *testing.T) {
 			event:                 noOpsCommentEvent,
 			logSnippet:            "skipping MetadataResolve error for no-ops comment event",
 		},
+		{
+			name: "retest when all pipelines already succeeded returns no runs and posts comment",
+			repositories: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testrepo",
+					Namespace: "test",
+				},
+				Spec: v1alpha1.RepositorySpec{},
+			},
+			tektondir:             "testdata/pull_request",
+			expectedNumberOfPruns: 0,
+			event:                 retestAllEvent,
+			logSnippet:            "All PipelineRuns for this commit have already succeeded",
+			seedData: &testclient.Data{
+				Repositories: []*v1alpha1.Repository{{
+					ObjectMeta: metav1.ObjectMeta{Name: "testrepo", Namespace: "test"},
+					Spec:       v1alpha1.RepositorySpec{},
+				}},
+				PipelineRuns: []*tektonv1.PipelineRun{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pull_request-xyz",
+						Namespace: "test",
+						Labels: map[string]string{
+							apipac.SHA:            "principale",
+							apipac.OriginalPRName: "pull_request",
+						},
+						Annotations: map[string]string{
+							apipac.OriginalPRName: "pull_request",
+						},
+					},
+					Status: tektonv1.PipelineRunStatus{
+						Status: knativeduckv1.Status{
+							Conditions: knativeduckv1.Conditions{{
+								Type:   apis.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+							}},
+						},
+					},
+				}},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -471,11 +528,23 @@ func TestGetPipelineRunsFromRepo(t *testing.T) {
 			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 			defer teardown()
 
+			// For retest-when-all-succeeded case, CreateComment is called; register handler so it succeeds.
+			if tt.name == "retest when all pipelines already succeeded returns no runs and posts comment" {
+				mux.HandleFunc("/repos/organizationes/lagaffe/issues/10/comments", func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodPost {
+						w.WriteHeader(http.StatusCreated)
+					}
+				})
+			}
 			if tt.tektondir != "" {
 				ghtesthelper.SetupGitTree(t, mux, tt.tektondir, tt.event, false)
 			}
 
-			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+			seedData := testclient.Data{}
+			if tt.seedData != nil {
+				seedData = *tt.seedData
+			}
+			stdata, _ := testclient.SeedTestData(t, ctx, seedData)
 			cs := &params.Run{
 				Clients: clients.Clients{
 					PipelineAsCode: stdata.PipelineAsCode,


### PR DESCRIPTION
## 📝 Description of the Change
When using `/retest` or `/ok-to-test` and all pipelines have already succeeded, the command now shows a helpful message instead of the misleading "could not find any PipelineRun in your .tekton/ directory" error.

**New message:**
> "all PipelineRuns for this commit have already succeeded. Use /retest \<pipeline-name\> to re-run a specific pipeline or /test to re-run all"

This guides users to:
- Use `/retest <pipeline-name>` to re-run a specific pipeline
- Use `/test` to re-run all pipelines

## 👨🏻‍ Linked Jira
[Fixes: SRVKP-10373](https://issues.redhat.com/browse/SRVKP-10373)
<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [x] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
