### PR TITLE
fix(github): support lightweight tags for GitOps commands

### DIFF
--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -662,14 +662,28 @@ func (v *Provider) handleCommitCommentEvent(ctx context.Context, event *github.C
 		if err != nil {
 			return runevent, fmt.Errorf("error getting ref for tag %s: %w", tagName, err)
 		}
-		// get the tag object to get the SHA
-		tag, _, err := wrapAPI(v, "get_tag", func() (*github.Tag, *github.Response, error) {
-			return v.Client().Git.GetTag(ctx, runevent.Organization, runevent.Repository, ref.GetObject().GetSHA())
-		})
-		if err != nil {
-			return runevent, fmt.Errorf("error getting tag %s: %w", tagName, err)
+
+		tagSha := ""
+
+		switch ref.GetObject().GetType() {
+		case "tag":
+			// annotated tag - get the tag object to resolve the commit SHA
+			tag, _, err := wrapAPI(v, "get_tag", func() (*github.Tag, *github.Response, error) {
+				return v.Client().Git.GetTag(ctx, runevent.Organization, runevent.Repository, ref.GetObject().GetSHA())
+			})
+			if err != nil {
+				return runevent, fmt.Errorf("error getting tag %s: %w", tagName, err)
+			}
+			tagSha = tag.GetObject().GetSHA()
+		case "commit":
+			// lightweight tag - ref contains the commit SHA directly.
+			// trying to get the tag object would return an error.
+			tagSha = ref.GetObject().GetSHA()
+		default:
+			return runevent, fmt.Errorf("invalid object type for tag %s: %s", tagName, ref.GetObject().GetType())
 		}
-		if tag.GetObject().GetSHA() != runevent.SHA {
+
+		if tagSha != runevent.SHA {
 			return runevent, fmt.Errorf("provided SHA %s is not the tagged commit for the tag %s", runevent.SHA, tagName)
 		}
 		runevent.HeadBranch = tagPath

--- a/test/github_tag_gitops_test.go
+++ b/test/github_tag_gitops_test.go
@@ -4,132 +4,122 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"path/filepath"
 	"testing"
 
 	"github.com/google/go-github/v81/github"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
 	"github.com/tektoncd/pipeline/pkg/names"
 	"gotest.tools/v3/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGithubGitOpsCommentOnTag(t *testing.T) {
 	ctx := context.Background()
 	ctx, runcnx, opts, ghcnx, err := tgithub.Setup(ctx, false, false)
 	assert.NilError(t, err)
-	tagName := "v1.0.0"
-	comment := "/test tag:" + tagName
-	sha := ""
-	targetBranch := "release-" + tagName
-	label := "Testing GitHub commit comment on tag with GitHub apps integration"
+	var g *tgithub.PRTest
 	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-tag")
-	numberOfPRs := 1
 	repoinfo, resp, err := ghcnx.Client().Repositories.Get(ctx, opts.Organization, opts.Repo)
 	assert.NilError(t, err)
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+		t.Errorf("Repository %s not found in %s", opts.Repo, opts.Organization)
 	}
 	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
 	assert.NilError(t, err)
-
 	runcnx.Clients.Log.Infof("Repository %s has been created successfully", targetNS)
 
-	ref, resp, err := ghcnx.Client().Git.GetRef(ctx, opts.Organization, opts.Repo, "refs/tags/"+tagName)
-	if err != nil && resp.StatusCode == http.StatusNotFound {
-		runcnx.Clients.Log.Infof("Tag %s is not found on the repository", tagName)
-		runcnx.Clients.Log.Infof("Creating tag %s on the repository", tagName)
-		yamlFiles := []string{"testdata/pipelinerun-on-tag.yaml"}
-		yamlEntries := map[string]string{}
-		for _, v := range yamlFiles {
-			yamlEntries[filepath.Join(".tekton", filepath.Base(v))] = v
+	tags := []string{"v1.0.0", "v1.0.0-lightweight"}
+	for _, tag := range tags {
+		comment := "/test tag:" + tag
+		sha := ""
+		targetRefName := "release-" + tag
+		label := ""
+		if tag == "v1.0.0" {
+			label = "Testing GitHub commit comment on tag with GitHub apps integration"
+		} else {
+			label = "Testing GitHub commit comment on lightweight tag with GitHub apps integration"
 		}
 
-		entries, err := payload.GetEntries(yamlEntries,
-			targetNS, "refs/tags/*", "push", map[string]string{})
-		assert.NilError(t, err)
+		numberOfPRs := 1
 
-		targetRefName := targetBranch
-		cloneURL, err := scm.MakeGitCloneURL(repoinfo.GetCloneURL(), "git", *ghcnx.Token)
-		assert.NilError(t, err)
-		scmOpts := scm.Opts{
-			GitURL:        cloneURL,
-			TargetRefName: targetRefName,
-			BaseRefName:   repoinfo.GetDefaultBranch(),
-			WebURL:        repoinfo.GetHTMLURL(),
-			Log:           runcnx.Clients.Log,
-			CommitTitle:   label,
+		ref, resp, err := ghcnx.Client().Git.GetRef(ctx, opts.Organization, opts.Repo, "refs/tags/"+tag)
+		if err != nil && resp.StatusCode == http.StatusNotFound {
+			runcnx.Clients.Log.Infof("Tag %s is not found on the repository", tag)
+			runcnx.Clients.Log.Infof("Creating tag %s on the repository", tag)
+			entries, err := payload.GetEntries(map[string]string{".tekton/pipelinerun-on-tag.yaml": "testdata/pipelinerun-on-tag.yaml"},
+				targetNS, "refs/tags/*", "push", map[string]string{})
+			assert.NilError(t, err)
+
+			cloneURL, err := scm.MakeGitCloneURL(repoinfo.GetCloneURL(), "git", *ghcnx.Token)
+			assert.NilError(t, err)
+			scmOpts := scm.Opts{
+				GitURL:        cloneURL,
+				TargetRefName: targetRefName,
+				BaseRefName:   repoinfo.GetDefaultBranch(),
+				WebURL:        repoinfo.GetHTMLURL(),
+				Log:           runcnx.Clients.Log,
+				CommitTitle:   label,
+			}
+			scm.PushFilesToRefGit(t, &scmOpts, entries)
+			branch, _, err := ghcnx.Client().Repositories.GetBranch(ctx, opts.Organization, opts.Repo, targetRefName, 1)
+			assert.NilError(t, err)
+
+			sha = branch.GetCommit().GetSHA()
+
+			// when we're testing a lightweight tag, we need to set the opts.LightweightTag to true
+			// so that we don't create an annotated tag. on creating lightweight tag, ref contains the commit SHA directly.
+			opts.LightweightTag = tag == "v1.0.0-lightweight"
+			runcnx.Clients.Log.Infof("is Lightweight tag: %t", opts.LightweightTag)
+			_, err = tgithub.CreateTag(ctx, t, runcnx, ghcnx, opts, sha, tag)
+			assert.NilError(t, err)
+			numberOfPRs++
+		} else {
+			// else if tag is already created, we need to get the tag object to get the commit SHA
+			if tag == "v1.0.0" {
+				// if tag is annotated tag, we need to get the tag object to get the commit SHA
+				runcnx.Clients.Log.Infof("Tag %s is already created on the repository", tag)
+				runcnx.Clients.Log.Infof("Getting tag %s", tag)
+				tagRef, _, err := ghcnx.Client().Git.GetTag(ctx, opts.Organization, opts.Repo, ref.GetObject().GetSHA())
+				assert.NilError(t, err)
+				sha = tagRef.GetObject().GetSHA()
+			} else {
+				// else if tag is lightweight tag, we need to get the commit SHA from the ref
+				runcnx.Clients.Log.Infof("Lightweight tag %s is already created on the repository", tag)
+				sha = ref.GetObject().GetSHA()
+			}
 		}
-		scm.PushFilesToRefGit(t, &scmOpts, entries)
-		branch, _, err := ghcnx.Client().Repositories.GetBranch(ctx, opts.Organization, opts.Repo, targetBranch, 1)
+
+		g = &tgithub.PRTest{
+			Label:           label,
+			Cnx:             runcnx,
+			Logger:          runcnx.Clients.Log,
+			Options:         opts,
+			Provider:        ghcnx,
+			TargetNamespace: targetNS,
+			PRNumber:        -1,
+			SHA:             sha,
+		}
+		defer g.TearDown(ctx, t)
+
+		runcnx.Clients.Log.Infof("%s on tag commit", comment)
+		_, _, err = ghcnx.Client().Repositories.CreateComment(ctx,
+			opts.Organization,
+			opts.Repo, sha, // this is the commit sha of the tag v1.0.0
+			&github.RepositoryComment{Body: github.Ptr(comment)})
 		assert.NilError(t, err)
 
-		sha = branch.GetCommit().GetSHA()
-
-		_, err = tgithub.CreateTag(ctx, t, runcnx, ghcnx, opts, sha, tagName)
+		waitOpts := twait.Opts{
+			RepoName:        targetNS,
+			Namespace:       targetNS,
+			MinNumberStatus: numberOfPRs,
+			PollTimeout:     twait.DefaultTimeout,
+			TargetSHA:       sha, // this is the commit sha of the tag v1.0.0
+		}
+		runcnx.Clients.Log.Info("Waiting for PipelineRun to be created")
+		err = twait.UntilPipelineRunCreated(ctx, runcnx.Clients, waitOpts)
 		assert.NilError(t, err)
-		numberOfPRs++
-	} else {
-		runcnx.Clients.Log.Infof("Tag %s is already created on the repository", tagName)
-		runcnx.Clients.Log.Infof("Getting tag %s", tagName)
-		tagRef, _, err := ghcnx.Client().Git.GetTag(ctx, opts.Organization, opts.Repo, ref.GetObject().GetSHA())
-		assert.NilError(t, err)
-		sha = tagRef.GetObject().GetSHA()
-	}
-
-	g := &tgithub.PRTest{
-		Label:           label,
-		Cnx:             runcnx,
-		Logger:          runcnx.Clients.Log,
-		Options:         opts,
-		Provider:        ghcnx,
-		TargetNamespace: targetNS,
-		PRNumber:        -1,
-		SHA:             sha,
-	}
-	defer g.TearDown(ctx, t)
-
-	runcnx.Clients.Log.Infof("%s on tag commit", comment)
-	_, _, err = ghcnx.Client().Repositories.CreateComment(ctx,
-		opts.Organization,
-		opts.Repo, sha, // this is the commit sha of the tag v1.0.0
-		&github.RepositoryComment{Body: github.Ptr(comment)})
-	assert.NilError(t, err)
-
-	waitOpts := twait.Opts{
-		RepoName:        targetNS,
-		Namespace:       targetNS,
-		MinNumberStatus: numberOfPRs,
-		PollTimeout:     twait.DefaultTimeout,
-		TargetSHA:       sha, // this is the commit sha of the tag v1.0.0
-	}
-	runcnx.Clients.Log.Info("Waiting for Repository to be updated")
-	_, err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
-	assert.NilError(t, err)
-
-	runcnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
-	repo, err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
-	assert.NilError(t, err)
-	assert.Equal(t, repo.Status[len(repo.Status)-1].Conditions[0].Status, corev1.ConditionTrue)
-
-	pruns, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", keys.SHA, sha),
-	})
-	assert.NilError(t, err)
-	assert.Equal(t, len(pruns.Items), numberOfPRs)
-
-	for i := range pruns.Items {
-		sData, err := runcnx.Clients.Kube.CoreV1().Secrets(targetNS).Get(ctx, pruns.Items[i].GetAnnotations()[keys.GitAuthSecret], metav1.GetOptions{})
-		assert.NilError(t, err)
-		assert.Assert(t, string(sData.Data["git-provider-token"]) != "")
-		assert.Assert(t, string(sData.Data[".git-credentials"]) != "")
-		assert.Assert(t, string(sData.Data[".gitconfig"]) != "")
 	}
 }

--- a/test/pkg/options/options.go
+++ b/test/pkg/options/options.go
@@ -10,6 +10,7 @@ type E2E struct {
 	Concurrency        int
 	UserName           string
 	Password           string
+	LightweightTag     bool
 	Settings           v1alpha1.Settings
 }
 


### PR DESCRIPTION
When GitOps command `/test` or `/retest` is triggered on a lightweight tag, it was causing an error in ParsePayload because GitHub treats annotated and lightweight tags differently:

- Annotated tags: ref object type is "tag", requires GetTag API call to resolve the commit SHA
- Lightweight tags: ref object type is "commit", the ref already contains the commit SHA directly

The fix uses a switch statement to handle both cases and returns an error for unexpected object types.

Also adds:
- Unit tests for lightweight tag and invalid object type scenarios
- E2E test coverage for both annotated and lightweight tags
- LightweightTag option in test framework

https://issues.redhat.com/browse/SRVKP-10467

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [x] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [x] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
