### PR TITLE
fix: various e2e fixes

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -294,16 +294,16 @@ jobs:
 
       - name: Run gosmee for main controller
         run: |
-          nohup gosmee client --saveDir /tmp/gosmee-replay ${{ secrets.PYSMEE_URL }} "https://${CONTROLLER_DOMAIN_URL}" &
+          nohup gosmee client --saveDir /tmp/gosmee-replay ${{ secrets.PYSMEE_URL }} "https://${CONTROLLER_DOMAIN_URL}" > /tmp/gosmee-main.log 2>&1 &
 
       - name: Run gosmee for main controller (Gitea)
         run: |
-          nohup gosmee client --saveDir /tmp/gosmee-replay ${{ secrets.TEST_GITEA_SMEEURL }} "https://${CONTROLLER_DOMAIN_URL}" &
+          nohup gosmee client --saveDir /tmp/gosmee-replay ${{ secrets.TEST_GITEA_SMEEURL }} "https://${CONTROLLER_DOMAIN_URL}" >> /tmp/gosmee-main.log 2>&1 &
 
       - name: Run gosmee for second controller (GHE)
         if: matrix.provider == 'github_second_controller' || matrix.provider == 'concurrency'
         run: |
-          nohup gosmee client --saveDir /tmp/gosmee-replay-ghe ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }} "https://ghe.paac-127-0-0-1.nip.io" &
+          nohup gosmee client --saveDir /tmp/gosmee-replay-ghe ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }} "https://ghe.paac-127-0-0-1.nip.io" > /tmp/gosmee-ghe.log 2>&1 &
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -78,31 +78,32 @@ get_tests() {
   all_tests=$(grep -hioP '^func[[:space:]]+Test[[:alnum:]_]+' "${testfiles[@]}" | sed -E 's/^func[[:space:]]+//')
 
   case "${target}" in
-    concurrency)
-      printf '%s\n' "${all_tests}" | grep -iP 'Concurrency'
-      ;;
-    github)
-      printf '%s\n' "${all_tests}" | grep -iP 'Github' | grep -ivP 'Concurrency|GithubSecond|SecondController'
-      ;;
-    github_second_controller)
-      printf '%s\n' "${all_tests}" | grep -iP 'GithubSecond|SecondController' | grep -ivP 'Concurrency'
-      ;;
-    gitlab_bitbucket)
-      printf '%s\n' "${all_tests}" | grep -iP 'Gitlab|Bitbucket' | grep -ivP 'Concurrency'
-      ;;
-    gitea_others)
-      printf '%s\n' "${all_tests}" | grep -ivP 'Github|Gitlab|Bitbucket|Concurrency'
-      ;;
-    *)
-      echo "Invalid target: ${target}"
-      echo "supported targets: github, github_second_controller, gitlab_bitbucket, gitea_others, concurrency"
-      ;;
+  concurrency)
+    printf '%s\n' "${all_tests}" | grep -iP 'Concurrency'
+    ;;
+  github)
+    printf '%s\n' "${all_tests}" | grep -iP 'Github' | grep -ivP 'Concurrency|GithubSecond'
+    ;;
+  github_second_controller)
+    printf '%s\n' "${all_tests}" | grep -iP 'GithubSecond' | grep -ivP 'Concurrency'
+    ;;
+  gitlab_bitbucket)
+    printf '%s\n' "${all_tests}" | grep -iP 'Gitlab|Bitbucket' | grep -ivP 'Concurrency'
+    ;;
+  gitea_others)
+    printf '%s\n' "${all_tests}" | grep -ivP 'Github|Gitlab|Bitbucket|Concurrency'
+    ;;
+  *)
+    echo "Invalid target: ${target}"
+    echo "supported targets: github, github_second_controller, gitlab_bitbucket, gitea_others, concurrency"
+    ;;
   esac
 }
 
 run_e2e_tests() {
   set +x
   target="${TEST_PROVIDER}"
+  export PAC_E2E_KEEP_NS=true
 
   mapfile -t tests < <(get_tests "${target}")
   echo "About to run ${#tests[@]} tests: ${tests[*]}"

--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -131,7 +131,13 @@ collect_logs() {
   kubectl logs -n pipelines-as-code -l app.kubernetes.io/part-of=pipelines-as-code \
     --all-containers=true --tail=1000 >/tmp/logs/pac-pods.log
   kind export logs /tmp/logs
-  [[ -d /tmp/gosmee-replay ]] && cp -a /tmp/gosmee-replay /tmp/logs/
+
+  # Collect all gosmee data in organized directory
+  mkdir -p /tmp/logs/gosmee
+  [[ -d /tmp/gosmee-replay ]] && cp -a /tmp/gosmee-replay /tmp/logs/gosmee/replay
+  [[ -d /tmp/gosmee-replay-ghe ]] && cp -a /tmp/gosmee-replay-ghe /tmp/logs/gosmee/replay-ghe
+  [[ -f /tmp/gosmee-main.log ]] && cp /tmp/gosmee-main.log /tmp/logs/gosmee/main.log
+  [[ -f /tmp/gosmee-ghe.log ]] && cp /tmp/gosmee-ghe.log /tmp/logs/gosmee/ghe.log
 
   kubectl get pipelineruns -A -o yaml >/tmp/logs/pac-pipelineruns.yaml
   kubectl get repositories.pipelinesascode.tekton.dev -A -o yaml >/tmp/logs/pac-repositories.yaml

--- a/pkg/sort/pipelinerun.go
+++ b/pkg/sort/pipelinerun.go
@@ -41,5 +41,9 @@ func (prs byStartTime) Less(i, j int) bool {
 	if prs[i].Status.StartTime == nil {
 		return true
 	}
+	// If times are equal, sort by name descending
+	if prs[j].Status.StartTime.Time.Equal(prs[i].Status.StartTime.Time) {
+		return prs[i].GetName() > prs[j].GetName()
+	}
 	return prs[j].Status.StartTime.Before(prs[i].Status.StartTime)
 }

--- a/pkg/sort/pipelinerun_test.go
+++ b/pkg/sort/pipelinerun_test.go
@@ -280,28 +280,16 @@ func TestPipelineRunSortByStartTimeSameTime(t *testing.T) {
 		gotNames[i] = pr.GetName()
 	}
 
-	// Verify that "started-later" comes first (since the sort puts later times first)
-	assert.Equal(t, "started-later", gotNames[0])
-	// Verify that "started-earlier" comes last
-	assert.Equal(t, "started-earlier", gotNames[len(gotNames)-1])
-	// Verify that the three items with same start time are in positions 1-3 (any order)
-	sameTimeNames := gotNames[1:4]
-	expectedSameTime := map[string]bool{
-		"first-same-start":  false,
-		"second-same-start": false,
-		"third-same-start":  false,
+	// With stable sorting by name descending when times are equal:
+	// - "started-later" comes first (later time)
+	// - Same-time items sorted by name descending: third, second, first
+	// - "started-earlier" comes last (earlier time)
+	expectedOrder := []string{
+		"started-later",
+		"third-same-start",
+		"second-same-start",
+		"first-same-start",
+		"started-earlier",
 	}
-	for _, name := range sameTimeNames {
-		if _, exists := expectedSameTime[name]; exists {
-			expectedSameTime[name] = true
-		} else {
-			t.Errorf("Unexpected name %s in same-start-time group", name)
-		}
-	}
-	// Verify all expected names were found
-	for name, found := range expectedSameTime {
-		if !found {
-			t.Errorf("Expected name %s not found in same-start-time group", name)
-		}
-	}
+	assert.DeepEqual(t, expectedOrder, gotNames)
 }

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -43,7 +43,7 @@ func TestGithubPullRequest(t *testing.T) {
 	defer g.TearDown(ctx, t)
 }
 
-func TestGithubPullRequestSecondController(t *testing.T) {
+func TestGithubSecondPullRequest(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label:            "Github Rerequest",

--- a/test/pkg/repository/teardown.go
+++ b/test/pkg/repository/teardown.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -13,7 +14,9 @@ func NSTearDown(ctx context.Context, t *testing.T, runcnx *params.Run, targetNS 
 	runcnx.Clients.Log.Infof("Deleting Repository in %s", targetNS)
 	err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Deleting NS %s", targetNS)
-	err = runcnx.Clients.Kube.CoreV1().Namespaces().Delete(ctx, targetNS, metav1.DeleteOptions{})
-	assert.NilError(t, err)
+	if os.Getenv("PAC_E2E_KEEP_NS") != "true" {
+		runcnx.Clients.Log.Infof("Deleting NS %s", targetNS)
+		err = runcnx.Clients.Kube.CoreV1().Namespaces().Delete(ctx, targetNS, metav1.DeleteOptions{})
+		assert.NilError(t, err)
+	}
 }


### PR DESCRIPTION
This pull request introduces improvements to the CI workflow, test log collection, and sorting logic for PipelineRuns. The most significant changes include enhancing the stability of PipelineRun sorting when start times are equal, improving log organization for easier debugging, and adding more control over test namespace cleanup. Minor updates include test renaming for clarity and environment variable usage for test control.

**PipelineRun Sorting Improvements**
- Added a stable tie-breaker to the `byStartTime` sorting logic in `pkg/sort/pipelinerun.go`, so PipelineRuns with the same start time are now sorted by name in descending order. This ensures consistent and predictable ordering.
- Updated the corresponding test in `pkg/sort/pipelinerun_test.go` to assert the new, deterministic order when start times are equal.

**Test Log Collection and Debugging**
- Enhanced the log collection script in `hack/gh-workflow-ci.sh` to organize all `gosmee` logs and replay data into a dedicated `/tmp/logs/gosmee` directory, making it easier to locate and analyze logs after CI runs.
- Modified the GitHub Actions workflow `.github/workflows/e2e.yaml` to redirect `gosmee` output to log files instead of backgrounding without logs, improving post-mortem debugging capabilities.

**Test Environment Control**
- Added support for the `PAC_E2E_KEEP_NS` environment variable to optionally keep test namespaces after E2E runs, allowing for easier manual inspection when debugging tests. This is set in `hack/gh-workflow-ci.sh` and respected in `test/pkg/repository/teardown.go`. [[1]](diffhunk://#diff-12b1dc56fa23ee45b98d4eaf2f6c65e0d1d3b58b32df30591028945605c11c8fR106) [[2]](diffhunk://#diff-62eb1904bb7070c7572d4a1588bf8fe5c51cda142ab041541a350a3464861d18R17-R22)

**Minor Improvements**
- Renamed a test function in `test/github_pullrequest_test.go` for clarity and consistency.