### PR TITLE
test: statibilize sorting logic and split more e2e gitea

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        provider: [github, github_second_controller, gitlab_bitbucket, gitea_others, concurrency]
+        provider: [github, github_second_controller, gitlab_bitbucket, gitea_1, gitea_2, gitea_3, concurrency]
 
     env:
       CONTROLLER_DOMAIN_URL: paac.paac-127-0-0-1.nip.io

--- a/.tekton/linter.yaml
+++ b/.tekton/linter.yaml
@@ -119,6 +119,11 @@ spec:
                       continue
                     fi
 
+                    # Skip revert commits
+                    if echo "$commit_msg" | grep -E -q '^Revert '; then
+                      echo "  Skipping revert commit: $commit_hash"
+                      continue
+                    fi
                     # Run gitlint check
                     if ! echo "$commit_body" | gitlint --staged; then
                       echo "  Gitlint failed for commit: $commit_hash"

--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -90,12 +90,22 @@ get_tests() {
   gitlab_bitbucket)
     printf '%s\n' "${all_tests}" | grep -iP 'Gitlab|Bitbucket' | grep -ivP 'Concurrency'
     ;;
+  gitea_1)
+    printf '%s\n' "${all_tests}" | grep -iP 'Gitea[A-G]' | grep -ivP 'Concurrency'
+    ;;
+  gitea_2)
+    printf '%s\n' "${all_tests}" | grep -iP 'Gitea[H-P]' | grep -ivP 'Concurrency'
+    ;;
+  gitea_3)
+    printf '%s\n' "${all_tests}" | grep -iP 'Gitea[Q-Z]' | grep -ivP 'Concurrency'
+    ;;
   gitea_others)
+    # Deprecated: Use gitea_1, gitea_2, gitea_3 instead
     printf '%s\n' "${all_tests}" | grep -ivP 'Github|Gitlab|Bitbucket|Concurrency'
     ;;
   *)
     echo "Invalid target: ${target}"
-    echo "supported targets: github, github_second_controller, gitlab_bitbucket, gitea_others, concurrency"
+    echo "supported targets: github, github_second_controller, gitlab_bitbucket, gitea_1, gitea_2, gitea_3, concurrency"
     ;;
   esac
 }

--- a/pkg/sort/task_log_snippets.go
+++ b/pkg/sort/task_log_snippets.go
@@ -15,6 +15,9 @@ func (s taskInfoSorter) Swap(i, j int) {
 }
 
 func (s taskInfoSorter) Less(i, j int) bool {
+	if s[i].CompletionTime.Equal(s[j].CompletionTime) {
+		return s[i].Name < s[j].Name
+	}
 	return s[i].CompletionTime.Before(s[j].CompletionTime)
 }
 

--- a/pkg/sort/task_log_snippets_test.go
+++ b/pkg/sort/task_log_snippets_test.go
@@ -38,6 +38,26 @@ func TestTaskInfos(t *testing.T) {
 			},
 			want: "before",
 		},
+		{
+			name: "same completion time sorts by name",
+			args: args{
+				taskinfos: map[string]pacv1alpha1.TaskInfos{
+					"task-zebra": {
+						Name: "zebra",
+						CompletionTime: &metav1.Time{
+							Time: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+						},
+					},
+					"task-alpha": {
+						Name: "alpha",
+						CompletionTime: &metav1.Time{
+							Time: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			want: "alpha",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/sort/task_status.go
+++ b/pkg/sort/task_status.go
@@ -38,6 +38,9 @@ func (trs taskrunList) Less(i, j int) bool {
 		return true
 	}
 
+	if trs[i].Status.StartTime.Equal(trs[j].Status.StartTime) {
+		return trs[i].PipelineTaskName > trs[j].PipelineTaskName
+	}
 	return trs[j].Status.StartTime.Before(trs[i].Status.StartTime)
 }
 


### PR DESCRIPTION
## 📝 Description of the Change

The sorting logic for task logs and status did not have a stable
tie-breaker when completion or start times were identical. This resulted
in inconsistent sorting order for tasks with the same timestamp.

The `taskInfoSorter.Less` function was updated to sort by task name
alphabetically when `CompletionTime` is the same.
The `taskrunList.Less` function was updated to sort by
`PipelineTaskName` in reverse alphabetical order when `StartTime` is the
same. This ensures a consistent and predictable sorting order in all
scenarios.

test: Split Gitea e2e tests into multiple configurations

The continuous integration workflow was updated to include three split
configurations for Gitea testing. This allows for more granular testing
of different Gitea setups. The `gitea_others` configuration has been
marked as deprecated in favor of the new specific configurations.

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [x] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [x] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
