### PR TITLE
fix: set PipelineURL for cached pipelines to resolve relative task paths

### DIFF
--- a/pkg/resolve/remote.go
+++ b/pkg/resolve/remote.go
@@ -120,9 +120,9 @@ func resolveRemoteResources(ctx context.Context, rt *matcher.RemoteTasks, types 
 					}
 					// add the pipeline to the Resources fetched for the Event
 					fetchedResourcesForEvent.Pipelines[remotePipeline] = pipeline
-					// add the pipeline URL to the run specific Resources
-					fetchedResourcesForPipelineRun.PipelineURL = remotePipeline
 				}
+				// set the pipeline URL for relative task path resolution (used by both cached and newly fetched)
+				fetchedResourcesForPipelineRun.PipelineURL = remotePipeline
 			}
 		}
 		pipelineTasks := []string{}

--- a/pkg/resolve/remote_test.go
+++ b/pkg/resolve/remote_test.go
@@ -245,6 +245,53 @@ func TestRemote(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple pipelineruns sharing same remote pipeline with relative tasks, pipeline and tasks all resolve",
+			pipelineruns: []*tektonv1.PipelineRun{
+				ttkn.MakePR(randomPipelineRunName, map[string]string{
+					apipac.Pipeline: remotePipelineURL,
+				},
+					tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{
+							Name: remotePipelineName,
+						},
+					},
+				),
+				ttkn.MakePR(randomPipelineRunName+"-second", map[string]string{
+					apipac.Pipeline: remotePipelineURL, // SAME URL as first PipelineRun
+				},
+					tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{
+							Name: remotePipelineName,
+						},
+					},
+				),
+			},
+			remoteURLS: map[string]map[string]string{
+				remotePipelineURL: {
+					"body": string(pipelineWithRelativeTaskRefYamlB),
+					"code": "200",
+				},
+				remoteTaskURL + "-a": {
+					"body": string(singleRelativeTaskBa),
+					"code": "200",
+				},
+				remoteTaskURL + "-b": {
+					"body": string(singleRelativeTaskBb),
+					"code": "200",
+				},
+				remoteTaskURL + "-c": {
+					"body": string(singleRelativeTaskBc),
+					"code": "200",
+				},
+			},
+			expectedTaskSpec:     taskFromPipelineSpec,
+			expectedLogsSnippets: []string{},
+			expectedPipelineRun: []string{
+				"remote-pipeline-with-relative-tasks.yaml",
+				"remote-pipeline-with-relative-tasks-same-pipeline.yaml",
+			},
+		},
+		{
 			name: "remote pipeline with remote task in pipeline overridden from pipelinerun",
 			pipelineruns: []*tektonv1.PipelineRun{
 				ttkn.MakePR(randomPipelineRunName, map[string]string{

--- a/pkg/resolve/testdata/remote-pipeline-with-relative-tasks-same-pipeline.yaml
+++ b/pkg/resolve/testdata/remote-pipeline-with-relative-tasks-same-pipeline.yaml
@@ -1,0 +1,31 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/pipeline: http://remote/remote-pipeline
+  generateName: pipelinerun-abc-second-
+spec:
+  pipelineSpec:
+    tasks:
+    - name: remote-task-a
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    - name: remote-task-b
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    - name: remote-task-c
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    finally: []


### PR DESCRIPTION
## 📝 Description of the Change
When multiple PipelineRuns reference the same remote pipeline with relative task paths, the second PipelineRun fails because the PipelineURL is not set when retrieving the pipeline from cache.

This causes assembleTaskFQDNs to receive an empty PipelineURL, which returns relative paths unchanged (e.g., '../../common/tasks/hello.yaml'). The go-github library then rejects these paths with 'path must not contain ..' error.

The fix sets PipelineURL when using cached pipelines, ensuring relative task paths are resolved correctly for all PipelineRuns.

Fixes: SRVKP-10604

## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-10604
<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
