### PR TITLE
fix: Enforce webhook signature for Forgejo

### DIFF
--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -625,7 +625,7 @@ func TestGiteaWithCLI(t *testing.T) {
 
 	output, err = tknpactest.ExecCommand(topts.ParamsRun, tknpacdelete.Root, "-n", topts.TargetNS, "repository", topts.TargetNS, "--cascade")
 	assert.NilError(t, err)
-	expectedOutput := fmt.Sprintf("secret %s has been deleted\nrepository %s has been deleted\n", topts.TargetNS, topts.TargetNS)
+	expectedOutput := fmt.Sprintf("secret %s has been deleted\nsecret webhook-secret has been deleted\nrepository %s has been deleted\n", topts.TargetNS, topts.TargetNS)
 	assert.Assert(t, output == expectedOutput, topts.TargetRefName, fmt.Sprintf("delete command should have this output: %s received: %s", expectedOutput, output))
 }
 

--- a/test/pkg/gitea/scm.go
+++ b/test/pkg/gitea/scm.go
@@ -106,7 +106,7 @@ func GetIssueTimeline(ctx context.Context, topts *TestOpts) (Timelines, error) {
 	return tls, nil
 }
 
-func CreateGiteaRepo(giteaClient *forgejo.Client, user, name, defaultBranch, hookURL string, onOrg bool, logger *zap.SugaredLogger) (*forgejo.Repository, error) {
+func CreateGiteaRepo(giteaClient *forgejo.Client, user, name, defaultBranch, hookURL, webhookSecret string, onOrg bool, logger *zap.SugaredLogger) (*forgejo.Repository, error) {
 	var repo *forgejo.Repository
 	var err error
 	// Create a new repo
@@ -149,6 +149,7 @@ func CreateGiteaRepo(giteaClient *forgejo.Client, user, name, defaultBranch, hoo
 			"name":         "hook to smee url",
 			"url":          hookURL,
 			"content_type": "json",
+			"secret":       webhookSecret,
 		},
 		Events: []string{"push", "issue_comments", "pull_request"},
 	})

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -155,7 +155,11 @@ func TestPR(t *testing.T, topts *TestOpts) (context.Context, func()) {
 		topts.DefaultBranch = options.MainBranch
 	}
 
-	repoInfo, err := CreateGiteaRepo(topts.GiteaCNX.Client(), topts.Opts.Organization, topts.TargetRepoName, topts.DefaultBranch, hookURL, topts.OnOrg, topts.ParamsRun.Clients.Log)
+	webhookSecret := os.Getenv("TEST_EL_WEBHOOK_SECRET")
+	repoInfo, err := CreateGiteaRepo(topts.GiteaCNX.Client(), topts.Opts.Organization,
+		topts.TargetRepoName, topts.DefaultBranch, hookURL,
+		webhookSecret, topts.OnOrg,
+		topts.ParamsRun.Clients.Log)
 	assert.NilError(t, err)
 	topts.Opts.Repo = repoInfo.Name
 	topts.Opts.Organization = repoInfo.Owner.UserName


### PR DESCRIPTION
### **Auto-created Ticket**

[#2422](https://github.com/openshift-pipelines/pipelines-as-code/issues/2422)

Implemented signature validation for Gitea and Forgejo webhooks to ensure the authenticity of incoming requests. This involves checking the `X-Forgejo-Signature` and `X-Gitea-Signature` headers against a computed HMAC-SHA256 hash of the request payload using a configured webhook secret.

The validation enforce that only requests originating from a trusted source with the correct secret are processed, enhancing the security of webhook integrations. This change also includes necessary test cases to verify the correct functioning of the validation logic.
This is not a breaking change, since user were not supposed to use gitea other than for local testing before 🙃 

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

Jira: https://issues.redhat.com/browse/SRVKP-10609

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [X] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [X] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my co
...(truncated)