### PR TITLE
feat: Implement GraphQL batch fetching for .tekton files

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -65,6 +65,7 @@ type Provider struct {
 	commitInfo         *github.Commit
 	pacUserLogin       string // user/bot login used by PAC
 	clock              clockwork.Clock
+	graphQLClient      *graphQLClient
 }
 
 type skippedRun struct {
@@ -351,8 +352,17 @@ func (v *Provider) GetTektonDir(ctx context.Context, runevent *info.Event, path,
 	// default set provenance from the SHA
 	revision := runevent.SHA
 	if provenance == "default_branch" {
-		revision = runevent.DefaultBranch
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", runevent.DefaultBranch)
+		branch, _, err := wrapAPI(v, "get_default_branch", func() (*github.Branch, *github.Response, error) {
+			return v.Client().Repositories.GetBranch(ctx, runevent.Organization, runevent.Repository, runevent.DefaultBranch, 1)
+		})
+		if err != nil {
+			return "", err
+		}
+		revision = branch.GetCommit().GetSHA()
+		if revision == "" {
+			return "", fmt.Errorf("default_branch %s did not resolve to a commit SHA", runevent.DefaultBranch)
+		}
 	} else {
 		prInfo := ""
 		if runevent.TriggerTarget == triggertype.PullRequest {
@@ -392,7 +402,7 @@ func (v *Provider) GetTektonDir(ctx context.Context, runevent *info.Event, path,
 	if err != nil {
 		return "", err
 	}
-	return v.concatAllYamlFiles(ctx, tektonDirObjects.Entries, runevent)
+	return v.concatAllYamlFiles(ctx, tektonDirObjects.Entries, runevent, path, revision)
 }
 
 // GetCommitInfo get info (url and title) on a commit in runevent, this needs to
@@ -486,26 +496,55 @@ func (v *Provider) GetFileInsideRepo(ctx context.Context, runevent *info.Event, 
 }
 
 // concatAllYamlFiles concat all yaml files from a directory as one big multi document yaml string.
-func (v *Provider) concatAllYamlFiles(ctx context.Context, objects []*github.TreeEntry, runevent *info.Event) (string, error) {
-	var allTemplates string
-
+func (v *Provider) concatAllYamlFiles(ctx context.Context, objects []*github.TreeEntry, runevent *info.Event, tektonDirPath, ref string) (string, error) {
+	var yamlFiles []string
 	for _, value := range objects {
 		if strings.HasSuffix(value.GetPath(), ".yaml") ||
 			strings.HasSuffix(value.GetPath(), ".yml") {
-			data, err := v.getObject(ctx, value.GetSHA(), runevent)
-			if err != nil {
-				return "", err
-			}
-			if err := provider.ValidateYaml(data, value.GetPath()); err != nil {
-				return "", err
-			}
-			if allTemplates != "" && !strings.HasPrefix(string(data), "---") {
-				allTemplates += "---"
-			}
-			allTemplates += "\n" + string(data) + "\n"
+			fullPath := tektonDirPath + "/" + value.GetPath()
+			yamlFiles = append(yamlFiles, fullPath)
 		}
 	}
-	return allTemplates, nil
+
+	if len(yamlFiles) == 0 {
+		return "", nil
+	}
+
+	if v.graphQLClient == nil {
+		var err error
+		v.graphQLClient, err = newGraphQLClient(v)
+		if err != nil {
+			return "", fmt.Errorf("failed to create GraphQL client: %w", err)
+		}
+	}
+
+	graphQLResults, err := v.graphQLClient.fetchFiles(ctx, runevent.Organization, runevent.Repository, ref, yamlFiles)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch .tekton files via GraphQL: %w", err)
+	}
+
+	var buf strings.Builder
+	for _, path := range yamlFiles {
+		content, ok := graphQLResults[path]
+		if !ok {
+			return "", fmt.Errorf("file %s not found in GraphQL response", path)
+		}
+
+		// it used to be like that (stripped prefix) before we moved to GraphQL so
+		// let's keep it that way.
+		relativePath := strings.TrimPrefix(path, tektonDirPath+"/")
+		if err := provider.ValidateYaml(content, relativePath); err != nil {
+			return "", err
+		}
+		if buf.Len() > 0 && !strings.HasPrefix(string(content), "---") {
+			buf.WriteString("---")
+		}
+		buf.WriteString("\n")
+		buf.Write(content)
+		buf.WriteString("\n")
+	}
+
+	return buf.String(), nil
 }
 
 // getPullRequest get a pull request details.

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -254,8 +254,8 @@ func TestGetTektonDir(t *testing.T) {
 			filterMessageSnippet: "Using PipelineRun definition from source pull_request tekton/cat#0",
 			// 1. Get Repo root objects
 			// 2. Get Tekton Dir objects
-			// 3/4. Get object content for each object (pipelinerun.yaml, pipeline.yaml)
-			expectedGHApiCalls: 4,
+			// 3. GraphQL batch fetch for 2 files (replaces 2 REST calls)
+			expectedGHApiCalls: 3,
 		},
 		{
 			name: "test no subtree on push",
@@ -270,8 +270,8 @@ func TestGetTektonDir(t *testing.T) {
 			filterMessageSnippet: "Using PipelineRun definition from source push",
 			// 1. Get Repo root objects
 			// 2. Get Tekton Dir objects
-			// 3/4. Get object content for each object (pipelinerun.yaml, pipeline.yaml)
-			expectedGHApiCalls: 4,
+			// 3. GraphQL batch fetch for 2 files (replaces 2 REST calls)
+			expectedGHApiCalls: 3,
 		},
 		{
 			name: "test provenance default_branch ",
@@ -284,9 +284,10 @@ func TestGetTektonDir(t *testing.T) {
 			treepath:             "testdata/tree/defaultbranch",
 			provenance:           "default_branch",
 			filterMessageSnippet: "Using PipelineRun definition from default_branch: main",
-			// 1. Get Repo root objects
-			// 2. Get Tekton Dir objects
-			// 3/4. Get object content for each object (pipelinerun.yaml, pipeline.yaml)
+			// 1. Resolve default branch to a commit SHA
+			// 2. Get Repo root objects
+			// 3. Get Tekton Dir objects
+			// 4. GraphQL batch fetch for 2 files
 			expectedGHApiCalls: 4,
 		},
 		{
@@ -365,11 +366,21 @@ func TestGetTektonDir(t *testing.T) {
 				Logger:       fakelogger,
 			}
 
+			shaDir := fmt.Sprintf("%x", sha256.Sum256([]byte(tt.treepath)))
+			tt.event.SHA = shaDir
 			if tt.provenance == "default_branch" {
-				tt.event.SHA = tt.event.DefaultBranch
-			} else {
-				shaDir := fmt.Sprintf("%x", sha256.Sum256([]byte(tt.treepath)))
-				tt.event.SHA = shaDir
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/branches/%s",
+					tt.event.Organization, tt.event.Repository, tt.event.DefaultBranch),
+					func(rw http.ResponseWriter, _ *http.Request) {
+						branch := &github.Branch{
+							Name: github.Ptr(tt.event.DefaultBranch),
+							Commit: &github.RepositoryCommit{
+								SHA: github.Ptr(shaDir),
+							},
+						}
+						b, _ := json.Marshal(branch)
+						fmt.Fprint(rw, string(b))
+					})
 			}
 			ghtesthelper.SetupGitTree(t, mux, tt.treepath, tt.event, false)
 
@@ -404,6 +415,232 @@ func TestGetTektonDir(t *testing.T) {
 				gotcha := exporter.FilterMessageSnippet(tt.filterMessageSnippet)
 				assert.Assert(t, gotcha.Len() > 0, "expected to find %s in logs, found %v", tt.filterMessageSnippet, exporter.All())
 			}
+		})
+	}
+}
+
+func TestGetTektonDirGraphQL(t *testing.T) {
+	tests := []struct {
+		name             string
+		event            *info.Event
+		treepath         string
+		provenance       string
+		setup            func(t *testing.T, mux *http.ServeMux, event *info.Event)
+		wantErr          string
+		wantLogSnippet   string
+		expectedAPICount int64
+		skipSetupGitTree bool
+	}{
+		{
+			name: "graphql batch fetch reduces api calls",
+			event: &info.Event{
+				Organization:  "tekton",
+				Repository:    "cat",
+				TriggerTarget: triggertype.PullRequest,
+			},
+			treepath:         "testdata/tree/simple",
+			wantLogSnippet:   "GraphQL batch fetch",
+			expectedAPICount: 3,
+		},
+		{
+			name: "graphql error handling",
+			event: &info.Event{
+				Organization:  "tekton",
+				Repository:    "cat",
+				TriggerTarget: triggertype.PullRequest,
+			},
+			skipSetupGitTree: true,
+			setup: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				shaDir := fmt.Sprintf("%x", sha256.Sum256([]byte("testdata/tree/simple")))
+				event.SHA = shaDir
+
+				// Setup tree endpoints manually
+				mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/git/trees/%v", event.Organization, event.Repository, event.SHA),
+					func(rw http.ResponseWriter, _ *http.Request) {
+						tree := &github.Tree{
+							SHA: &event.SHA,
+							Entries: []*github.TreeEntry{
+								{
+									Path: github.Ptr(".tekton"),
+									Type: github.Ptr("tree"),
+									SHA:  github.Ptr("tektondirsha"),
+								},
+							},
+						}
+						b, _ := json.Marshal(tree)
+						fmt.Fprint(rw, string(b))
+					})
+
+				// Set up .tekton directory tree
+				tektonDirSha := "tektondirsha"
+				mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/git/trees/%v", event.Organization, event.Repository, tektonDirSha),
+					func(rw http.ResponseWriter, _ *http.Request) {
+						tree := &github.Tree{
+							SHA: &tektonDirSha,
+							Entries: []*github.TreeEntry{
+								{
+									Path: github.Ptr("pipeline.yaml"),
+									Type: github.Ptr("blob"),
+									SHA:  github.Ptr("pipelinesha"),
+								},
+								{
+									Path: github.Ptr("pipelinerun.yaml"),
+									Type: github.Ptr("blob"),
+									SHA:  github.Ptr("pipelinerunsha"),
+								},
+							},
+						}
+						b, _ := json.Marshal(tree)
+						fmt.Fprint(rw, string(b))
+					})
+
+				// Error handler for /api/graphql
+				mux.HandleFunc("/api/graphql", func(w http.ResponseWriter, _ *http.Request) {
+					http.Error(w, "GraphQL endpoint not available", http.StatusNotFound)
+				})
+			},
+			wantErr: "failed to fetch .tekton files via GraphQL",
+		},
+		{
+			name: "default branch uses resolved sha for graphql",
+			event: &info.Event{
+				Organization:  "tekton",
+				Repository:    "cat",
+				DefaultBranch: "main",
+			},
+			provenance:       "default_branch",
+			skipSetupGitTree: true,
+			setup: func(t *testing.T, mux *http.ServeMux, _ *info.Event) {
+				t.Helper()
+				resolvedSHA := "resolved-default-branch-sha"
+				tektonDirSHA := "tektondirsha"
+
+				mux.HandleFunc("/repos/tekton/cat/branches/main", func(rw http.ResponseWriter, _ *http.Request) {
+					branch := &github.Branch{
+						Name: github.Ptr("main"),
+						Commit: &github.RepositoryCommit{
+							SHA: github.Ptr(resolvedSHA),
+						},
+					}
+					b, _ := json.Marshal(branch)
+					fmt.Fprint(rw, string(b))
+				})
+				mux.HandleFunc("/repos/tekton/cat/git/trees/"+resolvedSHA, func(rw http.ResponseWriter, _ *http.Request) {
+					tree := &github.Tree{
+						SHA: github.Ptr(resolvedSHA),
+						Entries: []*github.TreeEntry{
+							{
+								Path: github.Ptr(".tekton"),
+								Type: github.Ptr("tree"),
+								SHA:  github.Ptr(tektonDirSHA),
+							},
+						},
+					}
+					b, _ := json.Marshal(tree)
+					fmt.Fprint(rw, string(b))
+				})
+				mux.HandleFunc("/repos/tekton/cat/git/trees/"+tektonDirSHA, func(rw http.ResponseWriter, _ *http.Request) {
+					tree := &github.Tree{
+						SHA: github.Ptr(tektonDirSHA),
+						Entries: []*github.TreeEntry{
+							{
+								Path: github.Ptr("pipeline.yaml"),
+								Type: github.Ptr("blob"),
+								SHA:  github.Ptr("pipeline-sha"),
+							},
+							{
+								Path: github.Ptr("pipelinerun.yaml"),
+								Type: github.Ptr("blob"),
+								SHA:  github.Ptr("pipelinerun-sha"),
+							},
+						},
+					}
+					b, _ := json.Marshal(tree)
+					fmt.Fprint(rw, string(b))
+				})
+				mux.HandleFunc("/api/graphql", func(w http.ResponseWriter, r *http.Request) {
+					var graphQLReq struct {
+						Query string `json:"query"`
+					}
+					assert.NilError(t, json.NewDecoder(r.Body).Decode(&graphQLReq))
+					assert.Assert(t, strings.Contains(graphQLReq.Query, resolvedSHA+":.tekton/pipeline.yaml"), graphQLReq.Query)
+					assert.Assert(t, !strings.Contains(graphQLReq.Query, `main:.tekton/pipeline.yaml`), graphQLReq.Query)
+
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"data": map[string]any{
+							"repository": map[string]any{
+								"file0": map[string]any{"text": "kind: Pipeline\nmetadata:\n  name: pipeline\n"},
+								"file1": map[string]any{"text": "kind: PipelineRun\nmetadata:\n  name: run\n"},
+							},
+						},
+					})
+				})
+			},
+			expectedAPICount: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Common setup
+			prmetrics.ResetRecorder()
+			reader := sdkmetric.NewManualReader()
+			provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			otel.SetMeterProvider(provider)
+
+			observer, exporter := zapobserver.New(zap.DebugLevel)
+			fakelogger := zap.New(observer).Sugar()
+			ctx, _ := rtesting.SetupFakeContext(t)
+			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+
+			gvcs := Provider{
+				ghClient:     fakeclient,
+				providerName: "github",
+				Logger:       fakelogger,
+			}
+
+			// Custom setup if provided
+			if tt.setup != nil {
+				tt.setup(t, mux, tt.event)
+			}
+
+			// Standard tree setup unless skipped
+			if !tt.skipSetupGitTree && tt.treepath != "" {
+				shaDir := fmt.Sprintf("%x", sha256.Sum256([]byte(tt.treepath)))
+				tt.event.SHA = shaDir
+				ghtesthelper.SetupGitTree(t, mux, tt.treepath, tt.event, false)
+			}
+
+			// Execute test
+			got, err := gvcs.GetTektonDir(ctx, tt.event, ".tekton", tt.provenance)
+
+			// Validate error
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+
+			// Validate logs if specified
+			if tt.wantLogSnippet != "" {
+				logs := exporter.FilterMessageSnippet(tt.wantLogSnippet)
+				assert.Assert(t, logs.Len() > 0, "expected log message: %s", tt.wantLogSnippet)
+			}
+
+			// Validate metrics if specified
+			if tt.expectedAPICount > 0 {
+				var rm metricdata.ResourceMetrics
+				err = reader.Collect(ctx, &rm)
+				assert.NilError(t, err)
+				count, ok := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64])
+				assert.Assert(t, ok)
+				assert.Equal(t, count.DataPoints[0].Value, tt.expectedAPICount)
+			}
+
+			// Validate content
+			assert.Assert(t, len(got) > 0, "expected non-empty GetTektonDir output")
 		})
 	}
 }

--- a/pkg/provider/github/graphql.go
+++ b/pkg/provider/github/graphql.go
@@ -1,0 +1,274 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	providerMetrics "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/providermetrics"
+	"go.uber.org/zap"
+)
+
+// graphQLClient handles GraphQL API requests for fetching file contents.
+type graphQLClient struct {
+	httpClient   *http.Client
+	ghClient     *github.Client
+	endpoint     string
+	logger       *zap.SugaredLogger
+	provider     *Provider
+	triggerEvent string
+	repo         *v1alpha1.Repository
+}
+
+// newGraphQLClient creates a new GraphQL client from a GitHub provider.
+func newGraphQLClient(p *Provider) (*graphQLClient, error) {
+	httpClient := p.Client().Client()
+	if httpClient == nil {
+		return nil, fmt.Errorf("GitHub client HTTP client is nil")
+	}
+
+	endpoint, err := buildGraphQLEndpoint(p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build GraphQL endpoint: %w", err)
+	}
+
+	return &graphQLClient{
+		httpClient:   httpClient,
+		ghClient:     p.Client(),
+		endpoint:     endpoint,
+		logger:       p.Logger,
+		provider:     p,
+		triggerEvent: p.triggerEvent,
+		repo:         p.repo,
+	}, nil
+}
+
+// buildGraphQLEndpoint constructs the GraphQL API endpoint URL from the GitHub client's BaseURL.
+func buildGraphQLEndpoint(p *Provider) (string, error) {
+	baseURL := p.Client().BaseURL.String()
+	baseURL = strings.TrimSuffix(baseURL, "/")
+
+	// For GitHub.com, use standard GraphQL endpoint
+	// apiPublicURL has a trailing slash which TrimSuffix above removes,
+	// so compare directly with the slash-less form.
+	if baseURL == "https://api.github.com" {
+		return "https://api.github.com/graphql", nil
+	}
+
+	// For GHE and test servers, construct GraphQL endpoint from the base URL
+	// BaseURL could be:
+	//   - https://ghe.example.com/api/v3/ -> https://ghe.example.com/api/graphql
+	//   - http://127.0.0.1:PORT/api/v3/ -> http://127.0.0.1:PORT/api/graphql
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse BaseURL: %w", err)
+	}
+
+	// Replace /api/v3 with /api/graphql in the path
+	path := parsedURL.Path
+	if strings.HasSuffix(path, "/api/v3") || strings.HasSuffix(path, "/api/v3/") {
+		path = strings.TrimSuffix(path, "/api/v3/")
+		path = strings.TrimSuffix(path, "/api/v3")
+		path += "/api/graphql"
+	} else {
+		// Fallback: just use the host with /api/graphql
+		path = "/api/graphql"
+	}
+
+	parsedURL.Path = path
+	return parsedURL.String(), nil
+}
+
+// buildGraphQLQuery constructs a GraphQL query string with aliases for batch fetching multiple files.
+func buildGraphQLQuery(ref string, paths []string) string {
+	// Escape ref for GraphQL string (escape quotes and backslashes)
+	escapedRef := strings.ReplaceAll(ref, `\`, `\\`)
+	escapedRef = strings.ReplaceAll(escapedRef, `"`, `\"`)
+
+	aliases := make([]string, 0, len(paths))
+	for i, path := range paths {
+		// Escape path for GraphQL string (escape quotes and backslashes)
+		escapedPath := strings.ReplaceAll(path, `\`, `\\`)
+		escapedPath = strings.ReplaceAll(escapedPath, `"`, `\"`)
+		aliases = append(aliases, fmt.Sprintf(`    file%d: object(expression: "%s:%s") {
+      ... on Blob {
+        text
+      }
+    }`, i, escapedRef, escapedPath))
+	}
+
+	query := fmt.Sprintf(`query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+%s
+  }
+}`, strings.Join(aliases, "\n"))
+
+	return query
+}
+
+// graphQLResponse represents the structure of a GraphQL API response.
+type graphQLResponse struct {
+	Data struct {
+		Repository map[string]struct {
+			Text *string `json:"text"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors,omitempty"`
+}
+
+type rateLimitHeaders struct {
+	limit     string
+	remaining string
+	reset     string
+}
+
+func getRateLimitHeaders(header http.Header) rateLimitHeaders {
+	return rateLimitHeaders{
+		limit:     header.Get("X-RateLimit-Limit"),
+		remaining: header.Get("X-RateLimit-Remaining"),
+		reset:     header.Get("X-RateLimit-Reset"),
+	}
+}
+
+// fetchFiles fetches multiple file contents using GraphQL batch queries.
+// Returns a map of path -> content.
+func (c *graphQLClient) fetchFiles(ctx context.Context, owner, repo, ref string, paths []string) (map[string][]byte, error) {
+	if len(paths) == 0 {
+		return make(map[string][]byte), nil
+	}
+
+	// Limit batch size to avoid query complexity issues
+	const maxBatchSize = 50
+	result := make(map[string][]byte, len(paths))
+	for start := 0; start < len(paths); start += maxBatchSize {
+		end := min(start+maxBatchSize, len(paths))
+		batch := paths[start:end]
+		batchResult, err := c.fetchFilesBatch(ctx, owner, repo, ref, batch)
+		if err != nil {
+			return nil, err
+		}
+		maps.Copy(result, batchResult)
+	}
+
+	return result, nil
+}
+
+// fetchFilesBatch fetches multiple file contents in a single GraphQL query.
+// Returns a map of path -> content.
+func (c *graphQLClient) fetchFilesBatch(ctx context.Context, owner, repo, ref string, paths []string) (map[string][]byte, error) {
+	if len(paths) == 0 {
+		return make(map[string][]byte), nil
+	}
+
+	query := buildGraphQLQuery(ref, paths)
+	variables := map[string]any{
+		"owner": owner,
+		"name":  repo,
+	}
+
+	requestBody := map[string]any{
+		"query":     query,
+		"variables": variables,
+	}
+
+	req, err := c.ghClient.NewRequest(http.MethodPost, c.endpoint, requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GraphQL request: %w", err)
+	}
+	req = req.WithContext(ctx)
+
+	// Record metrics for GraphQL API call
+	if c.logger != nil {
+		providerMetrics.RecordAPIUsage(c.logger, c.provider.providerName, c.triggerEvent, c.repo)
+	}
+
+	start := time.Now()
+	resp, err := c.httpClient.Do(req)
+	duration := time.Since(start)
+
+	if err != nil {
+		if c.logger != nil {
+			c.logger.Debugw("GraphQL request failed",
+				"error", err.Error(),
+				"duration_ms", duration.Milliseconds(),
+			)
+		}
+		return nil, fmt.Errorf("GraphQL request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	rateLimit := getRateLimitHeaders(resp.Header)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read GraphQL response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if c.logger != nil {
+			c.logger.Debugw("GraphQL request returned non-200 status",
+				"status_code", resp.StatusCode,
+				"response", string(body),
+				"rate_limit", rateLimit.limit,
+				"rate_limit_remaining", rateLimit.remaining,
+				"rate_limit_reset", rateLimit.reset,
+			)
+		}
+		return nil, fmt.Errorf("GraphQL request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var graphQLResp graphQLResponse
+	if err := json.Unmarshal(body, &graphQLResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal GraphQL response: %w", err)
+	}
+
+	if len(graphQLResp.Errors) > 0 {
+		errorMsgs := make([]string, len(graphQLResp.Errors))
+		for i, e := range graphQLResp.Errors {
+			errorMsgs[i] = e.Message
+		}
+		if c.logger != nil {
+			c.logger.Debugw("GraphQL returned errors",
+				"errors", strings.Join(errorMsgs, "; "),
+			)
+		}
+		return nil, fmt.Errorf("GraphQL errors: %s", strings.Join(errorMsgs, "; "))
+	}
+
+	result := make(map[string][]byte, len(paths))
+	for i, path := range paths {
+		alias := fmt.Sprintf("file%d", i)
+		blobData, ok := graphQLResp.Data.Repository[alias]
+		if !ok {
+			return nil, fmt.Errorf("file %s (alias %s) not found in GraphQL response", path, alias)
+		}
+
+		if blobData.Text == nil {
+			return nil, fmt.Errorf("file %s returned null content (may be binary)", path)
+		}
+
+		result[path] = []byte(*blobData.Text)
+	}
+
+	if c.logger != nil {
+		c.logger.Debugw("GraphQL batch fetch completed",
+			"files_requested", len(paths),
+			"duration_ms", duration.Milliseconds(),
+			"rate_limit", rateLimit.limit,
+			"rate_limit_remaining", rateLimit.remaining,
+			"rate_limit_reset", rateLimit.reset,
+		)
+	}
+
+	return result, nil
+}

--- a/pkg/provider/github/graphql_test.go
+++ b/pkg/provider/github/graphql_test.go
@@ -1,0 +1,241 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestProvider(baseURL string) (*Provider, *zapobserver.ObservedLogs) {
+	client := github.NewClient(nil)
+	parsed, _ := url.Parse(baseURL)
+	client.BaseURL = parsed
+
+	core, observedLogs := zapobserver.New(zap.DebugLevel)
+	logger := zap.New(core).Sugar()
+
+	return &Provider{
+		ghClient:     client,
+		Logger:       logger,
+		providerName: "github",
+		triggerEvent: "push",
+		repo: &v1alpha1.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-ns",
+				Name:      "test-repo",
+			},
+		},
+	}, observedLogs
+}
+
+func newTestGraphQLClient(t *testing.T, baseURL string) (*graphQLClient, *zapobserver.ObservedLogs) {
+	t.Helper()
+	provider, observedLogs := newTestProvider(baseURL)
+	c, err := newGraphQLClient(provider)
+	assert.NilError(t, err)
+	return c, observedLogs
+}
+
+func withServer(t *testing.T, h http.Handler) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(h)
+	t.Cleanup(s.Close)
+	return s
+}
+
+func graphqlOK(repo map[string]any) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "4999")
+		w.Header().Set("X-RateLimit-Reset", "1735689600")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"repository": repo},
+		})
+	}
+}
+
+func graphqlStatus(code int) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "4998")
+		w.Header().Set("X-RateLimit-Reset", "1735689601")
+		w.WriteHeader(code)
+	}
+}
+
+func mockRepo(n int) map[string]any {
+	repo := make(map[string]any)
+	for i := range n {
+		repo[fmt.Sprintf("file%d", i)] = map[string]any{
+			"text": fmt.Sprintf("content-%d", i),
+		}
+	}
+	return repo
+}
+
+func TestBuildGraphQLEndpoint(t *testing.T) {
+	cases := []struct {
+		name string
+		base string
+		want string
+	}{
+		{"public", "https://api.github.com", "https://api.github.com/graphql"},
+		{"public slash", "https://api.github.com/", "https://api.github.com/graphql"},
+		{"ghe v3", "https://ghe/x/api/v3", "https://ghe/x/api/graphql"},
+		{"ghe v3 slash", "https://ghe/x/api/v3/", "https://ghe/x/api/graphql"},
+		{"ghe root", "https://ghe", "https://ghe/api/graphql"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := github.NewClient(nil)
+			parsed, _ := url.Parse(tc.base)
+			client.BaseURL = parsed
+
+			got, err := buildGraphQLEndpoint(&Provider{ghClient: client})
+			assert.NilError(t, err)
+			assert.Check(t, cmp.Equal(tc.want, got))
+		})
+	}
+}
+
+func TestBuildGraphQLQuery(t *testing.T) {
+	cases := []struct {
+		name  string
+		ref   string
+		paths []string
+		want  []string
+	}{
+		{
+			name:  "two files",
+			ref:   "main",
+			paths: []string{"a", "b"},
+			want:  []string{"query(", "repository(", "file0:", "file1:"},
+		},
+		{
+			name:  "no files",
+			ref:   "main",
+			paths: nil,
+			want:  []string{"query(", "repository("},
+		},
+		{
+			name:  "filename with double quotes",
+			ref:   "main",
+			paths: []string{`file"name.yaml`},
+			want:  []string{"query(", "repository(", `file\"name.yaml`},
+		},
+		{
+			name:  "filename with backslash",
+			ref:   "main",
+			paths: []string{`file\name.yaml`},
+			want:  []string{"query(", "repository(", `file\\name.yaml`},
+		},
+		{
+			name:  "filename with both quote and backslash",
+			ref:   "main",
+			paths: []string{`file\"name.yaml`},
+			want:  []string{"query(", "repository(", `file\\\"name.yaml`},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := buildGraphQLQuery(tc.ref, tc.paths)
+			for _, s := range tc.want {
+				assert.Check(t, strings.Contains(q, s))
+			}
+		})
+	}
+}
+
+func TestFetchFilesBatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		paths   []string
+		handler http.HandlerFunc
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "single batch",
+			paths:   []string{"a", "b"},
+			handler: graphqlOK(mockRepo(2)),
+			want:    2,
+		},
+		{
+			name:    "http error",
+			paths:   []string{"a"},
+			handler: graphqlStatus(http.StatusNotFound),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/graphql", tc.handler)
+
+			srv := withServer(t, mux)
+			c, observedLogs := newTestGraphQLClient(t, srv.URL+"/api/v3/")
+
+			res, err := c.fetchFilesBatch(context.Background(), "o", "r", "main", tc.paths)
+			if tc.wantErr {
+				assert.Assert(t, err != nil)
+				entries := observedLogs.FilterMessage("GraphQL request returned non-200 status").All()
+				assert.Check(t, cmp.Len(entries, 1))
+				assert.Check(t, cmp.Equal(entries[0].ContextMap()["rate_limit"], "5000"))
+				assert.Check(t, cmp.Equal(entries[0].ContextMap()["rate_limit_remaining"], "4998"))
+				assert.Check(t, cmp.Equal(entries[0].ContextMap()["rate_limit_reset"], "1735689601"))
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Check(t, cmp.Len(res, tc.want))
+			entries := observedLogs.FilterMessage("GraphQL batch fetch completed").All()
+			assert.Check(t, cmp.Len(entries, 1))
+			assert.Check(t, cmp.Equal(entries[0].ContextMap()["files_requested"], int64(len(tc.paths))))
+			assert.Check(t, cmp.Equal(entries[0].ContextMap()["rate_limit"], "5000"))
+			assert.Check(t, cmp.Equal(entries[0].ContextMap()["rate_limit_remaining"], "4999"))
+			assert.Check(t, cmp.Equal(entries[0].ContextMap()["rate_limit_reset"], "1735689600"))
+			_, exists := entries[0].ContextMap()["files_fetched"]
+			assert.Check(t, !exists)
+		})
+	}
+}
+
+func TestFetchFilesBatchPreservesGitHubHeaders(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/graphql", func(w http.ResponseWriter, r *http.Request) {
+		assert.Assert(t, r.Header.Get("User-Agent") != "")
+		assert.Assert(t, r.Header.Get("X-GitHub-Api-Version") != "")
+		assert.Check(t, cmp.Equal("application/json", r.Header.Get("Content-Type")))
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"file0": map[string]any{"text": "content-0"},
+				},
+			},
+		})
+	})
+
+	srv := withServer(t, mux)
+	c, _ := newTestGraphQLClient(t, srv.URL+"/api/v3/")
+
+	res, err := c.fetchFilesBatch(context.Background(), "o", "r", "main", []string{"a"})
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Len(res, 1))
+}


### PR DESCRIPTION
This commit introduces the use of GitHub's GraphQL API for fetching multiple `.tekton` directory files simultaneously. Previously, each file was fetched individually using REST API calls.

The new implementation leverages GraphQL batching to retrieve all necessary YAML files in a single request, significantly reducing the number of API calls and improving performance. This change also necessitates new test cases to cover the GraphQL client functionality and ensures compatibility with GitHub Enterprise instances.

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

https://redhat.atlassian.net/browse/SRVKP-11470

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
