### PR TITLE
fix: Enforce mandatory webhook secret for GitLab validation

### DIFF
--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -156,12 +156,16 @@ func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
 
 func (v *Provider) Validate(_ context.Context, _ *params.Run, event *info.Event) error {
 	token := event.Request.Header.Get("X-Gitlab-Token")
-	if event.Provider.WebhookSecret == "" && token != "" {
-		return fmt.Errorf("gitlab failed validation: failed to find webhook secret")
+	if token == "" {
+		return fmt.Errorf("no X-Gitlab-Token header detected: webhook validation requires a token for security")
+	}
+
+	if event.Provider.WebhookSecret == "" {
+		return fmt.Errorf("no webhook secret configured: set webhook secret in repository CR or secret")
 	}
 
 	if subtle.ConstantTimeCompare([]byte(event.Provider.WebhookSecret), []byte(token)) == 0 {
-		return fmt.Errorf("gitlab failed validation: event's secret doesn't match with webhook secret")
+		return fmt.Errorf("gitlab webhook validation failed: token does not match configured secret")
 	}
 	return nil
 }

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -1168,32 +1168,38 @@ func TestGetFileInsideRepo(t *testing.T) {
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name        string
-		wantErr     bool
+		wantErr     string
 		secretToken string
 		eventToken  string
 	}{
 		{
-			name:        "valid event",
-			wantErr:     false,
+			name:        "valid event with matching tokens",
+			wantErr:     "",
 			secretToken: "test",
 			eventToken:  "test",
 		},
 		{
-			name:        "fail validation, no secret defined",
-			wantErr:     true,
+			name:        "invalid when webhook secret not configured",
+			wantErr:     "no webhook secret configured",
 			secretToken: "",
 			eventToken:  "test",
 		},
 		{
-			name:        "fail validation",
-			wantErr:     true,
+			name:        "invalid when tokens do not match",
+			wantErr:     "token does not match configured secret",
 			secretToken: "secret",
 			eventToken:  "test",
 		},
 		{
-			name:        "fail validation, missing event token",
-			wantErr:     true,
+			name:        "invalid when X-Gitlab-Token header missing",
+			wantErr:     "no X-Gitlab-Token header detected",
 			secretToken: "secret",
+			eventToken:  "",
+		},
+		{
+			name:        "invalid when both token and secret are empty (security fix)",
+			wantErr:     "no X-Gitlab-Token header detected",
+			secretToken: "",
 			eventToken:  "",
 		},
 	}
@@ -1212,8 +1218,12 @@ func TestValidate(t *testing.T) {
 				WebhookSecret: tt.secretToken,
 			}
 
-			if err := v.Validate(context.TODO(), nil, event); (err != nil) != tt.wantErr {
-				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			err := v.Validate(context.TODO(), nil, event)
+			if tt.wantErr != "" {
+				assert.Assert(t, err != nil)
+				assert.ErrorContains(t, err, tt.wantErr)
+			} else {
+				assert.NilError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
## 📝 Description of the Change

Enforced strict validation to require both the X-Gitlab-Token header and a configured webhook secret. This prevented unauthenticated requests that were previously accepted when both values were empty.

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
