### PR TITLE
fix: Exclude deleted repository when reconciling

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -72,7 +72,6 @@ jobs:
       TEST_GITEA_INTERNAL_URL: http://forgejo-http.forgejo.svc.cluster.local:3000
       TEST_GITEA_PASSWORD: pac
       TEST_GITEA_REPO_OWNER: pac/pac
-      TEST_GITEA_SMEEURL: ${{ secrets.TEST_GITEA_SMEEURL }}
       TEST_GITEA_USERNAME: pac
       TEST_GITHUB_API_URL: api.github.com
       TEST_GITHUB_PRIVATE_TASK_NAME: task-remote
@@ -280,11 +279,6 @@ jobs:
         run: |
           nohup make allbinaries > /tmp/binary-build.log 2>&1 &
           echo $! > /tmp/binary-build.pid
-
-      - name: Install gosmee
-        uses: jaxxstorm/action-install-gh-release@v2.1.0
-        with:
-          repo: chmouel/gosmee
 
       - name: Install Snazy
         uses: jaxxstorm/action-install-gh-release@v2.1.0

--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -4,6 +4,7 @@
 set -exufo pipefail
 
 export PAC_API_INSTRUMENTATION_DIR=/tmp/api-instrumentation
+export TEST_GITEA_API_URL=http://pipelines-as-code-controller.pipelines-as-code.svc.cluster.local:8080
 
 create_pac_github_app_secret() {
   # Read from environment variables instead of arguments


### PR DESCRIPTION
## 📝 Description of the Change
During E2E test execution, a race condition occurs when test cleanup (NSTearDown) deletes Repository CRDs while the reconciler is still processing PipelineRun completion events. This causes noisy error logs appearing 32+ times in test output:

    repositories.pipelinesascode.tekton.dev "pac-e2e-ns-*" not found

**How the Problem Occurs:**

The race happens in this sequence:
1. E2E test creates Repository and PipelineRun CRDs
2. PipelineRun completes (success or failure)
3. Reconciler's ReconcileKind() is triggered by PipelineRun completion
4. Test cleanup begins: NSTearDown deletes the Repository CRD
5. Reconciler calls reportFinalStatus() to post final status to git provider
6. reportFinalStatus() tries to fetch the Repository from lister
7. Repository lookup fails with "not found" error
8. Error propagates up, causing ERROR-level logs

The timing is non-deterministic - sometimes the Repository is deleted before reportFinalStatus() runs, sometimes after. This creates intermittent but frequent error noise in test logs.

Add errors.IsNotFound() handling in reportFinalStatus() to match the graceful deletion pattern already used in finalizer.go and queue_pipelineruns.go. When the Repository is not found:

1. Log an info-level message instead of propagating an error
2. Remove the repository from the queue manager (cleanup)
3. Return nil, nil to skip further processing gracefully

This prevents the reconciler from treating a deleted Repository as an exceptional error condition, which is the correct behavior since Repository deletion is a valid state during cleanup.

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
