### PR TITLE
test(reconciler): add mock HTTP server to avoid network calls

### DIFF
--- a/pkg/reconciler/finalizer_test.go
+++ b/pkg/reconciler/finalizer_test.go
@@ -1,7 +1,8 @@
 package reconciler
 
 import (
-	"strings"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
@@ -13,6 +14,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/sync"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
 	testkubernetestint "github.com/openshift-pipelines/pipelines-as-code/pkg/test/kubernetestint"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.uber.org/zap"
@@ -31,7 +33,7 @@ var (
 			Namespace: "pac-app-pipelines",
 		},
 		Spec: v1alpha1.RepositorySpec{
-			URL:              "https://github.com/sm43/pac-app",
+			URL:              "https://github.com/org/repo",
 			ConcurrencyLimit: &concurrency,
 			GitProvider: &v1alpha1.GitProvider{
 				Secret: &v1alpha1.Secret{
@@ -56,8 +58,8 @@ func getTestPR(name, state string) *tektonv1.PipelineRun {
 				keys.Repository:    finalizeTestRepo.Name,
 				keys.GitProvider:   "github",
 				keys.SHA:           "123afc",
-				keys.URLOrg:        "sm43",
-				keys.URLRepository: "pac-app",
+				keys.URLOrg:        "org",
+				keys.URLRepository: "repo",
 			},
 		},
 		Spec: tektonv1.PipelineRunSpec{
@@ -69,6 +71,16 @@ func getTestPR(name, state string) *tektonv1.PipelineRun {
 func TestReconciler_FinalizeKind(t *testing.T) {
 	observer, _ := zapobserver.New(zap.InfoLevel)
 	fakelogger := zap.New(observer).Sugar()
+
+	_, mux, mockServerURL, teardown := ghtesthelper.SetupGH()
+	defer teardown()
+
+	finalizeTestRepo.Spec.GitProvider.URL = mockServerURL
+
+	// Mock status endpoint
+	mux.HandleFunc("/repos/org/repo/statuses/123afc", func(rw http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(rw, `{"state":"pending"}`)
+	})
 
 	tests := []struct {
 		name           string
@@ -159,9 +171,7 @@ func TestReconciler_FinalizeKind(t *testing.T) {
 				}
 			}
 			err := r.FinalizeKind(ctx, tt.pipelinerun)
-			if err != nil && !strings.Contains(err.Error(), "401 Bad credentials []") {
-				t.Fatalf("expected no error, got %v", err)
-			}
+			assert.NilError(t, err)
 
 			// if repo was deleted then no queue will be there
 			if tt.skipAddingRepo {


### PR DESCRIPTION
## 📝 Description of the Change
Use ghtesthelper.SetupGH() to mock GitHub API in finalizer and reconciler tests, reducing execution time from ~20s to ~0.01s.
```bash
=== RUN   TestReconcileKind_SCMReportingLogic
=== RUN   TestReconcileKind_SCMReportingLogic/Running_reason_without_SCMReportingPLRStarted_-_should_call_updatePipelineRunToInProgress
    logger.go:146: 2026-01-30T09:50:27.340+0530	DEBUG	reconciler/reconciler.go:60	reconciling pipelineRun test/test-pr	{"namespace": "test"}
    logger.go:146: 2026-01-30T09:50:27.340+0530	DEBUG	reconciler/reconciler.go:90	pipelineRun test/test-pr scmReportingPLRStarted=false, exist=false	{"namespace": "test"}
    logger.go:146: 2026-01-30T09:50:27.340+0530	INFO	reconciler/reconciler.go:93	pipelineRun test/test-pr is running but not yet reported to provider, updating status	{"namespace": "test"}
    logger.go:146: 2026-01-30T09:50:27.340+0530	INFO	reconciler/reconciler.go:379	updating pipelineRun test/test-pr state from queued to started	{"namespace": "test"}
    logger.go:146: 2026-01-30T09:50:27.340+0530	INFO	action/patch.go:54	patched pipelinerun with started state: test/test-pr	{"namespace": "test"}
    logger.go:146: 2026-01-30T09:50:27.342+0530	DEBUG	github/profiler.go:131	GitHub API call completed	{"namespace": "test", "operation": "create_status", "duration_ms": 1, "provider": "github", "repo": "test/test-repo", "url_path": "/api/v3/repos/random/app/statuses/123afc", "rate_limit_remaining": "", "status_code": 200}
    logger.go:146: 2026-01-30T09:50:27.343+0530	INFO	reconciler/reconciler.go:333	updated in_progress status on provider platform for pipelineRun test-pr	{"namespace": "test"}
=== RUN   TestReconcileKind_SCMReportingLogic/Running_reason_with_SCMReportingPLRStarted=true_-_should_NOT_call_updatePipelineRunToInProgress
    logger.go:146: 2026-01-30T09:50:27.344+0530	DEBUG	reconciler/reconciler.go:60	reconciling pipelineRun test/test-pr	{"namespace": "test"}
    logger.go:146: 2026-01-30T09:50:27.345+0530	DEBUG	reconciler/reconciler.go:90	pipelineRun test/test-pr scmReportingPLRStarted=true, exist=true	{"namespace": "test"}
    logger.go:146: 2026-01-30T09:50:27.345+0530	DEBUG	reconciler/reconciler.go:101	pipelineRun test/test-pr condition not met: reason='Running', startReported=true	{"namespace": "test"}
=== RUN   TestReconcileKind_SCMReportingLogic/Non-Running_reason_-_should_NOT_call_updatePipelineRunToInProgress
    logger.go:146: 2026-01-30T09:50:27.345+0530	DEBUG	reconciler/reconciler.go:60	reconciling pipelineRun test/test-pr	{"namespace": "test"}
    logger.go:146: 2026-01-30T09:50:27.345+0530	DEBUG	reconciler/reconciler.go:90	pipelineRun test/test-pr scmReportingPLRStarted=false, exist=false	{"namespace": "test"}
    logger.go:146: 2026-01-30T09:50:27.345+0530	DEBUG	reconciler/reconciler.go:101	pipelineRun test/test-pr condition not met: reason='PipelineRunPending', startReported=false	{"namespace": "test"}
--- PASS: TestReconcileKind_SCMReportingLogic (0.01s)
    --- PASS: TestReconcileKind_SCMReportingLogic/Running_reason_without_SCMReportingPLRStarted_-_should_call_updatePipelineRunToInProgress (0.00s)
    --- PASS: TestReconcileKind_SCMReportingLogic/Running_reason_with_SCMReportingPLRStarted=true_-_should_NOT_call_updatePipelineRunToInProgress (0.00s)
    --- PASS: TestReconcileKind_SCMReportingLogic/Non-Running_reason_-_should_NOT_call_updatePipelineRunToInProgress (0.00s)

=== RUN   TestReconciler_FinalizeKind
=== RUN   TestReconciler_FinalizeKind/completed_pipelinerun
=== RUN   TestReconciler_FinalizeKind/queued_pipelinerun
=== RUN   TestReconciler_FinalizeKind/repo_was_deleted
=== RUN   TestReconciler_FinalizeKind/cancelled_status_reported
--- PASS: TestReconciler_FinalizeKind (0.00s)
    --- PASS: TestReconciler_FinalizeKind/completed_pipelinerun (0.00s)
    --- PASS: TestReconciler_FinalizeKind/queued_pipelinerun (0.00s)
    --- PASS: TestReconciler_FinalizeKind/repo_was_deleted (0.00s)
    --- PASS: TestReconciler_FinalizeKind/cancelled_status_reported (0.00s)
```
[unit-tests.log](https://github.com/user-attachments/files/24954693/unit-tests.log) - all unit tests


## 👨🏻‍ Linked Jira
N/A
<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #2425 

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
