### PR TITLE
feat(gitlab): add update comment stategy

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -476,9 +476,11 @@ spec:
                             CommentStrategy defines how GitLab comments are handled for pipeline results.
                             Options:
                             - 'disable_all': Disables all comments on merge requests
+                            - 'update': Updates a single comment per PipelineRun on every trigger.
                           enum:
                             - ""
                             - disable_all
+                            - update
                           type: string
                       type: object
                     pipelinerun_provenance:

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -170,8 +170,9 @@ type GitlabSettings struct {
 	// CommentStrategy defines how GitLab comments are handled for pipeline results.
 	// Options:
 	// - 'disable_all': Disables all comments on merge requests
+	// - 'update': Updates a single comment per PipelineRun on every trigger.
 	// +optional
-	// +kubebuilder:validation:Enum="";disable_all
+	// +kubebuilder:validation:Enum="";disable_all;update
 	CommentStrategy string `json:"comment_strategy,omitempty"`
 }
 

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -298,10 +298,26 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 			if err != nil {
 				logger.Errorf("there was an error evaluating the CEL expression, skipping: %v", err)
 				if checkIfCELEvaluateError(err) {
-					celValidationErrors = append(celValidationErrors, &pacerrors.PacYamlValidations{
-						Name: prName,
-						Err:  fmt.Errorf("CEL expression evaluation error: %s", sanitizeErrorAsMarkdown(err)),
-					})
+					if provider.IsCommentStrategyUpdate(repo) {
+						// Using the same logic for getting OriginalPipelineRun as the one used for setting
+						// the annotation which is used in the provider's "update" comment strategy.
+						originPipelineRunName := prun.GetName()
+						if originPipelineRunName == "" && prun.GenerateName != "" {
+							originPipelineRunName = prun.GetGenerateName()
+						}
+
+						if reportErrors {
+							reportCELValidationErrors(ctx, repo, []*pacerrors.PacYamlValidations{{
+								Name: originPipelineRunName,
+								Err:  fmt.Errorf("CEL expression evaluation error: %s", sanitizeErrorAsMarkdown(err)),
+							}}, eventEmitter, vcx, event, fmt.Sprintf(provider.PlrStatusCommentPrefixTemplate, originPipelineRunName))
+						}
+					} else {
+						celValidationErrors = append(celValidationErrors, &pacerrors.PacYamlValidations{
+							Name: prName,
+							Err:  fmt.Errorf("CEL expression evaluation error: %s", sanitizeErrorAsMarkdown(err)),
+						})
+					}
 				}
 				continue
 			}
@@ -395,7 +411,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 
 	if len(celValidationErrors) > 0 && reportErrors {
 		logger.Debugf("MatchPipelinerunByAnnotation: reporting %d CEL validation errors", len(celValidationErrors))
-		reportCELValidationErrors(ctx, repo, celValidationErrors, eventEmitter, vcx, event)
+		reportCELValidationErrors(ctx, repo, celValidationErrors, eventEmitter, vcx, event, "")
 	}
 
 	if len(matchedPRs) > 0 {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"gopkg.in/yaml.v2"
@@ -223,4 +224,25 @@ var skipCIRegex = regexp.MustCompile(`\[(skip ci|ci skip|skip tkn|tkn skip)\]`)
 // SkipCI returns true if the given commit message contains any skip command.
 func SkipCI(commitMessage string) bool {
 	return skipCIRegex.MatchString(commitMessage)
+}
+
+// PlrStatusCommentPrefixTemplate is used to add a prefix to comments which include the status details
+// of a PipelineRun.
+// The %s placeholder must be replaced with the OriginalPipelineRunName of the associated PipelineRun.
+const PlrStatusCommentPrefixTemplate string = "<!-- pac-status-%s -->"
+
+const (
+	// Updates a single comment per PipelineRun on every trigger.
+	UpdateCommentStrategy string = "update"
+	// Disables all comments on merge requests.
+	DisableAllCommentStrategy string = "disable_all"
+)
+
+func IsCommentStrategyUpdate(repo *v1alpha1.Repository) bool {
+	var commentStrategy string
+	if repo != nil && repo.Spec.Settings != nil && repo.Spec.Settings.Gitlab != nil {
+		commentStrategy = repo.Spec.Settings.Gitlab.CommentStrategy
+	}
+
+	return commentStrategy == UpdateCommentStrategy
 }

--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	pac "github.com/openshift-pipelines/pipelines-as-code/pkg/generated/listers/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	v1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,7 +18,7 @@ import (
 
 var universalDeserializer = serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer()
 
-var allowedGitlabDisableCommentStrategyOnMr = sets.NewString("", "disable_all")
+var allowedGitlabDisableCommentStrategyOnMr = sets.NewString("", provider.DisableAllCommentStrategy, provider.UpdateCommentStrategy)
 
 // Path implements AdmissionController.
 func (ac *reconciler) Path() string {


### PR DESCRIPTION
## 📝 Description of the Change
Adds an "update" comment strategy which updates a single comment per PipelineRun on every trigger.

This comment strategy reports CEL validation errors immediately with a PipelineRun-specific prefix when using the update comment strategy, allowing them to be consolidated into a single updatable comment per PipelineRun.

## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-10453

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [x] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable


- Pull Request 1 with /retest
  <img width="436" height="821" alt="Screenshot From 2026-02-04 13-59-50" src="https://github.com/user-attachments/assets/945fb2c7-9d41-422d-a736-d7f4e15e9dc7" />
- Pull Request 2 with CEL validation errors
  <img width="1920" height="1200" alt="Screenshot From 2026-02-04 13-45-44" src="https://github.com/user-attachments/assets/c3227503-5517-45c5-87e5-a04d8d580b8a" />
- Pull request 2 status after CEL errors were resolved with an validation error
  <img width="1920" height="1200" alt="Screenshot From 2026-02-04 13-46-55" src="https://github.com/user-attachments/assets/ef312c9b-86dc-419f-bb31-2ad8ef48fdc8" />

## 🤖 AI Assistance

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
