### PR TITLE
fix: E2E test improvements and CEL error reporting

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -440,10 +440,136 @@ jobs:
           name: logs-e2e-tests-${{ matrix.provider }}
           path: /tmp/logs
 
+  e2e-flaky-tests:
+    name: e2e flaky tests
+    runs-on: ubuntu-latest
+    needs: e2e-tests
+    if: always() && !cancelled()
+    concurrency:
+      group: ${{ github.workflow }}-flaky-${{ github.event.pull_request.number || github.ref_name }}
+      cancel-in-progress: true
+
+    env:
+      CONTROLLER_DOMAIN_URL: controller.paac-127-0-0-1.nip.io
+      KOCACHE: /tmp/ko-cache
+      KO_DOCKER_REPO: localhost:5000
+      KUBECONFIG: /home/runner/.kube/config.kind
+      TEST_EL_URL: http://controller.paac-127-0-0-1.nip.io
+      TEST_EL_WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+      TEST_GITHUB_API_URL: api.github.com
+      TEST_GITHUB_PRIVATE_TASK_NAME: task-remote
+      TEST_GITHUB_PRIVATE_TASK_URL: https://github.com/openshift-pipelines/pipelines-as-code-e2e-tests-private/blob/main/remote_task.yaml
+      TEST_GITHUB_REPO_INSTALLATION_ID: ${{ vars.INSTALLATION_ID }}
+      TEST_GITHUB_REPO_OWNER_GITHUBAPP: openshift-pipelines/pipelines-as-code-e2e-tests
+      TEST_GITHUB_SECOND_API_URL: ghe.pipelinesascode.com
+      TEST_GITHUB_SECOND_EL_URL: http://ghe.paac-127-0-0-1.nip.io
+      TEST_GITHUB_SECOND_REPO_INSTALLATION_ID: 1
+      TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP: pipelines-as-code/e2e
+      TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
+      TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.target_ref || github.event.pull_request.head.sha || github.sha }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: Cache ko layer cache
+        uses: actions/cache@v5
+        with:
+          path: /tmp/ko-cache
+          key: ${{ runner.os }}-ko-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-ko-
+
+      - uses: ko-build/setup-ko@v0.9
+
+      - name: Build binaries in parallel with cluster installation
+        run: |
+          nohup make allbinaries > /tmp/binary-build.log 2>&1 &
+          echo $! > /tmp/binary-build.pid
+
+      - name: Install gosmee
+        uses: jaxxstorm/action-install-gh-release@v2.1.0
+        with:
+          repo: chmouel/gosmee
+
+      - name: Install Snazy
+        uses: jaxxstorm/action-install-gh-release@v2.1.0
+        with:
+          repo: chmouel/snazy
+
+      - name: Run gosmee for main controller
+        run: |
+          nohup gosmee client --saveDir /tmp/gosmee-replay ${{ secrets.PYSMEE_URL }} "http://${CONTROLLER_DOMAIN_URL}" > /tmp/gosmee-main.log 2>&1 &
+
+      - name: Start installing cluster
+        run: |
+          export PAC_DIR=${PWD}
+          bash -x ./hack/dev/kind/install.sh
+
+      - name: Create PAC github-app-secret
+        env:
+          PAC_GITHUB_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          PAC_GITHUB_APPLICATION_ID: ${{ vars.APPLICATION_ID }}
+          PAC_WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+        run: |
+          ./hack/gh-workflow-ci.sh create_pac_github_app_secret
+
+      - name: Create second Github APP Controller on GHE
+        env:
+          TEST_GITHUB_SECOND_SMEE_URL: ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}
+          TEST_GITHUB_SECOND_PRIVATE_KEY: ${{ secrets.TEST_GITHUB_SECOND_PRIVATE_KEY }}
+          TEST_GITHUB_SECOND_WEBHOOK_SECRET: ${{ secrets.TEST_GITHUB_SECOND_WEBHOOK_SECRET }}
+          TEST_GITHUB_SECOND_APPLICATION_ID: ${{ vars.TEST_GITHUB_SECOND_APPLICATION_ID }}
+        run: |
+          ./hack/gh-workflow-ci.sh create_second_github_app_controller_on_ghe
+
+      - name: Enable debug logging for e2e
+        run: |
+          set -euo pipefail
+          kubectl -n pipelines-as-code patch configmap pac-config-logging --type merge -p '{"data":{"loglevel.pipelinesascode":"debug","loglevel.pac-watcher":"debug","loglevel.pipelines-as-code-webhook":"debug"}}'
+          kubectl -n pipelines-as-code rollout restart deployment/pipelines-as-code-controller deployment/pipelines-as-code-webhook deployment/pipelines-as-code-watcher
+          for name in controller webhook watcher; do
+            echo "=== Waiting for $name to be ready ==="
+            kubectl -n pipelines-as-code rollout status deployment/pipelines-as-code-$name --timeout=120s
+          done
+
+      - name: Run Flaky E2E Tests
+        env:
+          TEST_PROVIDER: flaky
+          TEST_EL_WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+          TEST_GITHUB_REPO_INSTALLATION_ID: ${{ vars.INSTALLATION_ID }}
+          TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
+          TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
+        run: |
+          ./hack/gh-workflow-ci.sh run_e2e_tests
+
+      - name: Collect logs
+        if: ${{ always() }}
+        env:
+          TEST_GITHUB_SECOND_SMEE_URL: ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}
+        run: |
+          ./hack/gh-workflow-ci.sh collect_logs
+
+      - name: Show controllers/watcher errors with Snazy
+        if: ${{ always() }}
+        run: |
+          ./hack/gh-workflow-ci.sh output_logs
+
+      - name: Upload artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: logs-e2e-tests-flaky
+          path: /tmp/logs
+
   notify-slack:
     name: Notify Slack on Failures
     runs-on: ubuntu-latest
-    needs: e2e-tests
+    needs: [e2e-tests, e2e-flaky-tests]
     if: ${{ always() && github.ref_name == 'main' && github.event_name == 'schedule' }}
     steps:
       - uses: actions/checkout@v6

--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -86,7 +86,7 @@ get_tests() {
 
   local -a github_tests=()
   if [[ "${target}" == *"github"* ]] && [[ "${target}" != "github_second_controller" ]]; then
-    mapfile -t github_tests < <(echo "${all_tests}" | grep -iP '^TestGithub' 2>/dev/null | grep -ivP 'Concurrency|GithubSecond' 2>/dev/null | sort 2>/dev/null)
+    mapfile -t github_tests < <(echo "${all_tests}" | grep -iP '^TestGithub' 2>/dev/null | grep -ivP 'Concurrency|GithubSecond|Flaky' 2>/dev/null | sort 2>/dev/null)
   fi
 
   # Calculate chunk sizes for splitting gitea tests into 3 parts
@@ -104,6 +104,9 @@ get_tests() {
   fi
 
   case "${target}" in
+  flaky)
+    printf '%s\n' "${all_tests}" | grep -iP 'Flaky'
+    ;;
   concurrency)
     printf '%s\n' "${all_tests}" | grep -iP 'Concurrency'
     ;;
@@ -118,7 +121,7 @@ get_tests() {
     fi
     ;;
   github_second_controller)
-    printf '%s\n' "${all_tests}" | grep -iP 'GithubSecond|Others' | grep -ivP 'Concurrency'
+    printf '%s\n' "${all_tests}" | grep -iP 'GithubSecond|Others' | grep -ivP 'Concurrency|Flaky'
     ;;
   gitlab_bitbucket)
     printf '%s\n' "${all_tests}" | grep -iP 'Gitlab|Bitbucket' | grep -ivP 'Concurrency'
@@ -141,7 +144,7 @@ get_tests() {
     ;;
   *)
     echo "Invalid target: ${target}"
-    echo "supported targets: github_1, github_2, github_second_controller, gitlab_bitbucket, gitea_1, gitea_2, gitea_3, concurrency"
+    echo "supported targets: github_1, github_2, github_second_controller, gitlab_bitbucket, gitea_1, gitea_2, gitea_3, concurrency, flaky"
     ;;
   esac
 }
@@ -412,7 +415,7 @@ output_logs)
   ;;
 print_tests)
   set +x
-  for target in github_1 github_2 github_second_controller gitlab_bitbucket gitea_1 gitea_2 gitea_3 concurrency; do
+  for target in github_1 github_2 github_second_controller gitlab_bitbucket gitea_1 gitea_2 gitea_3 concurrency flaky; do
     mapfile -t tests < <(get_tests "${target}")
     echo "Tests for target: ${target} Total: ${#tests[@]}"
     printf '%s\n' "${tests[@]}"

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -192,7 +192,7 @@ func checkPipelineRunAnnotation(prun *tektonv1.PipelineRun, eventEmitter *events
 	}
 }
 
-func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger, pruns []*tektonv1.PipelineRun, cs *params.Run, event *info.Event, vcx provider.Interface, eventEmitter *events.EventEmitter, repo *apipac.Repository) ([]Match, error) {
+func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger, pruns []*tektonv1.PipelineRun, cs *params.Run, event *info.Event, vcx provider.Interface, eventEmitter *events.EventEmitter, repo *apipac.Repository, reportErrors bool) ([]Match, error) {
 	matchedPRs := []Match{}
 	infomsg := fmt.Sprintf("matching pipelineruns to event: URL=%s, target-branch=%s, source-branch=%s, target-event=%s",
 		event.URL,
@@ -381,7 +381,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 		matchedPRs = append(matchedPRs, prMatch)
 	}
 
-	if len(celValidationErrors) > 0 {
+	if len(celValidationErrors) > 0 && reportErrors {
 		reportCELValidationErrors(ctx, repo, celValidationErrors, eventEmitter, vcx, event)
 	}
 

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -194,6 +194,7 @@ func checkPipelineRunAnnotation(prun *tektonv1.PipelineRun, eventEmitter *events
 
 func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger, pruns []*tektonv1.PipelineRun, cs *params.Run, event *info.Event, vcx provider.Interface, eventEmitter *events.EventEmitter, repo *apipac.Repository, reportErrors bool) ([]Match, error) {
 	matchedPRs := []Match{}
+	logger.Debugf("MatchPipelinerunByAnnotation: pipelineruns=%d event_type=%s trigger_target=%s report_errors=%t", len(pruns), event.EventType, event.TriggerTarget, reportErrors)
 	infomsg := fmt.Sprintf("matching pipelineruns to event: URL=%s, target-branch=%s, source-branch=%s, target-event=%s",
 		event.URL,
 		event.BaseBranch,
@@ -222,6 +223,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 
 	celValidationErrors := []*pacerrors.PacYamlValidations{}
 	for _, prun := range pruns {
+		logger.Debugf("MatchPipelinerunByAnnotation: evaluating pipelinerun=%s annotations=%d", getName(prun), len(prun.GetObjectMeta().GetAnnotations()))
 		prMatch := Match{
 			PipelineRun: prun,
 			Config:      map[string]string{},
@@ -241,6 +243,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 
 		if maxPrNumber, ok := prun.GetObjectMeta().GetAnnotations()[keys.MaxKeepRuns]; ok {
 			prMatch.Config["max-keep-runs"] = maxPrNumber
+			logger.Debugf("PipelineRun %s: max-keep-runs=%s", prName, maxPrNumber)
 		}
 
 		if targetNS, ok := prun.GetObjectMeta().GetAnnotations()[keys.TargetNamespace]; ok {
@@ -250,6 +253,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 				logger.Warnf("could not find Repository CRD in branch %s, the pipelineRun %s has a label that explicitly targets it", targetNS, prName)
 				continue
 			}
+			logger.Debugf("PipelineRun %s: matched target namespace repo=%s/%s", prName, prMatch.Repo.GetNamespace(), prMatch.Repo.GetName())
 		}
 
 		if targetComment, ok := prun.GetObjectMeta().GetAnnotations()[keys.OnComment]; ok {
@@ -268,6 +272,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 				if event.EventType != originalEventType {
 					customParams = resolveCustomParamsForCEL(ctx, repo, event, cs, vcx, eventEmitter, logger)
 					originalEventType = event.EventType
+					logger.Debugf("PipelineRun %s: event_type switched to %s due to comment match", prName, event.EventType)
 				}
 
 				comment := event.TriggerComment
@@ -288,6 +293,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 		if celExpr, ok := prun.GetObjectMeta().GetAnnotations()[keys.OnCelExpression]; ok {
 			checkPipelineRunAnnotation(prun, eventEmitter, repo)
 
+			logger.Debugf("PipelineRun %s: evaluating CEL expression", prName)
 			out, err := celEvaluate(ctx, celExpr, event, vcx, customParams, eventEmitter, repo)
 			if err != nil {
 				logger.Errorf("there was an error evaluating the CEL expression, skipping: %v", err)
@@ -299,6 +305,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 				}
 				continue
 			}
+			logger.Debugf("PipelineRun %s: CEL result=%v", prName, out)
 			if out != types.True {
 				logger.Infof("CEL expression for PipelineRun %s is not matching, skipping", prName)
 				continue
@@ -319,10 +326,12 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 				return matchedPRs, err
 			}
 			if !matched {
+				logger.Debugf("PipelineRun %s: target branch/event did not match", prName)
 				continue
 			}
 			prMatch.Config["target-branch"] = targetBranch
 			prMatch.Config["target-event"] = targetEvent
+			logger.Debugf("PipelineRun %s: matched target event=%s target branch=%s", prName, targetEvent, targetBranch)
 
 			if key, ok := prun.GetObjectMeta().GetAnnotations()[keys.OnPathChange]; ok {
 				changedFiles, err := vcx.GetFiles(ctx, event)
@@ -338,6 +347,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 					return matchedPRs, err
 				}
 				if !matched {
+					logger.Debugf("PipelineRun %s: path-change annotation did not match", prName)
 					continue
 				}
 				logger.Infof("matched PipelineRun with name: %s, annotation PathChange: %q", prName, key)
@@ -350,6 +360,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 					return matchedPRs, err
 				}
 				if !matched {
+					logger.Debugf("PipelineRun %s: label annotation did not match", prName)
 					continue
 				}
 				logger.Infof("matched PipelineRun with name: %s, annotation Label: %q", prName, key)
@@ -374,6 +385,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 					continue
 				}
 				prMatch.Config["path-change-ignore"] = key
+				logger.Debugf("PipelineRun %s: path-change-ignore did not match, continuing", prName)
 			}
 		}
 
@@ -382,6 +394,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 	}
 
 	if len(celValidationErrors) > 0 && reportErrors {
+		logger.Debugf("MatchPipelinerunByAnnotation: reporting %d CEL validation errors", len(celValidationErrors))
 		reportCELValidationErrors(ctx, repo, celValidationErrors, eventEmitter, vcx, event)
 	}
 
@@ -389,6 +402,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 		// Filter out templates that already have successful PipelineRuns for /retest and /ok-to-test
 		if event.EventType == opscomments.RetestAllCommentEventType.String() ||
 			event.EventType == opscomments.OkToTestCommentEventType.String() {
+			logger.Debugf("MatchPipelinerunByAnnotation: filtering successful templates for event_type=%s", event.EventType)
 			return filterSuccessfulTemplates(ctx, logger, cs, event, repo, matchedPRs), nil
 		}
 		return matchedPRs, nil
@@ -413,6 +427,7 @@ func filterSuccessfulTemplates(ctx context.Context, logger *zap.SugaredLogger, c
 		logger.Errorf("failed to list existing PipelineRuns for SHA %s: %v", event.SHA, err)
 		return matchedPRs // Return all templates if we can't check
 	}
+	logger.Debugf("filterSuccessfulTemplates: existing pipelineruns=%d for sha=%s", len(existingPRs.Items), event.SHA)
 
 	// Create a map of template names to their most recent successful run
 	successfulTemplates := make(map[string]*tektonv1.PipelineRun)
@@ -533,6 +548,7 @@ func resolveCustomParamsForCEL(ctx context.Context, repo *apipac.Repository, eve
 	if repo == nil || repo.Spec.Params == nil {
 		return map[string]string{}
 	}
+	logger.Debugf("resolveCustomParamsForCEL: repo=%s/%s params=%d", repo.GetNamespace(), repo.GetName(), len(*repo.Spec.Params))
 
 	// Create kubeinteraction interface
 	kinteract, err := kubeinteraction.NewKubernetesInteraction(cs)
@@ -549,6 +565,7 @@ func resolveCustomParamsForCEL(ctx context.Context, repo *apipac.Repository, eve
 			fmt.Sprintf("failed to resolve custom params for CEL: %s", err.Error()))
 		return map[string]string{}
 	}
+	logger.Debugf("resolveCustomParamsForCEL: resolved %d total params", len(allParams))
 
 	// Filter to only include params defined in repo.Spec.Params (not standard PAC params)
 	result := make(map[string]string)
@@ -557,6 +574,7 @@ func resolveCustomParamsForCEL(ctx context.Context, repo *apipac.Repository, eve
 			result[param.Name] = value
 		}
 	}
+	logger.Debugf("resolveCustomParamsForCEL: returned %d custom params", len(result))
 
 	return result
 }

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -1699,7 +1699,7 @@ func runTest(ctx context.Context, t *testing.T, tt annotationTest, vcx provider.
 
 	matches, err := MatchPipelinerunByAnnotation(ctx, logger,
 		tt.args.pruns,
-		client, &tt.args.runevent, vcx, eventEmitter, repo,
+		client, &tt.args.runevent, vcx, eventEmitter, repo, true,
 	)
 
 	if tt.wantLog != "" {
@@ -2261,7 +2261,7 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 			}
 
 			eventEmitter := events.NewEventEmitter(cs.Clients.Kube, logger)
-			matches, err := MatchPipelinerunByAnnotation(ctx, logger, tt.args.pruns, cs, &tt.args.runevent, &ghprovider.Provider{}, eventEmitter, nil)
+			matches, err := MatchPipelinerunByAnnotation(ctx, logger, tt.args.pruns, cs, &tt.args.runevent, &ghprovider.Provider{}, eventEmitter, nil, true)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MatchPipelinerunByAnnotation() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/pipelineascode/logging.go
+++ b/pkg/pipelineascode/logging.go
@@ -1,0 +1,10 @@
+package pipelineascode
+
+// debugf logs only when a logger is available.
+// This avoids nil pointer panics in tests that don't wire a logger.
+func (p *PacRun) debugf(format string, args ...any) {
+	if p == nil || p.logger == nil {
+		return
+	}
+	p.logger.Debugf(format, args...)
+}

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -22,23 +22,28 @@ import (
 )
 
 func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Repository, error) {
+	p.debugf("matchRepoPR: starting repo verification for url=%s", p.event.URL)
 	repo, err := p.verifyRepoAndUser(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 	if repo == nil {
+		p.debugf("matchRepoPR: no repository match for url=%s", p.event.URL)
 		return nil, nil, nil
 	}
 
 	if p.event.CancelPipelineRuns {
+		p.debugf("matchRepoPR: cancel pipeline runs requested, skipping match")
 		return nil, repo, p.cancelPipelineRunsOpsComment(ctx, repo)
 	}
 
+	p.debugf("matchRepoPR: fetching pipelineruns from repo=%s/%s", repo.GetNamespace(), repo.GetName())
 	matchedPRs, err := p.getPipelineRunsFromRepo(ctx, repo)
 	if err != nil {
 		return nil, repo, err
 	}
 
+	p.debugf("matchRepoPR: matched=%d repo=%s/%s", len(matchedPRs), repo.GetNamespace(), repo.GetName())
 	return matchedPRs, repo, nil
 }
 
@@ -46,6 +51,7 @@ func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Re
 // if the user has permission to run CI  and also initialise provider client.
 func (p *PacRun) verifyRepoAndUser(ctx context.Context) (*v1alpha1.Repository, error) {
 	// Match the Event URL to a Repository URL,
+	p.debugf("verifyRepoAndUser: matching repository for url=%s", p.event.URL)
 	repo, err := matcher.MatchEventURLRepo(ctx, p.run, p.event, "")
 	if err != nil {
 		return nil, fmt.Errorf("error matching Repository for event: %w", err)
@@ -56,6 +62,7 @@ func (p *PacRun) verifyRepoAndUser(ctx context.Context) (*v1alpha1.Repository, e
 		p.eventEmitter.EmitMessage(nil, zap.WarnLevel, "RepositoryNamespaceMatch", msg)
 		return nil, nil
 	}
+	p.debugf("verifyRepoAndUser: matched repo=%s/%s", repo.GetNamespace(), repo.GetName())
 
 	p.logger = p.logger.With("namespace", repo.Namespace)
 	p.vcx.SetLogger(p.logger)
@@ -70,17 +77,21 @@ func (p *PacRun) verifyRepoAndUser(ctx context.Context) (*v1alpha1.Repository, e
 	if err != nil {
 		return repo, err
 	}
+	p.debugf("verifyRepoAndUser: authenticated client setup complete")
 
 	// Get the SHA commit info, we want to get the URL and commit title
 	if p.event.SHA == "" || p.event.SHATitle == "" || p.event.SHAURL == "" {
+		p.debugf("verifyRepoAndUser: fetching commit info")
 		if err = p.vcx.GetCommitInfo(ctx, p.event); err != nil {
 			return repo, fmt.Errorf("could not find commit info: %w", err)
 		}
+		p.debugf("verifyRepoAndUser: commit info loaded sha=%s title=%s", p.event.SHA, p.event.SHATitle)
 	}
 
 	// Verify whether the sender of the GitOps command (e.g., /test) has the appropriate permissions to
 	// trigger CI on the repository, as any user is able to comment on a pushed commit in open-source repositories.
 	if p.event.TriggerTarget == triggertype.Push && opscomments.IsAnyOpsEventType(p.event.EventType) {
+		p.debugf("verifyRepoAndUser: checking access for gitops comment on push")
 		status := provider.StatusOpts{
 			Status:       CompletedStatus,
 			Title:        "Permission denied",
@@ -97,6 +108,7 @@ func (p *PacRun) verifyRepoAndUser(ctx context.Context) (*v1alpha1.Repository, e
 	// on push we don't need to check the policy since the user has pushed to the repo so it has access to it.
 	// on comment we skip it for now, we are going to check later on
 	if p.event.TriggerTarget != triggertype.Push && p.event.EventType != opscomments.NoOpsCommentEventType.String() {
+		p.debugf("verifyRepoAndUser: checking access for trigger target=%s event_type=%s", p.event.TriggerTarget, p.event.EventType)
 		status := provider.StatusOpts{
 			Status:       queuedStatus,
 			Title:        "Pending approval, waiting for an /ok-to-test",
@@ -130,6 +142,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 	if repo.Spec.Settings != nil && repo.Spec.Settings.PipelineRunProvenance != "" {
 		provenance = repo.Spec.Settings.PipelineRunProvenance
 	}
+	p.debugf("getPipelineRunsFromRepo: repo=%s/%s provenance=%s", repo.GetNamespace(), repo.GetName(), provenance)
 	rawTemplates, err := p.vcx.GetTektonDir(ctx, p.event, tektonDir, provenance)
 	if err != nil && p.event.TriggerTarget == triggertype.PullRequest && strings.Contains(err.Error(), "error unmarshalling yaml file") {
 		// make the error a bit more friendly for users who don't know what marshalling or intricacies of the yaml parser works
@@ -151,6 +164,12 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		}
 
 		return nil, err
+	}
+
+	if err != nil {
+		p.debugf("getPipelineRunsFromRepo: GetTektonDir returned error: %v", err)
+	} else {
+		p.debugf("getPipelineRunsFromRepo: fetched templates length=%d", len(rawTemplates))
 	}
 
 	if rawTemplates == "" && p.event.EventType == opscomments.OkToTestCommentEventType.String() {
@@ -207,16 +226,19 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		if err != nil {
 			return nil, err
 		}
+		p.debugf("getPipelineRunsFromRepo: pre-parse types: pipelineruns=%d pipelines=%d tasks=%d", len(rtypes.PipelineRuns), len(rtypes.Pipelines), len(rtypes.Tasks))
 		// Don't fail or do anything if we don't have a match yet, we will do it properly later in this function
 		_, _ = matcher.MatchPipelinerunByAnnotation(ctx, p.logger, rtypes.PipelineRuns, p.run, p.event, p.vcx, p.eventEmitter, repo, false)
 	}
 	// Replace those {{var}} placeholders user has in her template to the run.Info variable
 	allTemplates := p.makeTemplate(ctx, repo, rawTemplates)
+	p.debugf("getPipelineRunsFromRepo: templated data length=%d", len(allTemplates))
 
 	types, err := resolve.ReadTektonTypes(ctx, p.logger, allTemplates)
 	if err != nil {
 		return nil, err
 	}
+	p.debugf("getPipelineRunsFromRepo: parsed types: pipelineruns=%d pipelines=%d tasks=%d validation_errors=%d", len(types.PipelineRuns), len(types.Pipelines), len(types.Tasks), len(types.ValidationErrors))
 
 	if len(types.ValidationErrors) > 0 && p.event.TriggerTarget == triggertype.PullRequest {
 		p.reportValidationErrors(ctx, repo, types.ValidationErrors)
@@ -227,11 +249,13 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		p.eventEmitter.EmitMessage(nil, zap.InfoLevel, "RepositoryCannotLocatePipelineRun", msg)
 		return nil, nil
 	}
+	p.debugf("getPipelineRunsFromRepo: pipelineRuns count=%d", len(pipelineRuns))
 	pipelineRuns, err = resolve.MetadataResolve(pipelineRuns)
 	if err != nil && len(pipelineRuns) == 0 {
 		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "FailedToResolvePipelineRunMetadata", err.Error())
 		return nil, err
 	}
+	p.debugf("getPipelineRunsFromRepo: metadata resolved for pipelineRuns count=%d", len(pipelineRuns))
 
 	// Match the PipelineRun with annotation
 	var matchedPRs []matcher.Match
@@ -252,6 +276,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 			}
 			return nil, nil
 		}
+		p.debugf("getPipelineRunsFromRepo: initial match count=%d", len(matchedPRs))
 	}
 
 	// if the event is a comment event, but we don't have any match from the keys.OnComment then do the ACL checks again
@@ -276,6 +301,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryCannotLocatePipelineRunForIncomingEvent", msg)
 		return nil, nil
 	}
+	p.debugf("getPipelineRunsFromRepo: incoming filter result count=%d", len(pipelineRuns))
 
 	// if /test command is used then filter out the pipelinerun
 	if p.event.TargetTestPipelineRun != "" {
@@ -286,6 +312,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 			return nil, nil
 		}
 		pipelineRuns = []*tektonv1.PipelineRun{targetPR}
+		p.debugf("getPipelineRunsFromRepo: filtered to target pipelinerun=%s", p.event.TargetTestPipelineRun)
 	}
 
 	// finally resolve with fetching the remote tasks (if enabled)
@@ -302,6 +329,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 				}
 			}
 		}
+		p.debugf("getPipelineRunsFromRepo: resolving remote tasks for pipelineRuns=%d", len(types.PipelineRuns))
 		pipelineRuns, err = resolve.Resolve(ctx, p.run, p.logger, p.vcx, types, p.event, &resolve.Opts{
 			GenerateName: true,
 			RemoteTasks:  true,
@@ -316,6 +344,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 	if err != nil {
 		return nil, err
 	}
+	p.debugf("getPipelineRunsFromRepo: updated pipelineRuns count=%d", len(pipelineRuns))
 	// if we are doing explicit /test command then we only want to run the one that has matched the /test
 	if p.event.TargetTestPipelineRun != "" {
 		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryMatchedPipelineRun", fmt.Sprintf("explicit testing via /test of PipelineRun %s", p.event.TargetTestPipelineRun))
@@ -332,6 +361,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		p.eventEmitter.EmitMessage(nil, zap.WarnLevel, "RepositoryNoMatch", err.Error())
 		return nil, nil
 	}
+	p.debugf("getPipelineRunsFromRepo: final match count=%d", len(matchedPRs))
 
 	return matchedPRs, nil
 }
@@ -352,11 +382,13 @@ func filterRunningPipelineRunOnTargetTest(testPipeline string, prs []*tektonv1.P
 // - the secret template variable with a random one as generated from GetBasicAuthSecretName
 // - the template variable with the one from the event (this includes the remote pipeline that has template variables).
 func (p *PacRun) changePipelineRun(ctx context.Context, repo *v1alpha1.Repository, prs []*tektonv1.PipelineRun) error {
+	p.debugf("changePipelineRun: processing %d pipelineruns", len(prs))
 	for k, pr := range prs {
 		prName := pr.GetName()
 		if prName == "" {
 			prName = pr.GetGenerateName()
 		}
+		p.debugf("changePipelineRun: processing pipelinerun=%s", prName)
 
 		b, err := json.Marshal(pr)
 		if err != nil {
@@ -381,6 +413,7 @@ func (p *PacRun) changePipelineRun(ctx context.Context, repo *v1alpha1.Repositor
 		np.Annotations[apipac.GitAuthSecret] = name
 
 		prs[k] = np
+		p.debugf("changePipelineRun: updated pipelinerun=%s with git_auth_secret annotation", prName)
 	}
 	return nil
 }
@@ -398,6 +431,7 @@ func (p *PacRun) checkNeedUpdate(_ string) (string, bool) {
 }
 
 func (p *PacRun) createNeutralStatus(ctx context.Context, title, text string) error {
+	p.debugf("createNeutralStatus: title=%s", title)
 	status := provider.StatusOpts{
 		Status:     CompletedStatus,
 		Title:      title,

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -208,7 +208,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 			return nil, err
 		}
 		// Don't fail or do anything if we don't have a match yet, we will do it properly later in this function
-		_, _ = matcher.MatchPipelinerunByAnnotation(ctx, p.logger, rtypes.PipelineRuns, p.run, p.event, p.vcx, p.eventEmitter, repo)
+		_, _ = matcher.MatchPipelinerunByAnnotation(ctx, p.logger, rtypes.PipelineRuns, p.run, p.event, p.vcx, p.eventEmitter, repo, false)
 	}
 	// Replace those {{var}} placeholders user has in her template to the run.Info variable
 	allTemplates := p.makeTemplate(ctx, repo, rawTemplates)
@@ -236,7 +236,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 	// Match the PipelineRun with annotation
 	var matchedPRs []matcher.Match
 	if p.event.TargetTestPipelineRun == "" {
-		if matchedPRs, err = matcher.MatchPipelinerunByAnnotation(ctx, p.logger, pipelineRuns, p.run, p.event, p.vcx, p.eventEmitter, repo); err != nil {
+		if matchedPRs, err = matcher.MatchPipelinerunByAnnotation(ctx, p.logger, pipelineRuns, p.run, p.event, p.vcx, p.eventEmitter, repo, true); err != nil {
 			// Don't fail when you don't have a match between pipeline and annotations
 			p.eventEmitter.EmitMessage(nil, zap.WarnLevel, "RepositoryNoMatch", err.Error())
 			// In a scenario where an external user submits a pull request and the repository owner uses the
@@ -326,7 +326,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		}}, nil
 	}
 
-	matchedPRs, err = matcher.MatchPipelinerunByAnnotation(ctx, p.logger, pipelineRuns, p.run, p.event, p.vcx, p.eventEmitter, repo)
+	matchedPRs, err = matcher.MatchPipelinerunByAnnotation(ctx, p.logger, pipelineRuns, p.run, p.event, p.vcx, p.eventEmitter, repo, false)
 	if err != nil {
 		// Don't fail when you don't have a match between pipeline and annotations
 		p.eventEmitter.EmitMessage(nil, zap.WarnLevel, "RepositoryNoMatch", err.Error())

--- a/pkg/pipelineascode/secret.go
+++ b/pkg/pipelineascode/secret.go
@@ -40,6 +40,7 @@ func (s *SecretFromRepository) Get(ctx context.Context) error {
 	} else {
 		s.Event.Provider.URL = s.Repo.Spec.GitProvider.URL
 	}
+	s.Logger.Debugf("secretFromRepository: repo=%s/%s provider_url=%s namespace=%s", s.Repo.Namespace, s.Repo.Name, s.Repo.Spec.GitProvider.URL, s.Namespace)
 
 	if s.Repo.Spec.GitProvider.Secret == nil {
 		return fmt.Errorf("failed to find secret in git_provider section in repository spec: %v/%v", s.Repo.Namespace, s.Repo.Name)
@@ -48,6 +49,7 @@ func (s *SecretFromRepository) Get(ctx context.Context) error {
 	if gitProviderSecretKey == "" {
 		gitProviderSecretKey = DefaultGitProviderSecretKey
 	}
+	s.Logger.Debugf("secretFromRepository: reading provider token secret=%s key=%s", s.Repo.Spec.GitProvider.Secret.Name, gitProviderSecretKey)
 
 	if s.Event.Provider.Token, err = s.K8int.GetSecret(ctx, ktypes.GetSecretOpt{
 		Namespace: s.Namespace,
@@ -74,6 +76,7 @@ func (s *SecretFromRepository) Get(ctx context.Context) error {
 	if gitProviderWebhookSecretKey == "" {
 		gitProviderWebhookSecretKey = DefaultGitProviderWebhookSecretKey
 	}
+	s.Logger.Debugf("secretFromRepository: reading webhook secret=%s key=%s", s.Repo.Spec.GitProvider.WebhookSecret.Name, gitProviderWebhookSecretKey)
 	logmsg := fmt.Sprintf("Using git provider %s: apiurl=%s user=%s token-secret=%s token-key=%s",
 		s.WebhookType,
 		s.Repo.Spec.GitProvider.URL,

--- a/pkg/pipelineascode/template.go
+++ b/pkg/pipelineascode/template.go
@@ -19,6 +19,8 @@ func (p *PacRun) makeTemplate(ctx context.Context, repo *v1alpha1.Repository, te
 	if err != nil {
 		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "ParamsError",
 			fmt.Sprintf("error processing repository CR custom params: %s", err.Error()))
+	} else {
+		p.debugf("makeTemplate: resolved %d params and %d changed file groups", len(maptemplate), len(changedFiles))
 	}
 
 	// convert pull request number to string

--- a/pkg/resolve/logging.go
+++ b/pkg/resolve/logging.go
@@ -1,0 +1,17 @@
+package resolve
+
+import "go.uber.org/zap"
+
+func debugf(log *zap.SugaredLogger, format string, args ...any) {
+	if log == nil {
+		return
+	}
+	log.Debugf(format, args...)
+}
+
+func logInfo(log *zap.SugaredLogger, msg string) {
+	if log == nil {
+		return
+	}
+	log.Info(msg)
+}

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -165,7 +165,7 @@ func TestGithubPullRequestWebhook(t *testing.T) {
 	defer g.TearDown(ctx, t)
 }
 
-func TestGithubSecondPullRequestBadYaml(t *testing.T) {
+func TestGithubSecondFlakyPullRequestBadYaml(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label:            "Github PullRequest Bad Yaml",
@@ -196,7 +196,7 @@ func TestGithubSecondPullRequestBadYaml(t *testing.T) {
 	t.Fatal("No comments with the pipelinerun error found on the pull request")
 }
 
-func TestGithubInvalidCELExpressionReportingOnPR(t *testing.T) {
+func TestGithubFlakyInvalidCELExpressionReportingOnPR(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label:         "Github PullRequest Invalid CEL expression",
@@ -231,10 +231,7 @@ func TestGithubInvalidCELExpressionReportingOnPR(t *testing.T) {
 
 // TestGithubPullRequestInvalidSpecValues tests invalid field values of a PipelinRun and
 // ensures that these validation errors are reported on UI.
-func TestGithubPullRequestInvalidSpecValues(t *testing.T) {
-	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
-		t.Skip("Skipping test since only enabled for nightly")
-	}
+func TestGithubFlakyPullRequestInvalidSpecValues(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label:            "Github Invalid Yaml",

--- a/test/pkg/repository/teardown.go
+++ b/test/pkg/repository/teardown.go
@@ -6,14 +6,25 @@ import (
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/random"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NSTearDown(ctx context.Context, t *testing.T, runcnx *params.Run, targetNS string) {
-	runcnx.Clients.Log.Infof("Deleting Repository in %s", targetNS)
-	err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
+	repos, err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
+
+	// Add random suffix to the repo URL so we can keep it for logs collection (if PAC_E2E_KEEP_NS is set)
+	// so we can investigate later if needed and capture its status it captured
+	// we need to rename it so webhooks don't trigger any more runs
+	for _, repo := range repos.Items {
+		repo.Spec.URL += random.AlphaString(5)
+		if _, err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Update(ctx, &repo, metav1.UpdateOptions{}); err != nil {
+			runcnx.Clients.Log.Warnf("Failed to renamae Repository URL %s: %v", repo.Name, err)
+		}
+	}
+
 	if os.Getenv("PAC_E2E_KEEP_NS") != "true" {
 		runcnx.Clients.Log.Infof("Deleting NS %s", targetNS)
 		err = runcnx.Clients.Kube.CoreV1().Namespaces().Delete(ctx, targetNS, metav1.DeleteOptions{})


### PR DESCRIPTION
## 📝 Description of the Change

This PR contains several improvements to the E2E test infrastructure and fixes:

### 1. Only report CEL validation errors once When someone writes a bad CEL expression in their PipelineRun, the system was posting **2 identical error comments** on the PR instead of just 1.

The function `MatchPipelinerunByAnnotation()` gets called **twice** during processing:
- First call - Quick check before processing templates
- Second call - Real check after templates are ready

Added a `reportErrors` parameter to control when errors are reported, preventing duplicate comments.

### 2. Move flaky tests to dedicated CI job 
- Added new `e2e-flaky-tests` job that runs after main E2E tests complete
- Renamed tests from `_Z_` prefix to `Flaky` naming convention (e.g., `TestGithubFlakyPullRequestBadYaml`)
- Removed `t.Skip()` calls so these tests actually run
- Updated `hack/gh-workflow-ci.sh` to handle the new `flaky` target

### 3. Add debug logging for pipelineascode
Added extensive debug logging throughout matching, remote resource fetching, cancellation, client setup, and more.

### 4. Fix repo URL for log collection
Modified `NSTearDown` to append a random suffix to repository URLs before deletion, preventing race conditions with active webhooks.

## 🚀 Type of Change

- [x] 🐛 Bug fix (`fix:`)
- [x] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [x] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's commit message guide.
- [x] ✨ I have ensured my commit message prefix matches the "Type of Change" selected above.
- [x] ♽ I have run `make test` and `make lint` locally.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.