### PR TITLE
perf(github): skip comment edit when body is already up to date

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -776,9 +776,13 @@ func (v *Provider) CreateComment(ctx context.Context, event *info.Event, commit,
 		re := regexp.MustCompile(regexp.QuoteMeta(updateMarker))
 		for _, comment := range comments {
 			if re.MatchString(comment.GetBody()) {
+				// No edit required if the comment is exactly the same.
+				if comment.GetBody() == commit {
+					return nil
+				}
 				if _, _, err := wrapAPI(v, "edit_comment", func() (*github.IssueComment, *github.Response, error) {
 					return v.Client().Issues.EditComment(ctx, event.Organization, event.Repository, comment.GetID(), &github.IssueComment{
-						Body: &commit,
+						Body: github.Ptr(commit),
 					})
 				}); err != nil {
 					return err
@@ -790,7 +794,7 @@ func (v *Provider) CreateComment(ctx context.Context, event *info.Event, commit,
 
 	_, _, err := wrapAPI(v, "create_comment", func() (*github.IssueComment, *github.Response, error) {
 		return v.Client().Issues.CreateComment(ctx, event.Organization, event.Repository, event.PullRequestNumber, &github.IssueComment{
-			Body: &commit,
+			Body: github.Ptr(commit),
 		})
 	})
 	return err


### PR DESCRIPTION

## 📝 Description of the Change
Avoid unnecessary GitHub API calls by checking if comment body already matches before editing. Use github.Ptr() for consistency.

Saw `edit_comment` API call being made which returns 200 status
```json
{
  "level": "debug",
  "ts": "2026-02-04T09:14:15.527Z",
  "logger": "pipelinesascode",
  "caller": "github/profiler.go:131",
  "msg": "GitHub API call completed",
  "commit": "43bf4b1",
  "provider": "github",
  "event-id": "ddbe19c0-01a9-11f1-961c-7f1fee891363",
  "event-sha": "0afb7232f1c85b17c7a7aac7c416d6ad3fb775be",
  "event-type": "pull_request",
  "source-repo-url": "https://github.com/openshift-pipelines/pipelines-as-code-e2e-tests",
  "target-branch": "main",
  "source-branch": "pac-e2e-test-fg4nl",
  "namespace": "pac-e2e-ns-nnzz2",
  "operation": "edit_comment",
  "duration_ms": 430,
  "provider": "github",
  "repo": "pac-e2e-ns-nnzz2/pac-e2e-ns-nnzz2",
  "url_path": "/repos/openshift-pipelines/pipelines-as-code-e2e-tests/issues/comments/3846247136",
  "rate_limit_remaining": "5746",
  "status_code": 200
}
```

However, the said comment does not show the "edited" tag. 

<img width="913" height="382" alt="image" src="https://github.com/user-attachments/assets/f126ab56-f884-43a2-9c61-cffac697763f" />
Github only shows the edited tag if the body is changed after editing. We save a single API call in cases where validation errors are to being reported in subsequent triggers without any change in the comment body.

## 👨🏻‍ Linked Jira
N/A
<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [x] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
