### PR TITLE
fix(github): use correct name for failed checkruns on retest

### DIFF
--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -157,12 +157,17 @@ func (p *PacRun) Run(ctx context.Context) error {
 				errMsg := fmt.Sprintf("There was an error starting the PipelineRun %s, %s", match.PipelineRun.GetGenerateName(), err.Error())
 				errMsgM := fmt.Sprintf("There was an error creating the PipelineRun: <b>%s</b>\n\n%s", match.PipelineRun.GetGenerateName(), err.Error())
 				p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryPipelineRun", errMsg)
+				prName := match.PipelineRun.GetName()
+				if prName == "" {
+					prName = match.PipelineRun.GetGenerateName()
+				}
 				createStatusErr := p.vcx.CreateStatus(ctx, p.event, provider.StatusOpts{
-					PipelineRunName:          match.PipelineRun.GetName(),
+					PipelineRunName:          prName,
 					PipelineRun:              match.PipelineRun,
 					OriginalPipelineRunName:  match.PipelineRun.GetAnnotations()[keys.OriginalPRName],
 					Status:                   CompletedStatus,
 					Conclusion:               failureConclusion,
+					Title:                    "pipelinerun start failure",
 					Text:                     errMsgM,
 					DetailsURL:               p.run.Clients.ConsoleUI().URL(),
 					InstanceCountForCheckRun: i,

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -397,7 +397,9 @@ func (v *Provider) CreateStatus(ctx context.Context, runevent *info.Event, statu
 		statusOpts.Title = "Success"
 		statusOpts.Summary = "has <b>successfully</b> validated your commit."
 	case "failure":
-		statusOpts.Title = "Failed"
+		if statusOpts.Title == "" {
+			statusOpts.Title = "Failed"
+		}
 		statusOpts.Summary = "has <b>failed</b>."
 	case "pending":
 		// for concurrency set title as pending

--- a/test/testdata/pipelinerun-tekton-validation.yaml
+++ b/test/testdata/pipelinerun-tekton-validation.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          stepsos:
+            - name: step
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                echo "HELLOMOTO"
+                exit 0


### PR DESCRIPTION
after /retest or /test command failed check run was being wiped out because we didn't used correct pipelinerun name before when reporting failure in startPR func. now this uses the generateName if name is not available for a pipelinerun.

this also adds an e2e tests to ensure that checkrun for tekton validation failed pipelinerun is not wiped out.

https://issues.redhat.com/browse/SRVKP-10741

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [x] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
