### PR TITLE
ci: Move some GitHub public e2e test to GHE

### DIFF
--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -108,7 +108,7 @@ get_tests() {
     printf '%s\n' "${all_tests}" | grep -iP 'Flaky'
     ;;
   concurrency)
-    printf '%s\n' "${all_tests}" | grep -iP 'Concurrency'
+    printf '%s\n' "${all_tests}" | grep -iP 'Concurrency|Others'
     ;;
   github_1)
     if [[ ${#github_tests[@]} -gt 0 ]]; then
@@ -121,7 +121,7 @@ get_tests() {
     fi
     ;;
   github_second_controller)
-    printf '%s\n' "${all_tests}" | grep -iP 'GithubSecond|Others' | grep -ivP 'Concurrency|Flaky'
+    printf '%s\n' "${all_tests}" | grep -iP 'GithubSecond' | grep -ivP 'Concurrency|Flaky'
     ;;
   gitlab_bitbucket)
     printf '%s\n' "${all_tests}" | grep -iP 'Gitlab|Bitbucket' | grep -ivP 'Concurrency'

--- a/pkg/matcher/errors.go
+++ b/pkg/matcher/errors.go
@@ -48,7 +48,7 @@ func reportCELValidationErrors(ctx context.Context, repo *apipac.Repository, val
 	}
 	markdownErrMessage := fmt.Sprintf(`%s
 %s`, provider.ValidationErrorTemplate, strings.Join(errorRows, "\n"))
-	if err := vcx.CreateComment(ctx, event, markdownErrMessage, provider.ValidationErrorTemplate); err != nil {
+	if err := vcx.CreateComment(ctx, event, markdownErrMessage, provider.ValidationErrorMarker); err != nil {
 		eventEmitter.EmitMessage(repo, zap.ErrorLevel, "PipelineRunCommentCreationError",
 			fmt.Sprintf("failed to create comment: %s", err.Error()))
 	}

--- a/pkg/pipelineascode/errors.go
+++ b/pkg/pipelineascode/errors.go
@@ -63,7 +63,7 @@ func (p *PacRun) reportValidationErrors(ctx context.Context, repo *v1alpha1.Repo
 	}
 	markdownErrMessage := fmt.Sprintf(`%s
 %s`, provider.ValidationErrorTemplate, strings.Join(errorRows, "\n"))
-	if err := p.vcx.CreateComment(ctx, p.event, markdownErrMessage, provider.ValidationErrorTemplate); err != nil {
+	if err := p.vcx.CreateComment(ctx, p.event, markdownErrMessage, provider.ValidationErrorMarker); err != nil {
 		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "PipelineRunCommentCreationError",
 			fmt.Sprintf("failed to create comment: %s", err.Error()))
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -11,7 +11,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const ValidationErrorTemplate = `> [!CAUTION]
+const ValidationErrorMarker = "<!-- pac-validation-errors -->"
+
+const ValidationErrorTemplate = ValidationErrorMarker + `
+> [!CAUTION]
 > There are some errors in your PipelineRun template.
 
 | PipelineRun | Error |

--- a/test/github_config_maxkeepruns_test.go
+++ b/test/github_config_maxkeepruns_test.go
@@ -17,11 +17,12 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-func TestGithubMaxKeepRuns(t *testing.T) {
+func TestGithubSecondMaxKeepRuns(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:     "Github MaxKeepRun config",
-		YamlFiles: []string{"testdata/pipelinerun-max-keep-run-1.yaml"},
+		Label:            "Github MaxKeepRun config",
+		YamlFiles:        []string{"testdata/pipelinerun-max-keep-run-1.yaml"},
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)

--- a/test/github_incoming_test.go
+++ b/test/github_incoming_test.go
@@ -33,7 +33,7 @@ const (
 // TestGithubAppIncoming tests that a Pipelinerun with the incoming event
 // gets created despite the presence of multiple Pipelineruns in the .tekton directory with
 // eventType as incoming.
-func TestGithubAppIncoming(t *testing.T) {
+func TestGithubSecondAppIncoming(t *testing.T) {
 	randomedString := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 
 	entries, err := payload.GetEntries(map[string]string{
@@ -41,7 +41,7 @@ func TestGithubAppIncoming(t *testing.T) {
 	}, randomedString, randomedString, triggertype.Incoming.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{randomedString}, false, false, 1)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{randomedString}, false, true, 1)
 }
 
 func TestGithubSecondIncoming(t *testing.T) {
@@ -84,7 +84,7 @@ func TestGithubWebhookIncoming(t *testing.T) {
 // TestGithubAppIncomingForDifferentEvent tests that a Pipelinerun with the incoming event
 // gets created despite the presence of multiple Pipelineruns in the .tekton directory,
 // where one has an eventType as incoming and another as pull_request.
-func TestGithubAppIncomingForDifferentEvent(t *testing.T) {
+func TestGithubSecondAppIncomingForDifferentEvent(t *testing.T) {
 	randomedString := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 
 	entries, err := payload.GetEntries(map[string]string{
@@ -92,11 +92,11 @@ func TestGithubAppIncomingForDifferentEvent(t *testing.T) {
 	}, randomedString, randomedString, triggertype.PullRequest.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming-", entries, []string{randomedString}, false, false, 1)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming-", entries, []string{randomedString}, false, true, 1)
 }
 
 // TestGithubAppIncomingGlobPattern tests incoming webhook with glob pattern matching.
-func TestGithubAppIncomingGlobPattern(t *testing.T) {
+func TestGithubSecondAppIncomingGlobPattern(t *testing.T) {
 	randomedString := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 
 	entries, err := payload.GetEntries(map[string]string{
@@ -106,11 +106,11 @@ func TestGithubAppIncomingGlobPattern(t *testing.T) {
 
 	// Test with glob pattern that matches the branch name
 	// Pattern: pac-e2e-ns* should match branch pac-e2e-ns-xxxxx
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"pac-e2e-ns*"}, false, false, 1)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"pac-e2e-ns*"}, false, true, 1)
 }
 
 // TestGithubAppIncomingGlobPrefixPattern tests incoming webhook with prefix glob pattern.
-func TestGithubAppIncomingGlobPrefixPattern(t *testing.T) {
+func TestGithubSecondAppIncomingGlobPrefixPattern(t *testing.T) {
 	// Create a branch name with "feature-" prefix (using hyphen instead of slash for Kubernetes compliance)
 	randomedString := fmt.Sprintf("feature-%s", names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e"))
 
@@ -120,11 +120,11 @@ func TestGithubAppIncomingGlobPrefixPattern(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Test with glob pattern that matches feature branches
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"feature-*"}, false, false, 1)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"feature-*"}, false, true, 1)
 }
 
 // TestGithubAppIncomingGlobFirstMatchWins tests first-match-wins with multiple glob targets.
-func TestGithubAppIncomingGlobFirstMatchWins(t *testing.T) {
+func TestGithubSecondAppIncomingGlobFirstMatchWins(t *testing.T) {
 	randomedString := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 
 	entries, err := payload.GetEntries(map[string]string{
@@ -134,11 +134,11 @@ func TestGithubAppIncomingGlobFirstMatchWins(t *testing.T) {
 
 	// Multiple patterns - first one that matches should win
 	// Both pac-e2e-ns* and * will match, but first should win
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"pac-e2e-ns*", "*"}, false, false, 1)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"pac-e2e-ns*", "*"}, false, true, 1)
 }
 
 // TestGithubAppIncomingNoMatch tests that incoming webhook fails when branch doesn't match any target.
-func TestGithubAppIncomingNoMatch(t *testing.T) {
+func TestGithubSecondAppIncomingNoMatch(t *testing.T) {
 	randomedString := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 
 	entries, err := payload.GetEntries(map[string]string{
@@ -148,11 +148,11 @@ func TestGithubAppIncomingNoMatch(t *testing.T) {
 
 	// Test with glob pattern that will NOT match the branch
 	// Pattern: production-* should NOT match branch pac-e2e-ns-xxxxx
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"production-*"}, false, false, 0)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"production-*"}, false, true, 0)
 }
 
 // TestGithubAppIncomingMultiplePatternsNoMatch tests that incoming webhook fails when none of the patterns match.
-func TestGithubAppIncomingMultiplePatternsNoMatch(t *testing.T) {
+func TestGithubSecondAppIncomingMultiplePatternsNoMatch(t *testing.T) {
 	randomedString := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 
 	entries, err := payload.GetEntries(map[string]string{
@@ -161,11 +161,11 @@ func TestGithubAppIncomingMultiplePatternsNoMatch(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Multiple patterns that all don't match the branch
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"production-*", "staging-*", "release-*"}, false, false, 0)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"production-*", "staging-*", "release-*"}, false, true, 0)
 }
 
 // TestGithubAppIncomingNoMatchExactName tests that exact non-matching string doesn't match.
-func TestGithubAppIncomingNoMatchExactName(t *testing.T) {
+func TestGithubSecondAppIncomingNoMatchExactName(t *testing.T) {
 	randomedString := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 
 	entries, err := payload.GetEntries(map[string]string{
@@ -174,7 +174,7 @@ func TestGithubAppIncomingNoMatchExactName(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Test with exact branch name that doesn't match
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"main", "develop", "staging"}, false, false, 0)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"main", "develop", "staging"}, false, true, 0)
 }
 
 func verifyIncomingWebhook(t *testing.T, randomedString, pipelinerunName string, entries map[string]string, targets []string, onWebhook, onSecondController bool, numberOfPR int) {

--- a/test/github_pullrequest_retest_test.go
+++ b/test/github_pullrequest_retest_test.go
@@ -147,7 +147,7 @@ func TestGithubSecondPullRequestGitopsCommentCancel(t *testing.T) {
 	assert.Equal(t, unknownCount, 0, "should have zero unknown PipelineRuns: %+v", pruns.Items)
 }
 
-func TestGithubRetestWithMultipleFailedPipelineRuns(t *testing.T) {
+func TestGithubSecondRetestWithMultipleFailedPipelineRuns(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label: "Github Retest with multiple failed PipelineRuns",
@@ -155,7 +155,8 @@ func TestGithubRetestWithMultipleFailedPipelineRuns(t *testing.T) {
 			"testdata/pipelinerun-tekton-validation.yaml",
 			"testdata/failures/pipelinerun-exit-1.yaml", // failed pipelinerun to be re-trigger after retest
 		},
-		NoStatusCheck: true,
+		NoStatusCheck:    true,
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -54,38 +54,41 @@ func TestGithubSecondPullRequest(t *testing.T) {
 	defer g.TearDown(ctx, t)
 }
 
-func TestGithubPullRequestMultiples(t *testing.T) {
+func TestGithubSecondPullRequestMultiples(t *testing.T) {
 	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
 		t.Skip("Skipping test since only enabled for nightly")
 	}
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:     "Github multiple PullRequest",
-		YamlFiles: []string{"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml"},
+		Label:            "Github multiple PullRequest",
+		YamlFiles:        []string{"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml"},
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
 }
 
-func TestGithubPullRequestMatchOnCEL(t *testing.T) {
+func TestGithubSecondPullRequestMatchOnCEL(t *testing.T) {
 	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
 		t.Skip("Skipping test since only enabled for nightly")
 	}
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:     "Github CEL Match",
-		YamlFiles: []string{"testdata/pipelinerun-cel-annotation.yaml"},
+		Label:            "Github CEL Match",
+		YamlFiles:        []string{"testdata/pipelinerun-cel-annotation.yaml"},
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
 }
 
-func TestGithubPullRequestOnLabel(t *testing.T) {
+func TestGithubSecondPullRequestOnLabel(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:         "Github On Label",
-		YamlFiles:     []string{"testdata/pipelinerun-on-label.yaml"},
-		NoStatusCheck: true,
+		Label:            "Github On Label",
+		YamlFiles:        []string{"testdata/pipelinerun-on-label.yaml"},
+		NoStatusCheck:    true,
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
@@ -136,11 +139,12 @@ func TestGithubPullRequestOnLabel(t *testing.T) {
 	assert.Assert(t, strings.HasPrefix(checkName, expected), "checkName %s != expected %s", checkName, expected)
 }
 
-func TestGithubPullRequestCELMatchOnTitle(t *testing.T) {
+func TestGithubSecondPullRequestCELMatchOnTitle(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:     "Github CEL Match on Title",
-		YamlFiles: []string{"testdata/pipelinerun-cel-annotation-for-title-match.yaml"},
+		Label:            "Github CEL Match on Title",
+		YamlFiles:        []string{"testdata/pipelinerun-cel-annotation-for-title-match.yaml"},
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
@@ -422,11 +426,12 @@ func TestGithubSecondCancelInProgressPRClosed(t *testing.T) {
 	assert.Equal(t, res.CheckRuns[0].GetConclusion(), "cancelled")
 }
 
-func TestGithubPullRequestNoOnLabelAnnotation(t *testing.T) {
+func TestGithubSecondPullRequestNoOnLabelAnnotation(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:     "Github PullRequest",
-		YamlFiles: []string{"testdata/pipelinerun-pr-cel-expression.yaml"},
+		Label:            "Github PullRequest",
+		YamlFiles:        []string{"testdata/pipelinerun-pr-cel-expression.yaml"},
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
@@ -450,12 +455,13 @@ func TestGithubPullRequestNoOnLabelAnnotation(t *testing.T) {
 	}
 }
 
-func TestGithubPullRequestCELLabelEvent(t *testing.T) {
+func TestGithubSecondPullRequestCELLabelEvent(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:         "Github CEL Label Event",
-		YamlFiles:     []string{"testdata/pipelinerun-cel-label-event.yaml"},
-		NoStatusCheck: true,
+		Label:            "Github CEL Label Event",
+		YamlFiles:        []string{"testdata/pipelinerun-cel-label-event.yaml"},
+		NoStatusCheck:    true,
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
@@ -514,12 +520,13 @@ func TestGithubPullRequestCELLabelEvent(t *testing.T) {
 	assert.Assert(t, strings.HasPrefix(checkName, expected), "checkName %s != expected %s", checkName, expected)
 }
 
-func TestGithubPullRequestNoPipelineRunCancelledOnPRClosed(t *testing.T) {
+func TestGithubSecondPullRequestNoPipelineRunCancelledOnPRClosed(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:         "Github PullRequest",
-		YamlFiles:     []string{"testdata/pipelinerun-gitops.yaml"},
-		NoStatusCheck: true,
+		Label:            "Github PullRequest",
+		YamlFiles:        []string{"testdata/pipelinerun-gitops.yaml"},
+		NoStatusCheck:    true,
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
@@ -666,11 +673,12 @@ func TestGithubCancelInProgressSettingFromConfigMapOnPush(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func TestGithubPullandPushMatchTriggerOnlyPull(t *testing.T) {
+func TestGithubSecondPullandPushMatchTriggerOnlyPull(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:     "Github PullRequest",
-		YamlFiles: []string{"testdata/pipelinerun-match-push-pullr.yaml"},
+		Label:            "Github PullRequest",
+		YamlFiles:        []string{"testdata/pipelinerun-match-push-pullr.yaml"},
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
@@ -719,12 +727,13 @@ func TestGithubDisableCommentsOnPR(t *testing.T) {
 	assert.Equal(t, 0, successCommentsPost)
 }
 
-func TestGithubIgnoreTagPushCommitsFromSkipPushEventsSetting(t *testing.T) {
+func TestGithubSecondIgnoreTagPushCommitsFromSkipPushEventsSetting(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:         "Github PullRequest",
-		YamlFiles:     []string{"testdata/pipelinerun.yaml"},
-		NoStatusCheck: true,
+		Label:            "Github PullRequest",
+		YamlFiles:        []string{"testdata/pipelinerun.yaml"},
+		NoStatusCheck:    true,
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
@@ -752,11 +761,12 @@ func TestGithubIgnoreTagPushCommitsFromSkipPushEventsSetting(t *testing.T) {
 
 // TestGithubPullRequestCelPrefix tests the cel: prefix for arbitrary CEL expressions.
 // The cel: prefix allows evaluating full CEL expressions with access to body, headers, files, and pac namespaces.
-func TestGithubPullRequestCelPrefix(t *testing.T) {
+func TestGithubSecondPullRequestCelPrefix(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:     "Github CEL Prefix",
-		YamlFiles: []string{"testdata/pipelinerun-cel-prefix-github.yaml"},
+		Label:            "Github CEL Prefix",
+		YamlFiles:        []string{"testdata/pipelinerun-cel-prefix-github.yaml"},
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)

--- a/test/github_pullrequest_test_comment_test.go
+++ b/test/github_pullrequest_test_comment_test.go
@@ -17,7 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestGithubPullRequestTest(t *testing.T) {
+func TestGithubSecondPullRequestTest(t *testing.T) {
 	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
 		t.Skip("Skipping test since only enabled for nightly")
 	}
@@ -25,7 +25,7 @@ func TestGithubPullRequestTest(t *testing.T) {
 	g := &tgithub.PRTest{
 		Label:            "Github test implicit comment",
 		YamlFiles:        []string{"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml"},
-		SecondController: false,
+		SecondController: true,
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)

--- a/test/github_push_retest_test.go
+++ b/test/github_push_retest_test.go
@@ -20,14 +20,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGithubPushRequestGitOpsCommentOnComment(t *testing.T) {
+func TestGithubSecondPushRequestGitOpsCommentOnComment(t *testing.T) {
 	opsComment := "/hello-world"
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:         "Github GitOps push/retest request",
-		YamlFiles:     []string{"testdata/pipelinerun-on-comment-annotation.yaml"},
-		NoStatusCheck: true,
-		TargetRefName: options.MainBranch,
+		Label:            "Github GitOps push/retest request",
+		YamlFiles:        []string{"testdata/pipelinerun-on-comment-annotation.yaml"},
+		NoStatusCheck:    true,
+		TargetRefName:    options.MainBranch,
+		SecondController: true,
 	}
 	g.RunPushRequest(ctx, t)
 	defer g.TearDown(ctx, t)
@@ -81,13 +82,14 @@ func TestGithubPushRequestGitOpsCommentOnComment(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func TestGithubPushRequestGitOpsCommentRetest(t *testing.T) {
+func TestGithubSecondPushRequestGitOpsCommentRetest(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label: "Github GitOps push/retest request",
 		YamlFiles: []string{
 			"testdata/pipelinerun-on-push.yaml", "testdata/pipelinerun.yaml",
 		},
+		SecondController: true,
 	}
 	g.RunPushRequest(ctx, t)
 	defer g.TearDown(ctx, t)
@@ -137,12 +139,12 @@ func TestGithubPushRequestGitOpsCommentRetest(t *testing.T) {
 	}
 }
 
-func TestGithubPushRequestGitOpsCommentCancel(t *testing.T) {
+func TestGithubSecondPushRequestGitOpsCommentCancel(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label:            "GitHub Gitops push/cancel request",
 		YamlFiles:        []string{"testdata/pipelinerun-on-push.yaml", "testdata/pipelinerun.yaml"},
-		SecondController: false,
+		SecondController: true,
 	}
 	g.RunPushRequest(ctx, t)
 	defer g.TearDown(ctx, t)

--- a/test/github_skip_ci_test.go
+++ b/test/github_skip_ci_test.go
@@ -48,12 +48,13 @@ func verifySkipCI(ctx context.Context, t *testing.T, g *tgithub.PRTest, eventTyp
 
 // TestGithubSkipCIPullRequest tests that [skip ci] in commit message prevents
 // PipelineRun execution on pull requests.
-func TestGithubSkipCIPullRequest(t *testing.T) {
+func TestGithubSecondSkipCIPullRequest(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:         "Github Skip CI Pull Request [skip ci]",
-		YamlFiles:     []string{"testdata/pipelinerun.yaml"},
-		NoStatusCheck: true, // Don't wait for success since we expect no PipelineRun
+		Label:            "Github Skip CI Pull Request [skip ci]",
+		YamlFiles:        []string{"testdata/pipelinerun.yaml"},
+		NoStatusCheck:    true, // Don't wait for success since we expect no PipelineRun
+		SecondController: true,
 	}
 
 	// The CommitTitle will be used as the commit message, so [skip ci] is included
@@ -65,12 +66,13 @@ func TestGithubSkipCIPullRequest(t *testing.T) {
 
 // TestGithubSkipCIPush tests that [skip ci] in commit message prevents
 // PipelineRun execution on push events.
-func TestGithubSkipCIPush(t *testing.T) {
+func TestGithubSecondSkipCIPush(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:         "Github Skip CI Push [skip ci]",
-		YamlFiles:     []string{"testdata/pipelinerun-on-push.yaml"},
-		NoStatusCheck: true, // Don't wait for success since we expect no PipelineRun
+		Label:            "Github Skip CI Push [skip ci]",
+		YamlFiles:        []string{"testdata/pipelinerun-on-push.yaml"},
+		NoStatusCheck:    true, // Don't wait for success since we expect no PipelineRun
+		SecondController: true,
 	}
 
 	g.RunPushRequest(ctx, t)
@@ -80,12 +82,13 @@ func TestGithubSkipCIPush(t *testing.T) {
 }
 
 // TestGithubSkipCITestCommand tests that /test command can override [skip tkn].
-func TestGithubSkipCITestCommand(t *testing.T) {
+func TestGithubSecondSkipCITestCommand(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:         "Github Skip CI Test Command [skip tkn]",
-		YamlFiles:     []string{"testdata/pipelinerun.yaml"},
-		NoStatusCheck: true,
+		Label:            "Github Skip CI Test Command [skip tkn]",
+		YamlFiles:        []string{"testdata/pipelinerun.yaml"},
+		NoStatusCheck:    true,
+		SecondController: true,
 	}
 
 	g.RunPullRequest(ctx, t)

--- a/test/github_tag_gitops_test.go
+++ b/test/github_tag_gitops_test.go
@@ -21,9 +21,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGithubGitOpsCommentOnTag(t *testing.T) {
+func TestGithubSecondGitOpsCommentOnTag(t *testing.T) {
 	ctx := context.Background()
-	ctx, runcnx, opts, ghcnx, err := tgithub.Setup(ctx, false, false)
+	ctx, runcnx, opts, ghcnx, err := tgithub.Setup(ctx, true, false)
 	assert.NilError(t, err)
 	tagName := "v1.0.0"
 	comment := "/test tag:" + tagName

--- a/test/github_tkn_pac_cli_test.go
+++ b/test/github_tkn_pac_cli_test.go
@@ -24,10 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGithubPacCli(t *testing.T) {
+func TestGithubSecondPacCli(t *testing.T) {
 	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 	ctx := context.Background()
-	ctx, runcnx, opts, ghprovider, err := tgithub.Setup(ctx, false, false)
+	ctx, runcnx, opts, ghprovider, err := tgithub.Setup(ctx, true, false)
 	assert.NilError(t, err)
 
 	entries := map[string]string{

--- a/test/testdata/TestGithubSecondFlakyPullRequestBadYaml.golden
+++ b/test/testdata/TestGithubSecondFlakyPullRequestBadYaml.golden
@@ -1,3 +1,4 @@
+<!-- pac-validation-errors -->
 > [!CAUTION]
 > There are some errors in your PipelineRun template.
 


### PR DESCRIPTION
- **fix: Rework the duplicate comments creation fix**
  Removed the workaround that introduced a random sleep to mitigate
  duplicate comment creation on GitHub. Instead, the `CreateComment`
  function now explicitly lists existing comments with the provided marker
  and deletes any duplicates, ensuring only the most recent comment is
  retained. This provides a more robust solution to the issue where
  GitHub's API occasionally creates multiple identical comments from a
  single API call.
  
  Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
  

- **feat: Move some GitHub public e2e test to GHE**
  Added the `SecondController: true` flag to numerous GitHub integration
  tests. This change enables the use of the second controller in these
  tests, ensuring broader coverage and verification of the GitHub
  integration's functionality. The modification spans various test files,
  including those for pull requests, incoming webhooks, push events, and
  skip CI scenarios.
  
  And at the same time move the TestOthers to concurrency to balance the
  loads.
  
  Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
  