### PR TITLE
fix(github): resolve pull_request_number on retest for pushed commits

### DIFF
--- a/test/github_push_retest_test.go
+++ b/test/github_push_retest_test.go
@@ -5,16 +5,23 @@ package test
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v81/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/names"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -216,4 +223,113 @@ func TestGithubSecondPushRequestGitOpsCommentCancel(t *testing.T) {
 		}
 	}
 	assert.Assert(t, cancelled, "No cancelled pipeline run found")
+}
+
+func TestGithubPullRequestRetestPullRequestNumberSubstitution(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	g := &tgithub.PRTest{}
+
+	ctx, runcnx, opts, ghcnx, err := tgithub.Setup(ctx, g.SecondController, g.Webhook)
+	assert.NilError(t, err)
+	g.Logger = runcnx.Clients.Log
+
+	g.CommitTitle = fmt.Sprintf("Testing %s with Github APPS integration on %s", g.Label, targetNS)
+	g.Logger.Info(g.CommitTitle)
+
+	repoinfo, resp, err := ghcnx.Client().Repositories.Get(ctx, opts.Organization, opts.Repo)
+	assert.NilError(t, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	if g.Options.Settings.Github != nil {
+		opts.Settings = g.Options.Settings
+	}
+	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
+	assert.NilError(t, err)
+
+	tempBaseBranch := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("temp-base-branch")
+	tempBaseBranchRef := fmt.Sprintf("refs/heads/%s", tempBaseBranch)
+
+	// Get the SHA of the default branch
+	defaultBranchRef, _, err := ghcnx.Client().Git.GetRef(ctx, opts.Organization, opts.Repo, fmt.Sprintf("refs/heads/%s", repoinfo.GetDefaultBranch()))
+	assert.NilError(t, err)
+
+	// Create the temporary base branch
+	_, _, err = ghcnx.Client().Git.CreateRef(ctx, opts.Organization, opts.Repo, github.CreateRef{
+		Ref: tempBaseBranchRef,
+		SHA: *defaultBranchRef.Object.SHA,
+	})
+	assert.NilError(t, err)
+
+	yamlEntries := map[string]string{".tekton/pipelinerun-pr-number-variable.yaml": "testdata/pipelinerun-pr-number-variable.yaml"}
+
+	entries, err := payload.GetEntries(yamlEntries, targetNS, tempBaseBranchRef, triggertype.Push.String(), map[string]string{})
+	assert.NilError(t, err)
+
+	targetRefName := fmt.Sprintf("refs/heads/%s",
+		names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"))
+
+	sha, vref, err := tgithub.PushFilesToRef(ctx, ghcnx.Client(), g.CommitTitle, tempBaseBranchRef, targetRefName,
+		opts.Organization, opts.Repo, entries)
+	assert.NilError(t, err)
+
+	g.Logger.Infof("Commit %s has been created and pushed to %s", sha, vref.GetURL())
+	number, err := tgithub.PRCreate(ctx, runcnx, ghcnx, opts.Organization,
+		opts.Repo, targetRefName, tempBaseBranchRef, g.CommitTitle)
+	assert.NilError(t, err)
+
+	g.Cnx = runcnx
+	g.Options = opts
+	g.Provider = ghcnx
+	g.TargetNamespace = targetNS
+	g.TargetRefName = targetRefName
+	g.PRNumber = number
+	g.SHA = sha
+
+	defer g.TearDown(ctx, t)
+	defer func() {
+		if os.Getenv("TEST_NOCLEANUP") != "true" {
+			g.Logger.Infof("Deleting Ref %s", tempBaseBranchRef)
+			_, err := ghcnx.Client().Git.DeleteRef(ctx, opts.Organization, opts.Repo, tempBaseBranchRef)
+			assert.NilError(t, err)
+		}
+	}()
+
+	mergeResult, _, err := g.Provider.Client().PullRequests.Merge(ctx, opts.Organization, opts.Repo, g.PRNumber, g.CommitTitle, &github.PullRequestOptions{
+		MergeMethod: "rebase",
+		SHA:         sha,
+	})
+	assert.NilError(t, err)
+	g.Logger.Infof("Pull request %d has been merged", g.PRNumber)
+
+	// wait for API to reflect this PR in response
+	time.Sleep(10 * time.Second)
+
+	mergedSHA := mergeResult.GetSHA()
+
+	_, _, err = g.Provider.Client().Repositories.CreateComment(ctx, opts.Organization, opts.Repo, mergedSHA, &github.RepositoryComment{Body: github.Ptr("/retest pipelinerun-pr-number-variable branch:" + tempBaseBranch)})
+	assert.NilError(t, err)
+	g.Logger.Infof("Comment %s has been created", mergedSHA)
+
+	waitOpts := twait.Opts{
+		RepoName:        g.TargetNamespace,
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: 2,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       mergedSHA,
+	}
+
+	err = twait.UntilPipelineRunHasReason(ctx, g.Cnx.Clients, tektonv1.PipelineRunReasonSuccessful, waitOpts)
+	assert.NilError(t, err)
+
+	regex := regexp.MustCompile(fmt.Sprintf("I don't know my PR number is %d", g.PRNumber))
+
+	// because there are two pipeline runs were created due to pull request merge, we need the one which is triggered on retest comment.
+	err = twait.RegexpMatchingInPodLog(ctx, g.Cnx, g.TargetNamespace,
+		fmt.Sprintf("pipelinesascode.tekton.dev/event-type=%s",
+			opscomments.RetestSingleCommentEventType.String()),
+		"step-task", *regex, "", 2)
+	assert.NilError(t, err)
 }

--- a/test/testdata/pipelinerun-pr-number-variable.yaml
+++ b/test/testdata/pipelinerun-pr-number-variable.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "pipelinerun-pr-number-variable"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        displayName: "The Task name is Task"
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi10/ubi-micro
+              command: ["/bin/echo", "I don't know my PR number is {{ pull_request_number }}"]


### PR DESCRIPTION
- The {{ pull_request_number }} variable was not substituted when a /retest command was issued on a pushed commit (e.g. a commit resulting from a PR merge) because the commit comment handler in ParsePayload did not fetch the associated pull requests for the commit SHA.
- Fetch PRs via getPullRequestsWithCommit in handleCommitCommentEvent so the PullRequestNumber is set on the event before variable substitution runs.
- Add a unit test for commit_comment events to verify the PullRequestNumber is populated from the associated PR.
- Add an e2e test that merges a PR, issues /retest on the merged commit, and asserts the PipelineRun logs contain the correct pull request number.
- Add a new testdata PipelineRun fixture that echoes the {{ pull_request_number }} variable for validation.

https://issues.redhat.com/browse/SRVKP-10662

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [x] GitHub App
  - [x] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
