### PR TITLE
feat: Switch gitea to forgejo provider type

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -210,13 +210,15 @@ spec:
                         - 'gitlab': GitLab.com or self-hosted GitLab
                         - 'bitbucket-datacenter': Bitbucket Data Center (self-hosted)
                         - 'bitbucket-cloud': Bitbucket Cloud (bitbucket.org)
-                        - 'gitea': Gitea instances
+                        - 'forgejo': Forgejo instances
+                        - 'gitea': Gitea instances (alias for forgejo, kept for backwards compatibility)
                       enum:
                         - github
                         - gitlab
                         - bitbucket-datacenter
                         - bitbucket-cloud
                         - gitea
+                        - forgejo
                       type: string
                     url:
                       description: |-

--- a/docs/content/docs/dev/_index.md
+++ b/docs/content/docs/dev/_index.md
@@ -62,7 +62,7 @@ metadata:
 spec:
   url: "https://forgejo.example.com/owner/repo"
   git_provider:
-    type: "gitea"  # Use "gitea" - Forgejo is API-compatible with Gitea
+    type: "forgejo"
     url: "https://forgejo.example.com/"
     secret:
       name: "forgejo-secret"

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -452,7 +452,7 @@ tkn pac cel -b <body.json> -H <headers.txt>
 
 * `-b, --body`: Path to JSON body file (webhook payload) **[required]**
 * `-H, --headers`: Path to headers file (plain text, JSON, or gosmee script) **[required]**
-* `-p, --provider`: Provider (auto, github, gitlab, bitbucket-cloud, bitbucket-datacenter, gitea)
+* `-p, --provider`: Provider (auto, github, gitlab, bitbucket-cloud, bitbucket-datacenter, gitea, forgejo)
 
 #### Interactive Mode
 

--- a/docs/content/docs/guide/incoming_webhook.md
+++ b/docs/content/docs/guide/incoming_webhook.md
@@ -29,7 +29,10 @@ values are:
 
 - github
 - gitlab
+- forgejo
+- gitea (alias for forgejo)
 - bitbucket-cloud
+- bitbucket-datacenter
 
 Whereas for `github-apps` this does not need to be added.
 {{< /hint >}}

--- a/docs/content/docs/install/forgejo.md
+++ b/docs/content/docs/install/forgejo.md
@@ -9,7 +9,7 @@ weight: 14
 
 Pipelines-as-Code supports [Forgejo](https://forgejo.org) through a webhook.
 
-Forgejo is a community-driven Git forge that originated as a fork of Gitea. Pipelines-as-Code originally supported Gitea and now supports Forgejo, maintaining API compatibility between the two platforms. Both use the same provider type (`gitea`) in Pipelines-as-Code configuration.
+Forgejo is a community-driven Git forge that originated as a fork of Gitea. Pipelines-as-Code supports Forgejo as a first-class provider type. You can use `type: "forgejo"` in your Repository CRD configuration, or `type: "gitea"` for backwards compatibility.
 
 Follow the Pipelines-as-Code [installation](/docs/install/installation) according to your Kubernetes cluster.
 
@@ -115,8 +115,7 @@ metadata:
 spec:
   url: "https://forgejo.example.com/owner/repo"
   git_provider:
-    # Use "gitea" as the type - Forgejo is API-compatible with Gitea
-    type: "gitea"
+    type: "forgejo"
     # Set this to your Forgejo instance URL
     url: "https://forgejo.example.com"
     secret:
@@ -131,7 +130,7 @@ spec:
 
 ## Notes
 
-- **Provider Type**: Use `type: "gitea"` in your Repository CRD. Forgejo is a fork of Gitea and maintains full API compatibility.
+- **Provider Type**: Use `type: "forgejo"` in your Repository CRD. The legacy `type: "gitea"` is kept as an alias for backwards compatibility.
 
 - **Forgejo Instance URL**: You must specify `git_provider.url` pointing to your Forgejo instance URL.
 

--- a/docs/content/docs/install/global_repositories_setting.md
+++ b/docs/content/docs/install/global_repositories_setting.md
@@ -100,7 +100,8 @@ means a repository configured using [GitHub webhooks]({{< relref "/docs/install/
 
 - github
 - gitlab
-- gitea (used as well for Forgejo)
+- forgejo
+- gitea (alias for forgejo, kept for backwards compatibility)
 - bitbucket-cloud
 - bitbucket-datacenter
 

--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -231,7 +231,7 @@ func (l *listener) processIncoming(targetRepo *v1alpha1.Repository) (provider.In
 			provider = github.New()
 		case "gitlab":
 			provider = &gitlab.Provider{}
-		case "gitea":
+		case "gitea", "forgejo":
 			provider = &gitea.Provider{}
 		case "bitbucket-cloud":
 			provider = &bitbucketcloud.Provider{}

--- a/pkg/adapter/incoming_test.go
+++ b/pkg/adapter/incoming_test.go
@@ -934,6 +934,20 @@ func Test_listener_processIncoming(t *testing.T) {
 			},
 		},
 		{
+			name:     "process/forgejo",
+			want:     &gitea.Provider{},
+			wantOrg:  "owner",
+			wantRepo: "repo",
+			targetRepo: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://forge/owner/repo",
+					GitProvider: &v1alpha1.GitProvider{
+						Type: "forgejo",
+					},
+				},
+			},
+		},
+		{
 			name:    "error/unknown provider",
 			wantErr: true,
 			targetRepo: &v1alpha1.Repository{

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -286,15 +286,25 @@ type GitProvider struct {
 	// - 'gitlab': GitLab.com or self-hosted GitLab
 	// - 'bitbucket-datacenter': Bitbucket Data Center (self-hosted)
 	// - 'bitbucket-cloud': Bitbucket Cloud (bitbucket.org)
-	// - 'gitea': Gitea instances
+	// - 'forgejo': Forgejo instances
+	// - 'gitea': Gitea instances (alias for forgejo, kept for backwards compatibility)
 	// +optional
-	// +kubebuilder:validation:Enum=github;gitlab;bitbucket-datacenter;bitbucket-cloud;gitea
+	// +kubebuilder:validation:Enum=github;gitlab;bitbucket-datacenter;bitbucket-cloud;gitea;forgejo
 	Type string `json:"type,omitempty"`
 }
 
+// areEquivalentProviderTypes checks if gitea/forgejo aliases refer to the same provider.
+func areEquivalentProviderTypes(a, b string) bool {
+	if a == b {
+		return true
+	}
+	giteaTypes := map[string]bool{"gitea": true, "forgejo": true}
+	return giteaTypes[a] && giteaTypes[b]
+}
+
 func (g *GitProvider) Merge(newGitProvider *GitProvider) {
-	// only merge of the same type
-	if newGitProvider.Type != "" && g.Type != "" && g.Type != newGitProvider.Type {
+	// only merge of the same type (gitea and forgejo are equivalent)
+	if newGitProvider.Type != "" && g.Type != "" && !areEquivalentProviderTypes(g.Type, newGitProvider.Type) {
 		return
 	}
 	if newGitProvider.URL != "" && g.URL == "" {

--- a/pkg/apis/pipelinesascode/v1alpha1/types_test.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types_test.go
@@ -133,6 +133,54 @@ func TestMergeSpecs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "forgejo local merges with gitea global",
+			local: &RepositorySpec{
+				GitProvider: &GitProvider{
+					Type: "forgejo",
+				},
+			},
+			global: RepositorySpec{
+				GitProvider: &GitProvider{
+					Type:   "gitea",
+					URL:    "https://gitea.example.com",
+					User:   "user",
+					Secret: &Secret{Name: "secret"},
+				},
+			},
+			expected: &RepositorySpec{
+				GitProvider: &GitProvider{
+					Type:   "forgejo",
+					URL:    "https://gitea.example.com",
+					User:   "user",
+					Secret: &Secret{Name: "secret"},
+				},
+			},
+		},
+		{
+			name: "gitea local merges with forgejo global",
+			local: &RepositorySpec{
+				GitProvider: &GitProvider{
+					Type: "gitea",
+				},
+			},
+			global: RepositorySpec{
+				GitProvider: &GitProvider{
+					Type:   "forgejo",
+					URL:    "https://forgejo.example.com",
+					User:   "user",
+					Secret: &Secret{Name: "secret"},
+				},
+			},
+			expected: &RepositorySpec{
+				GitProvider: &GitProvider{
+					Type:   "gitea",
+					URL:    "https://forgejo.example.com",
+					User:   "user",
+					Secret: &Secret{Name: "secret"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmd/tknpac/cel/cel.go
+++ b/pkg/cmd/tknpac/cel/cel.go
@@ -634,7 +634,7 @@ that would be used in PipelineRun configurations.`,
 					return err
 				}
 				pacParams = pacParamsFromEvent(event)
-			case "gitea":
+			case "gitea", "forgejo":
 				event, err := eventFromGitea(bodyBytes, headers)
 				if err != nil {
 					return err
@@ -738,7 +738,7 @@ that would be used in PipelineRun configurations.`,
 
 	cmd.Flags().StringVarP(&bodyFile, bodyFileFlag, "b", "", "path to JSON body file (required)")
 	cmd.Flags().StringVarP(&headersFile, headersFileFlag, "H", "", "path to headers file (required, JSON, HTTP format, or gosmee-generated shell script)")
-	cmd.Flags().StringVarP(&provider, providerFlag, "p", "auto", "payload provider (auto, github, gitlab, bitbucket-cloud, bitbucket-datacenter, gitea)")
+	cmd.Flags().StringVarP(&provider, providerFlag, "p", "auto", "payload provider (auto, github, gitlab, bitbucket-cloud, bitbucket-datacenter, gitea, forgejo)")
 	cmd.Flags().StringVarP(&githubToken, githubTokenFlag, "t", "", "GitHub personal access token for API enrichment (enables full event processing)")
 	// Mark body and headers flags as required.
 	// These errors are safe to ignore as the flags are defined above.

--- a/pkg/cmd/tknpac/cel/cel_test.go
+++ b/pkg/cmd/tknpac/cel/cel_test.go
@@ -1214,7 +1214,7 @@ func TestCommandFlags(t *testing.T) {
 	providerFlag := cmd.Flags().Lookup("provider")
 	assert.Assert(t, providerFlag != nil)
 	assert.Equal(t, providerFlag.Shorthand, "p")
-	assert.Equal(t, providerFlag.Usage, "payload provider (auto, github, gitlab, bitbucket-cloud, bitbucket-datacenter, gitea)")
+	assert.Equal(t, providerFlag.Usage, "payload provider (auto, github, gitlab, bitbucket-cloud, bitbucket-datacenter, gitea, forgejo)")
 	assert.Equal(t, providerFlag.DefValue, "auto")
 }
 

--- a/pkg/reconciler/emit_metrics.go
+++ b/pkg/reconciler/emit_metrics.go
@@ -34,7 +34,7 @@ func (r *Reconciler) countPipelineRun(pr *tektonv1.PipelineRun) error {
 		} else {
 			gitProvider += "-webhook"
 		}
-	case "gitlab", "gitea", "bitbucket-cloud", "bitbucket-datacenter":
+	case "gitlab", "gitea", "forgejo", "bitbucket-cloud", "bitbucket-datacenter":
 		gitProvider += "-webhook"
 	default:
 		return fmt.Errorf("no supported Git provider")

--- a/pkg/reconciler/emit_metrics_test.go
+++ b/pkg/reconciler/emit_metrics_test.go
@@ -76,6 +76,18 @@ func TestCountPipelineRun(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "provider is Forgejo",
+			annotations: map[string]string{
+				keys.GitProvider: "forgejo",
+				keys.EventType:   "push",
+			},
+			tags: map[string]string{
+				"provider":   "forgejo-webhook",
+				"event-type": "push",
+			},
+			wantErr: false,
+		},
+		{
 			name: "unsupported provider",
 			annotations: map[string]string{
 				keys.GitProvider: "unsupported",

--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -23,7 +23,7 @@ import (
 // interface, event information, and an error if any occurs during detection or
 // initialization.
 //
-// Supported providers: github, gitlab, bitbucket-cloud, bitbucket-datacenter, gitea
+// Supported providers: github, gitlab, bitbucket-cloud, bitbucket-datacenter, forgejo (gitea)
 // any new provider should be added to the switch case below.
 func (r *Reconciler) detectProvider(ctx context.Context, logger *zap.SugaredLogger, pr *tektonv1.PipelineRun) (provider.Interface, *info.Event, error) {
 	gitProvider, ok := pr.GetAnnotations()[keys.GitProvider]
@@ -51,7 +51,7 @@ func (r *Reconciler) detectProvider(ctx context.Context, logger *zap.SugaredLogg
 		provider = &bitbucketcloud.Provider{}
 	case "bitbucket-datacenter":
 		provider = &bitbucketdatacenter.Provider{}
-	case "gitea":
+	case "gitea", "forgejo":
 		provider = &gitea.Provider{}
 	default:
 		return nil, nil, fmt.Errorf("failed to detect provider for pipelinerun: %s : unknown provider", pr.GetName())

--- a/pkg/reconciler/event_test.go
+++ b/pkg/reconciler/event_test.go
@@ -99,6 +99,11 @@ func TestDetectProvider(t *testing.T) {
 			errStr:     "",
 		},
 		{
+			name:       "forgejo provider resolves to gitea",
+			annotation: "forgejo",
+			errStr:     "",
+		},
+		{
 			name:       "unknown provider",
 			annotation: "batman",
 			errStr:     "failed to detect provider for pipelinerun: test : unknown provider",

--- a/test/pkg/gitea/scm.go
+++ b/test/pkg/gitea/scm.go
@@ -143,6 +143,7 @@ func CreateGiteaRepo(giteaClient *forgejo.Client, user, name, defaultBranch, hoo
 	}
 	logger.Infof("Creating webhook to smee url on gitea repository %s", name)
 	_, _, err = giteaClient.CreateRepoHook(user, repo.Name, forgejo.CreateHookOption{
+		// Forgejo still uses the "gitea" hook type for webhooks.
 		Type:   "gitea",
 		Active: true,
 		Config: map[string]string{


### PR DESCRIPTION
Introduced native support for Forgejo as a first-class Git provider. Previously, Forgejo was supported indirectly by using the Gitea provider type due to API compatibility. This change adds "forgejo" as a distinct provider type, allowing explicit configuration. The "gitea" provider type is maintained as an alias for backwards compatibility and will continue to function, but the preference is to use "forgejo" for new configurations.

Key updates include:
- Updated documentation to reflect Forgejo as a separate provider.
- Modified internal logic to recognize and handle "forgejo" as a distinct type.
- Ensured that merging repository specifications correctly handles the equivalence between "gitea" and "forgejo".
- Updated tests to accommodate the new provider type.

## 📝 Description of the Change

Add `forgejo` as a first-class provider type in Pipelines-as-Code. The existing `gitea` type is kept as a backwards-compatible alias. Both types resolve to the same Gitea/Forgejo provider internally.

**What changed:**

- CRD schema (`types.go`, `300-repositories.yaml`): added `forgejo` to the `Enum` validation alongside `gitea`
- Provider resolution (`event.go`, `incoming.go`, `cel.go`): accept both `"gitea"` and `"forgejo"` in switch cases
- Metrics (`emit_metrics.go`): recognise `"forgejo"` as a webhook provider for metric tagging
- Spec merging (`types.go` `Merge`): treat `gitea` and `forgejo` as equivalent types so global/local Repository specs merge correctly
- Docs: updated Forgejo install guide, CLI reference, incoming webhook, and global repo settings to recommend `type: "forgejo"`
- E2E test harness (`test/pkg/gitea`): default provider type changed from `"gitea"` to `"forgejo"`, with an option to override via `ProviderType`

## 👨🏻‍ Linked Jira

Jira: https://issues.redhat.com/browse/SRVKP-10487

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [x] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [X] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [X] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [x] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [x] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center