### PR TITLE
chore: add race-trace logs for PR comments

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -2,7 +2,9 @@ package github
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -750,7 +752,117 @@ func (v *Provider) GetTemplate(commentType provider.CommentType) string {
 	return provider.GetHTMLTemplate(commentType)
 }
 
-func (v *Provider) listCommentsByMarker(ctx context.Context, event *info.Event, marker string) ([]*github.IssueComment, error) {
+type commentTraceLogContext struct {
+	dedupTrace      string
+	eventID         string
+	markerHash      string
+	markerLen       int
+	controllerLabel string
+}
+
+func newDedupTraceID() string {
+	//nolint:gosec // best-effort correlation ID for debug logs only
+	return fmt.Sprintf("%x-%04x", time.Now().UnixNano(), rand.Intn(1<<16))
+}
+
+func markerHash(marker string) string {
+	if marker == "" {
+		return "none"
+	}
+	sum := sha256.Sum256([]byte(marker))
+	digest := hex.EncodeToString(sum[:])
+	if len(digest) > 12 {
+		return digest[:12]
+	}
+	return digest
+}
+
+func formatCommentTime(ts github.Timestamp) string {
+	if ts.IsZero() {
+		return "unknown"
+	}
+	return ts.UTC().Format(time.RFC3339)
+}
+
+func compactCommentIDs(comments []*github.IssueComment) []string {
+	out := make([]string, 0, len(comments))
+	for _, comment := range comments {
+		out = append(out, fmt.Sprintf("%d@%s", comment.GetID(), formatCommentTime(comment.GetCreatedAt())))
+	}
+	return out
+}
+
+func responseStatusCode(resp *github.Response) int {
+	if resp == nil {
+		return 0
+	}
+	return resp.StatusCode
+}
+
+func eventID(event *info.Event) string {
+	if event == nil || event.Request == nil {
+		return "unknown"
+	}
+	if id := event.Request.Header.Get("X-GitHub-Delivery"); id != "" {
+		return id
+	}
+	return "unknown"
+}
+
+func (v *Provider) controllerLabel(ctx context.Context) string {
+	if name := info.GetCurrentControllerName(ctx); name != "" {
+		return name
+	}
+	if v.Run != nil && v.Run.Info.Controller != nil && v.Run.Info.Controller.Name != "" {
+		return v.Run.Info.Controller.Name
+	}
+	return "unknown"
+}
+
+func (v *Provider) newCommentTraceLogContext(ctx context.Context, event *info.Event, marker string) commentTraceLogContext {
+	return commentTraceLogContext{
+		dedupTrace:      newDedupTraceID(),
+		eventID:         eventID(event),
+		markerHash:      markerHash(marker),
+		markerLen:       len(marker),
+		controllerLabel: v.controllerLabel(ctx),
+	}
+}
+
+func (v *Provider) debugCommentPhase(event *info.Event, trace commentTraceLogContext, phase string, kv ...any) {
+	if v.Logger == nil {
+		return
+	}
+
+	org := "unknown"
+	repo := "unknown"
+	pr := 0
+	if event != nil {
+		org = event.Organization
+		repo = event.Repository
+		pr = event.PullRequestNumber
+	}
+
+	baseFields := []any{
+		"phase", phase,
+		"organization", org,
+		"repository", repo,
+		"pr", pr,
+		"event_id", trace.eventID,
+		"dedup_trace", trace.dedupTrace,
+		"marker_hash", trace.markerHash,
+		"marker_len", trace.markerLen,
+		"controller_label", trace.controllerLabel,
+	}
+	v.Logger.Debugw("github comment dedup flow", append(baseFields, kv...)...)
+}
+
+func (v *Provider) listCommentsByMarker(
+	ctx context.Context,
+	event *info.Event,
+	marker, phase string,
+	trace commentTraceLogContext,
+) ([]*github.IssueComment, error) {
 	comments, _, err := wrapAPI(v, "list_comments", func() ([]*github.IssueComment, *github.Response, error) {
 		return v.Client().Issues.ListComments(ctx, event.Organization, event.Repository, event.PullRequestNumber, &github.IssueListCommentsOptions{
 			ListOptions: github.ListOptions{
@@ -770,6 +882,13 @@ func (v *Provider) listCommentsByMarker(ctx context.Context, event *info.Event, 
 			matchedComments = append(matchedComments, comment)
 		}
 	}
+
+	v.debugCommentPhase(event, trace, phase,
+		"fetched_count", len(comments),
+		"matched_count", len(matchedComments),
+		"matched_comments", compactCommentIDs(matchedComments),
+	)
+
 	return matchedComments, nil
 }
 
@@ -778,9 +897,14 @@ func (v *Provider) ensureSingleMarkerComment(
 	event *info.Event,
 	comments []*github.IssueComment,
 	commit string,
+	trace commentTraceLogContext,
 ) error {
 	if len(comments) == 0 {
 		return nil
+	}
+
+	if len(comments) > 1 {
+		v.debugCommentPhase(event, trace, "duplicate_detected", "matched_count", len(comments))
 	}
 
 	primaryComment := comments[0]
@@ -790,6 +914,11 @@ func (v *Provider) ensureSingleMarkerComment(
 			break
 		}
 	}
+
+	v.debugCommentPhase(event, trace, "dedup_select_primary",
+		"matched_count", len(comments),
+		"primary_comment_id", primaryComment.GetID(),
+	)
 
 	if primaryComment.GetBody() != commit {
 		if _, _, err := wrapAPI(v, "edit_comment", func() (*github.IssueComment, *github.Response, error) {
@@ -806,14 +935,23 @@ func (v *Provider) ensureSingleMarkerComment(
 		if comment.GetID() == primaryComment.GetID() {
 			continue
 		}
-		if _, _, err := wrapAPI(v, "delete_comment", func() (struct{}, *github.Response, error) {
+
+		v.debugCommentPhase(event, trace, "dedup_delete_attempt", "delete_comment_id", comment.GetID())
+		_, resp, err := wrapAPI(v, "delete_comment", func() (struct{}, *github.Response, error) {
 			resp, err := v.Client().Issues.DeleteComment(ctx, event.Organization, event.Repository, comment.GetID())
 			return struct{}{}, resp, err
-		}); err != nil && v.Logger != nil {
+		})
+		v.debugCommentPhase(event, trace, "dedup_delete_done",
+			"delete_comment_id", comment.GetID(),
+			"status_code", responseStatusCode(resp),
+			"delete_error", err != nil,
+		)
+		if err != nil && v.Logger != nil {
 			v.Logger.Warnf("failed to delete duplicate comment %d on %s/%s#%d: %v",
 				comment.GetID(), event.Organization, event.Repository, event.PullRequestNumber, err)
 		}
 	}
+	v.debugCommentPhase(event, trace, "dedup_complete", "final_expected_count", 1)
 	return nil
 }
 
@@ -827,18 +965,25 @@ func (v *Provider) CreateComment(ctx context.Context, event *info.Event, commit,
 		return fmt.Errorf("create comment only works on pull requests")
 	}
 
+	trace := v.newCommentTraceLogContext(ctx, event, updateMarker)
+
 	if updateMarker != "" {
-		existingComments, err := v.listCommentsByMarker(ctx, event, updateMarker)
+		existingComments, err := v.listCommentsByMarker(ctx, event, updateMarker, "initial_list", trace)
 		if err != nil {
 			return err
 		}
 
+		if len(existingComments) > 1 {
+			v.debugCommentPhase(event, trace, "duplicate_detected", "matched_count", len(existingComments))
+		}
+
 		if len(existingComments) > 0 {
-			return v.ensureSingleMarkerComment(ctx, event, existingComments, commit)
+			return v.ensureSingleMarkerComment(ctx, event, existingComments, commit, trace)
 		}
 
 		//nolint:gosec // No need for crypto/rand here, just reducing timing window
 		jitter := time.Duration(rand.Intn(500)) * time.Millisecond
+		v.debugCommentPhase(event, trace, "jitter_wait", "jitter_ms", jitter.Milliseconds())
 		timer := time.NewTimer(jitter)
 		defer timer.Stop()
 
@@ -849,23 +994,37 @@ func (v *Provider) CreateComment(ctx context.Context, event *info.Event, commit,
 		}
 
 		// Re-check after jitter in case another processor already created the marker comment.
-		existingComments, err = v.listCommentsByMarker(ctx, event, updateMarker)
+		existingComments, err = v.listCommentsByMarker(ctx, event, updateMarker, "post_jitter_list", trace)
 		if err != nil {
 			return err
 		}
-		if len(existingComments) > 0 {
-			return v.ensureSingleMarkerComment(ctx, event, existingComments, commit)
+		if len(existingComments) > 1 {
+			v.debugCommentPhase(event, trace, "duplicate_detected", "matched_count", len(existingComments))
 		}
+		if len(existingComments) > 0 {
+			return v.ensureSingleMarkerComment(ctx, event, existingComments, commit, trace)
+		}
+
+		v.debugCommentPhase(event, trace, "pre_create_race_window", "matched_count", len(existingComments))
 	}
 
-	_, _, err := wrapAPI(v, "create_comment", func() (*github.IssueComment, *github.Response, error) {
+	v.debugCommentPhase(event, trace, "create_comment_start")
+	createdComment, createResp, err := wrapAPI(v, "create_comment", func() (*github.IssueComment, *github.Response, error) {
 		return v.Client().Issues.CreateComment(ctx, event.Organization, event.Repository, event.PullRequestNumber, &github.IssueComment{
 			Body: github.Ptr(commit),
 		})
 	})
 	if err != nil {
+		v.debugCommentPhase(event, trace, "create_comment_done",
+			"status_code", responseStatusCode(createResp),
+			"create_error", err.Error(),
+		)
 		return err
 	}
+	v.debugCommentPhase(event, trace, "create_comment_done",
+		"status_code", responseStatusCode(createResp),
+		"created_comment_id", createdComment.GetID(),
+	)
 
 	if updateMarker == "" {
 		return nil
@@ -873,9 +1032,12 @@ func (v *Provider) CreateComment(ctx context.Context, event *info.Event, commit,
 
 	// Best-effort post-create reconciliation to collapse duplicates created by
 	// concurrent processors handling the same event.
-	matchedComments, listErr := v.listCommentsByMarker(ctx, event, updateMarker)
+	matchedComments, listErr := v.listCommentsByMarker(ctx, event, updateMarker, "post_create_list", trace)
 	if listErr != nil {
 		return nil
 	}
-	return v.ensureSingleMarkerComment(ctx, event, matchedComments, commit)
+	if len(matchedComments) > 1 {
+		v.debugCommentPhase(event, trace, "duplicate_detected", "matched_count", len(matchedComments))
+	}
+	return v.ensureSingleMarkerComment(ctx, event, matchedComments, commit, trace)
 }

--- a/test/pkg/wait/wait_test.go
+++ b/test/pkg/wait/wait_test.go
@@ -1,0 +1,138 @@
+package wait
+
+import (
+	"testing"
+	"time"
+
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	paramsclients "github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	"go.uber.org/zap"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	knativeapis "knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func makeRepositoryRunStatus(sha *string, reason string) pacv1alpha1.RepositoryRunStatus {
+	status := pacv1alpha1.RepositoryRunStatus{
+		SHA: sha,
+	}
+	if reason != "" {
+		status.Status = duckv1.Status{
+			Conditions: []knativeapis.Condition{
+				{Reason: reason},
+			},
+		}
+	}
+	return status
+}
+
+func strPtr(v string) *string {
+	return &v
+}
+
+func TestUntilRepositoryHasStatusReason(t *testing.T) {
+	tests := []struct {
+		name      string
+		statuses  []pacv1alpha1.RepositoryRunStatus
+		targetSHA string
+		reason    string
+		wantErr   bool
+	}{
+		{
+			name: "match by target sha and reason",
+			statuses: []pacv1alpha1.RepositoryRunStatus{
+				makeRepositoryRunStatus(strPtr("sha-1"), "Succeeded"),
+				makeRepositoryRunStatus(strPtr("sha-2"), "Cancelled"),
+			},
+			targetSHA: "sha-2",
+			reason:    "Cancelled",
+		},
+		{
+			name: "wrong reason for matching sha",
+			statuses: []pacv1alpha1.RepositoryRunStatus{
+				makeRepositoryRunStatus(strPtr("sha-2"), "Succeeded"),
+			},
+			targetSHA: "sha-2",
+			reason:    "Cancelled",
+			wantErr:   true,
+		},
+		{
+			name: "reason exists on a different sha only",
+			statuses: []pacv1alpha1.RepositoryRunStatus{
+				makeRepositoryRunStatus(strPtr("sha-1"), "Cancelled"),
+			},
+			targetSHA: "sha-2",
+			reason:    "Cancelled",
+			wantErr:   true,
+		},
+		{
+			name: "match without target sha filter",
+			statuses: []pacv1alpha1.RepositoryRunStatus{
+				makeRepositoryRunStatus(strPtr("sha-1"), "Cancelled"),
+			},
+			reason: "Cancelled",
+		},
+		{
+			name: "status without conditions",
+			statuses: []pacv1alpha1.RepositoryRunStatus{
+				makeRepositoryRunStatus(strPtr("sha-2"), ""),
+			},
+			targetSHA: "sha-2",
+			reason:    "Cancelled",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			repositoryNS := "test-repository-ns"
+			repositoryName := "test-repository"
+			seeded, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Namespaces: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: repositoryNS},
+					},
+				},
+				Repositories: []*pacv1alpha1.Repository{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      repositoryName,
+							Namespace: repositoryNS,
+						},
+						Spec: pacv1alpha1.RepositorySpec{
+							URL: "https://ghe.pipelinesascode.com/org/repo",
+						},
+						Status: tt.statuses,
+					},
+				},
+			})
+
+			clients := paramsclients.Clients{
+				PipelineAsCode: seeded.PipelineAsCode,
+				Log:            zap.NewNop().Sugar(),
+			}
+			opts := Opts{
+				RepoName:    repositoryName,
+				Namespace:   repositoryNS,
+				TargetSHA:   tt.targetSHA,
+				PollTimeout: 10 * time.Millisecond,
+			}
+
+			repository, err := UntilRepositoryHasStatusReason(ctx, clients, opts, tt.reason)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				assert.ErrorContains(t, err, "timed out")
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Assert(t, repository != nil)
+			assert.Equal(t, repository.GetName(), repositoryName)
+		})
+	}
+}


### PR DESCRIPTION
## 📝 Description of the Change

Add structured debug logging to the GitHub comment deduplication flow to
help diagnose race conditions where duplicate PR comments are created by
concurrent processors handling the same event.

Changes:
- Add `commentTraceLogContext` and `debugCommentPhase` helpers in the GitHub
  provider to emit structured debug logs at each phase of the
  create/dedup/delete comment lifecycle.
- Propagate trace context through `listCommentsByMarker`,
  `ensureSingleMarkerComment`, and `CreateComment`.
- Add validation-error logging in `reportValidationErrors` with event
  metadata (event ID, PR, repo, branch, namespace).
- Enhance the `TestGithubSecondFlakyPullRequestBadYaml` E2E test with
  recheck-with-backoff logic and diagnostic logging when duplicate comments
  are observed.
- Add unit tests (`TestCreateCommentDedupLogging`) covering all three
  dedup scenarios: no existing comment, single existing comment, and
  multiple duplicates.

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

## 🚀 Type of Change

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [x] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [x] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.