### PR TITLE
fix: Update Go-SCM to v1.15.17 for Bitbucket Group Permissions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-github/v75 v75.0.0
 	github.com/google/go-github/v81 v81.0.0
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
-	github.com/jenkins-x/go-scm v1.15.16
+	github.com/jenkins-x/go-scm v1.15.17
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/juju/ansiterm v1.0.0
 	github.com/ktrysmt/go-bitbucket v0.9.88

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jenkins-x/go-scm v1.15.16 h1:fdmMcjlA+VOpWO1lS8V7jzxIGvwgJ6Ls286FUpHoUSk=
-github.com/jenkins-x/go-scm v1.15.16/go.mod h1:RU3n2g3nxbIkjjm7cg7iOUh/7Wr1V+bTr/YM8qZeAr0=
+github.com/jenkins-x/go-scm v1.15.17 h1:mQU/ixf5YsPFLEJT71/hVWsfp2YAjowwWcEThKK6kZg=
+github.com/jenkins-x/go-scm v1.15.17/go.mod h1:RU3n2g3nxbIkjjm7cg7iOUh/7Wr1V+bTr/YM8qZeAr0=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/pkg/provider/bitbucketdatacenter/acl_test.go
+++ b/pkg/provider/bitbucketdatacenter/acl_test.go
@@ -35,6 +35,7 @@ func TestIsAllowed(t *testing.T) {
 		projectMembers            []*bbv1test.UserPermission
 		repoMembers               []*bbv1test.UserPermission
 		projGroups                []*bbv1test.ProjGroup
+		repoGroups                []*bbv1test.ProjGroup
 		activities                []*bbv1test.Activity
 		filescontents             map[string]string
 		defaultBranchLatestCommit string
@@ -213,6 +214,7 @@ func TestIsAllowed(t *testing.T) {
 			bbv1test.MuxProjectMemberShip(t, mux, tt.event, tt.fields.projectMembers)
 			bbv1test.MuxRepoMemberShip(t, mux, tt.event, tt.fields.repoMembers)
 			bbv1test.MuxProjectGroupMembership(t, mux, tt.event, tt.fields.projGroups)
+			bbv1test.MuxRepoGroupMembership(t, mux, tt.event, tt.fields.repoGroups)
 			bbv1test.MuxPullRequestActivities(t, mux, tt.event, tt.fields.pullRequestNumber, tt.fields.activities)
 			bbv1test.MuxFiles(t, mux, tt.event, tt.fields.defaultBranchLatestCommit, "", tt.fields.filescontents, false)
 

--- a/pkg/provider/bitbucketdatacenter/acl_test.go
+++ b/pkg/provider/bitbucketdatacenter/acl_test.go
@@ -36,6 +36,7 @@ func TestIsAllowed(t *testing.T) {
 		repoMembers               []*bbv1test.UserPermission
 		projGroups                []*bbv1test.ProjGroup
 		repoGroups                []*bbv1test.ProjGroup
+		groupMembers              map[string][]bbv1test.GroupMember
 		activities                []*bbv1test.Activity
 		filescontents             map[string]string
 		defaultBranchLatestCommit string
@@ -139,6 +140,69 @@ func TestIsAllowed(t *testing.T) {
 			isAllowed: false,
 		},
 		{
+			name:  "allowed/user is in project group",
+			event: bbv1test.MakeEvent(&info.Event{Sender: "sender", AccountID: fmt.Sprintf("%d", otherAccountID)}),
+			fields: fields{
+				projGroups: []*bbv1test.ProjGroup{
+					{
+						Group:      bbv1test.Group{Name: "project-devs"},
+						Permission: "PROJECT_WRITE",
+					},
+				},
+				groupMembers: map[string][]bbv1test.GroupMember{
+					"project-devs": {
+						{Name: "sender", Slug: "sender"},
+					},
+				},
+			},
+			isAllowed: true,
+		},
+		{
+			name:  "allowed/user is in repo group",
+			event: bbv1test.MakeEvent(&info.Event{Sender: "sender", AccountID: fmt.Sprintf("%d", otherAccountID)}),
+			fields: fields{
+				repoGroups: []*bbv1test.ProjGroup{
+					{
+						Group:      bbv1test.Group{Name: "repo-devs"},
+						Permission: "REPO_WRITE",
+					},
+				},
+				groupMembers: map[string][]bbv1test.GroupMember{
+					"repo-devs": {
+						{Name: "sender", Slug: "sender"},
+					},
+				},
+			},
+			isAllowed: true,
+		},
+		{
+			name:  "disallowed/user not in any group members",
+			event: bbv1test.MakeEvent(&info.Event{Sender: "outsider", AccountID: fmt.Sprintf("%d", otherAccountID)}),
+			fields: fields{
+				projGroups: []*bbv1test.ProjGroup{
+					{
+						Group:      bbv1test.Group{Name: "project-devs"},
+						Permission: "PROJECT_WRITE",
+					},
+				},
+				repoGroups: []*bbv1test.ProjGroup{
+					{
+						Group:      bbv1test.Group{Name: "repo-devs"},
+						Permission: "REPO_WRITE",
+					},
+				},
+				groupMembers: map[string][]bbv1test.GroupMember{
+					"project-devs": {
+						{Name: "someone-else", Slug: "someone-else"},
+					},
+					"repo-devs": {
+						{Name: "another-person", Slug: "another-person"},
+					},
+				},
+			},
+			isAllowed: false,
+		},
+		{
 			name:  "disallowed/same nickname different account id",
 			event: bbv1test.MakeEvent(&info.Event{Sender: "Bouffon", AccountID: "6666"}),
 			fields: fields{
@@ -215,6 +279,7 @@ func TestIsAllowed(t *testing.T) {
 			bbv1test.MuxRepoMemberShip(t, mux, tt.event, tt.fields.repoMembers)
 			bbv1test.MuxProjectGroupMembership(t, mux, tt.event, tt.fields.projGroups)
 			bbv1test.MuxRepoGroupMembership(t, mux, tt.event, tt.fields.repoGroups)
+			bbv1test.MuxGroupMembers(t, mux, tt.fields.groupMembers)
 			bbv1test.MuxPullRequestActivities(t, mux, tt.event, tt.fields.pullRequestNumber, tt.fields.activities)
 			bbv1test.MuxFiles(t, mux, tt.event, tt.fields.defaultBranchLatestCommit, "", tt.fields.filescontents, false)
 

--- a/pkg/provider/bitbucketdatacenter/test/test.go
+++ b/pkg/provider/bitbucketdatacenter/test/test.go
@@ -218,62 +218,53 @@ func MuxCreateAndTestCommitStatus(t *testing.T, mux *http.ServeMux, event *info.
 	})
 }
 
-func MuxProjectMemberShip(t *testing.T, mux *http.ServeMux, event *info.Event, userperms []*UserPermission) {
-	path := fmt.Sprintf("/projects/%s/permissions/users", event.Organization)
+func muxPermissions(t *testing.T, mux *http.ServeMux, path string, values any) {
+	t.Helper()
 	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
-		if userperms == nil {
-			fmt.Fprintf(rw, "{\"values\": []}")
-		}
 		resp := map[string]any{
-			"values": userperms,
+			"values":     values,
+			"isLastPage": true,
 		}
 		b, err := json.Marshal(resp)
 		assert.NilError(t, err)
-
 		fmt.Fprint(rw, string(b))
 	})
+}
+
+func MuxProjectMemberShip(t *testing.T, mux *http.ServeMux, event *info.Event, userperms []*UserPermission) {
+	path := fmt.Sprintf("/projects/%s/permissions/users", event.Organization)
+	muxPermissions(t, mux, path, userperms)
 }
 
 func MuxProjectGroupMembership(t *testing.T, mux *http.ServeMux, event *info.Event, groups []*ProjGroup) {
 	path := fmt.Sprintf("/projects/%s/permissions/groups", event.Organization)
-	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
-		if groups == nil {
-			fmt.Fprintf(rw, "{\"values\": []}")
-		}
-		resp := map[string]any{
-			"values": groups,
-		}
-		b, err := json.Marshal(resp)
-		assert.NilError(t, err)
-
-		fmt.Fprint(rw, string(b))
-	})
+	muxPermissions(t, mux, path, groups)
 }
 
 func MuxRepoGroupMembership(t *testing.T, mux *http.ServeMux, event *info.Event, groups []*ProjGroup) {
 	path := fmt.Sprintf("/projects/%s/repos/%s/permissions/groups", event.Organization, event.Repository)
-	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
-		if groups == nil {
-			fmt.Fprintf(rw, "{\"values\": []}")
-		}
-		resp := map[string]any{
-			"values": groups,
-		}
-		b, err := json.Marshal(resp)
-		assert.NilError(t, err)
-
-		fmt.Fprint(rw, string(b))
-	})
+	muxPermissions(t, mux, path, groups)
 }
 
 func MuxRepoMemberShip(t *testing.T, mux *http.ServeMux, event *info.Event, userperms []*UserPermission) {
 	path := fmt.Sprintf("/projects/%s/repos/%s/permissions/users", event.Organization, event.Repository)
-	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
-		if userperms == nil {
-			fmt.Fprintf(rw, "{\"values\": []}")
+	muxPermissions(t, mux, path, userperms)
+}
+
+// MuxGroupMembers mocks the /admin/groups/more-members endpoint used by go-scm
+// to resolve group names to individual users. groupMembers maps group name to
+// the list of members in that group.
+func MuxGroupMembers(t *testing.T, mux *http.ServeMux, groupMembers map[string][]GroupMember) {
+	t.Helper()
+	mux.HandleFunc("/admin/groups/more-members", func(rw http.ResponseWriter, r *http.Request) {
+		groupName := r.URL.Query().Get("context")
+		members, ok := groupMembers[groupName]
+		if !ok {
+			members = []GroupMember{}
 		}
 		resp := map[string]any{
-			"values": userperms,
+			"values":     members,
+			"isLastPage": true,
 		}
 		b, err := json.Marshal(resp)
 		assert.NilError(t, err)

--- a/pkg/provider/bitbucketdatacenter/test/test.go
+++ b/pkg/provider/bitbucketdatacenter/test/test.go
@@ -250,6 +250,22 @@ func MuxProjectGroupMembership(t *testing.T, mux *http.ServeMux, event *info.Eve
 	})
 }
 
+func MuxRepoGroupMembership(t *testing.T, mux *http.ServeMux, event *info.Event, groups []*ProjGroup) {
+	path := fmt.Sprintf("/projects/%s/repos/%s/permissions/groups", event.Organization, event.Repository)
+	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
+		if groups == nil {
+			fmt.Fprintf(rw, "{\"values\": []}")
+		}
+		resp := map[string]any{
+			"values": groups,
+		}
+		b, err := json.Marshal(resp)
+		assert.NilError(t, err)
+
+		fmt.Fprint(rw, string(b))
+	})
+}
+
 func MuxRepoMemberShip(t *testing.T, mux *http.ServeMux, event *info.Event, userperms []*UserPermission) {
 	path := fmt.Sprintf("/projects/%s/repos/%s/permissions/users", event.Organization, event.Repository)
 	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {

--- a/pkg/provider/bitbucketdatacenter/test/test_types.go
+++ b/pkg/provider/bitbucketdatacenter/test/test_types.go
@@ -34,6 +34,13 @@ type Group struct {
 	Name string `json:"name"`
 }
 
+// GroupMember matches the member struct in go-scm's stash driver,
+// returned by the /admin/groups/more-members endpoint.
+type GroupMember struct {
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
 // kept these structs here because these are only used in tests
 
 type Comment struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -289,7 +289,7 @@ github.com/hashicorp/golang-lru/simplelru
 # github.com/inconshreveable/mousetrap v1.1.0
 ## explicit; go 1.18
 github.com/inconshreveable/mousetrap
-# github.com/jenkins-x/go-scm v1.15.16
+# github.com/jenkins-x/go-scm v1.15.17
 ## explicit; go 1.24.0
 github.com/jenkins-x/go-scm/pkg/hmac
 github.com/jenkins-x/go-scm/scm


### PR DESCRIPTION
## 📝 Description of the Change

Bumps vendored `jenkins-x/go-scm` to v1.15.17 to fix three bugs in Bitbucket Data Center group-based permission checking: URL-encoding of group names with spaces, error short-circuiting that aborted authorization checks, and missing repository-level group permission lookups. Adds missing test mock for repo-level group permissions to fix test failures caused by the new `IsCollaborator()` group lookup.
 
**Changes**

- Update go-scm dependency to support Bitbucket Data Center users with project or repo access through groups
- Add `MuxRepoGroupMembership` test helper and wire it into `acl_test.go` to mock the new `/permissions/groups` endpoint hit by `IsCollaborator()`

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #2477

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
