### PR TITLE
fix: skip prun when target-ns repo cannot be found

### DIFF
--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -258,7 +258,17 @@ func (p *PacRun) resolveRepoForTargetCancelPipelineRun(ctx context.Context, repo
 		return repo
 	}
 
-	return p.resolveTargetNamespaceRepo(ctx, repo, targetPR)
+	targetRepo := p.resolveTargetNamespaceRepo(ctx, repo, targetPR)
+	if targetRepo == nil {
+		p.logger.Warnf(
+			"resolveRepoForTargetCancelPipelineRun: target repo not found for pipelinerun=%s, falling back to repo=%s/%s",
+			pipelineRunIdentifier(targetPR),
+			repo.GetNamespace(),
+			repo.GetName(),
+		)
+		return repo
+	}
+	return targetRepo
 }
 
 func (p *PacRun) cancelPipelineRuns(ctx context.Context, prs *tektonv1.PipelineRunList, repo *v1alpha1.Repository, condition matchingCond) {

--- a/pkg/pipelineascode/cancel_pipelineruns_test.go
+++ b/pkg/pipelineascode/cancel_pipelineruns_test.go
@@ -461,6 +461,90 @@ spec:
 	assert.Equal(t, string(got.Spec.Status), pipelinev1.PipelineRunSpecStatusCancelledRunFinally)
 }
 
+func TestCancelPipelineRunsOpsCommentFallsBackWhenTargetNamespaceRepoMissing(t *testing.T) {
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	ctx, _ := rtesting.SetupFakeContext(t)
+
+	fooRepo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "foo",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			URL: "https://ghe.pipelinesascode.com/pipelines-as-code/e2e",
+		},
+	}
+
+	targetPR := &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr-gitops-comment-ztrg2",
+			Namespace: "foo",
+			Labels: map[string]string{
+				keys.URLRepository: formatting.CleanValueKubernetes("e2e"),
+				keys.PullRequest:   strconv.Itoa(pullReqNumber),
+			},
+			Annotations: map[string]string{
+				keys.OriginalPRName: "pr-gitops-comment",
+			},
+		},
+		Spec: pipelinev1.PipelineRunSpec{},
+	}
+
+	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Repositories: []*v1alpha1.Repository{fooRepo},
+		PipelineRuns: []*pipelinev1.PipelineRun{targetPR},
+	})
+
+	run := &params.Run{
+		Clients: clients.Clients{
+			Log:            logger,
+			Tekton:         stdata.Pipeline,
+			Kube:           stdata.Kube,
+			PipelineAsCode: stdata.PipelineAsCode,
+		},
+	}
+
+	event := &info.Event{
+		Repository:        "e2e",
+		URL:               "https://ghe.pipelinesascode.com/pipelines-as-code/e2e",
+		SHA:               "123",
+		TriggerTarget:     triggertype.PullRequest,
+		PullRequestNumber: pullReqNumber,
+		State: info.State{
+			CancelPipelineRuns:      true,
+			TargetCancelPipelineRun: "pr-gitops-comment",
+		},
+	}
+
+	template := `apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pr-gitops-comment
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "does-not-exist"
+spec:
+  pipelineSpec:
+    tasks:
+    - name: task
+      taskSpec:
+        steps:
+        - name: task
+          image: quay.io/prometheus/busybox
+          script: |
+            echo "HELLOMOTO"
+            exit 0
+`
+
+	pac := NewPacs(event, &testprovider.TestProviderImp{TektonDirTemplate: template}, run, &info.PacOpts{}, nil, logger, nil)
+	err := pac.cancelPipelineRunsOpsComment(ctx, fooRepo)
+	assert.NilError(t, err)
+
+	got, err := run.Clients.Tekton.TektonV1().PipelineRuns("foo").Get(ctx, targetPR.GetName(), metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(got.Spec.Status), pipelinev1.PipelineRunSpecStatusCancelledRunFinally)
+}
+
 func TestCancelInProgressMatchingPipelineRun(t *testing.T) {
 	observer, catcher := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(observer).Sugar()

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -159,6 +159,7 @@ func TestGetPipelineRunsFromRepoExplicitTestUsesTargetNamespaceRepo(t *testing.T
 		targetNamespaceLine string
 		wantRepositoryNS    string
 		wantRepositoryName  string
+		wantNoMatch         bool
 	}{
 		{
 			name:                "uses target namespace repo from annotation",
@@ -171,6 +172,11 @@ func TestGetPipelineRunsFromRepoExplicitTestUsesTargetNamespaceRepo(t *testing.T
 			targetNamespaceLine: "",
 			wantRepositoryNS:    "foo",
 			wantRepositoryName:  "foo",
+		},
+		{
+			name:                "skips pipelinerun when target namespace repo not found",
+			targetNamespaceLine: "    pipelinesascode.tekton.dev/target-namespace: \"nonexistent\"",
+			wantNoMatch:         true,
 		},
 	}
 
@@ -261,6 +267,10 @@ spec:
 
 			matchedPRs, err := p.getPipelineRunsFromRepo(ctx, repositories[0])
 			assert.NilError(t, err)
+			if tt.wantNoMatch {
+				assert.Equal(t, len(matchedPRs), 0)
+				return
+			}
 			assert.Equal(t, len(matchedPRs), 1)
 			assert.Assert(t, matchedPRs[0].Repo != nil)
 			assert.Equal(t, matchedPRs[0].Repo.GetNamespace(), tt.wantRepositoryNS)


### PR DESCRIPTION
## 📝 Description of the Change

This fix addresses a critical issue in PipelineRun handling when target namespace repositories are not found. The problem was when a PipelineRun carries a `target-namespace` annotation pointing to a namespace where no matching Repository object exists, the code was silently falling back to the originating repository. This caused:
- Foreign PipelineRuns (e.g., `/test no-match`) to execute in the wrong namespace
- Repository status pollution, leading to flaky E2E assertions
- Incorrect cancellation behavior in the ops-comment flow

### Why the original fix in  606c830b5bb9c98dc9c5a8ecf4cabf7522889841 needed this follow-up

The `resolveTargetNamespaceRepo` function introduced in 606c830b5 was written with a defensive fallback philosophy: if anything goes wrong (lookup error, repo not found), return the `fallbackRepo` so the system keeps working. The assumption was that it's better to run in the wrong namespace than to fail entirely.

However, this removed the caller's ability to distinguish between "resolved successfully" and "failed, gave you the fallback", and the silent fallback did the wrong thing depending on which code path was calling:

- **`/test` path** (`getPipelineRunsFromRepo`): If a PipelineRun template says `target-namespace: "production"` but no Repository CR exists in that namespace, the old code would silently run the PipelineRun using the source repo — executing it in the wrong namespace with no indication. The user thinks it's targeting `production`, but it's not. This is a silent misconfiguration that should be surfaced, not hidden.
- **`/cancel` path** (`resolveRepoForTargetCancelPipelineRun`): Here, falling back is actually fine — you still want to cancel the running PipelineRun even if the target-namespace repo is gone. But the old code had no logging to indicate the fallback happened.

This fix changes `resolveTargetNamespaceRepo` to return `nil` on failure, pushing the decision back to each caller: `/test` now skips the PipelineRun and emits an event, while `/cancel` still falls back but logs a warning.

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

<!-- No specific GitHub issue -->

## 🚀 Type of Change

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [x] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center