### PR TITLE
ci: pin golangci-lint and fix lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,6 +106,9 @@ linters:
           - revive
         path: pkg/test/http/
         text: "var-naming"
+      - linters:
+          - gosec
+        text: "G115|G117|G702|G703|G704|G705|G706"
     paths:
       - vendor
       - pkg/provider/gitea/structs

--- a/.tekton/go.yaml
+++ b/.tekton/go.yaml
@@ -97,7 +97,7 @@ spec:
                 chmod +x ./codecov
                 ./codecov -P $GITHUB_PULL_REQUEST_ID -C {{revision}} -v
             - name: lint
-              image: docker.io/golangci/golangci-lint:latest
+              image: docker.io/golangci/golangci-lint:v2.10.1
               workingDir: $(workspaces.source.path)
               env:
                 - name: GOCACHE

--- a/pkg/llm/providers/common.go
+++ b/pkg/llm/providers/common.go
@@ -106,7 +106,7 @@ func BuildPrompt(request *ltypes.AnalysisRequest) (string, error) {
 		promptBuilder.WriteString("Context Information:\n")
 
 		for key, value := range request.Context {
-			promptBuilder.WriteString(fmt.Sprintf("=== %s ===\n", strings.ToUpper(key)))
+			fmt.Fprintf(&promptBuilder, "=== %s ===\n", strings.ToUpper(key))
 
 			switch v := value.(type) {
 			case string:
@@ -118,7 +118,7 @@ func BuildPrompt(request *ltypes.AnalysisRequest) (string, error) {
 				}
 				promptBuilder.Write(jsonData)
 			default:
-				promptBuilder.WriteString(fmt.Sprintf("%v", v))
+				fmt.Fprintf(&promptBuilder, "%v", v)
 			}
 
 			promptBuilder.WriteString("\n\n")


### PR DESCRIPTION
Pin golangci-lint CI image to v2.10.1 to prevent surprise breakages from new linter versions. Exclude false-positive gosec taint rules (G115, G117, G702-G706) and fix staticcheck QF1012 in BuildPrompt.

errors were, they are all false positives to us.....


```
Linting go files...
pkg/adapter/incoming.go:45:2: G117: Exported struct field "Secret" (JSON key "secret") matches secret pattern (gosec)
	Secret      string         `json:"secret"`
	^
pkg/cmd/tknpac/bootstrap/install.go:56:28: G702: Command injection via taint analysis (gosec)
	cmd := exec.CommandContext(ctx, path, "apply", "-f", uri)
	                         ^
pkg/cmd/tknpac/bootstrap/route.go:56:24: G704: SSRF via taint analysis (gosec)
	resp, err := client.Do(req)
	                     ^
pkg/cmd/tknpac/cel/cel.go:660:26: G115: integer overflow conversion uintptr -> int (gosec)
			if term.IsTerminal(int(os.Stdin.Fd())) {
			                     ^
pkg/cmd/tknpac/info/install.go:149:33: G704: SSRF via taint analysis (gosec)
	res, err := run.Clients.HTTP.Do(newreq)
	                              ^
pkg/llm/providers/common.go:15:2: G117: Exported struct field "APIKey" (JSON key "APIKey") matches secret pattern (gosec)
	APIKey         string
	^
pkg/llm/providers/gemini/client.go:28:2: G117: Exported struct field "APIKey" (JSON key "APIKey") matches secret pattern (gosec)
	APIKey         string
	^
pkg/llm/providers/gemini/client.go:132:30: G704: SSRF via taint analysis (gosec)
	resp, err := c.httpClient.Do(httpReq)
	                           ^
pkg/llm/providers/openai/client.go:27:2: G117: Exported struct field "APIKey" (JSON key "APIKey") matches secret pattern (gosec)
	APIKey         string
	^
pkg/llm/providers/openai/client.go:135:30: G704: SSRF via taint analysis (gosec)
	resp, err := c.httpClient.Do(httpReq)
	                           ^
pkg/params/clients/clients.go:55:23: G704: SSRF via taint analysis (gosec)
	res, err := c.HTTP.Do(req)
	                    ^
pkg/params/info/controller_info.go:23:2: G117: Exported struct field "Secret" (JSON key "secret") matches secret pattern (gosec)
	Secret           string `json:"secret"`
	^
pkg/params/settings/config.go:64:2: G117: Exported struct field "SecretGhAppTokenScopedExtraRepos" (JSON key "secret-github-app-scope-extra-repos") matches secret pattern (gosec)
	SecretGhAppTokenScopedExtraRepos string `json:"secret-github-app-scope-extra-repos"`
	^
pkg/params/settings/default.go:110:28: G704: SSRF via taint analysis (gosec)
	resp, err := httpClient.Do(req)
	                         ^
pkg/provider/bitbucketcloud/test/bbcloudtest.go:33:15: G705: XSS via taint analysis (gosec)
		fmt.Fprintln(os.Stderr, "\t"+req.URL.String())
		           ^
pkg/provider/bitbucketdatacenter/test/test.go:36:15: G705: XSS via taint analysis (gosec)
		fmt.Fprintln(os.Stderr, "\t"+req.URL.String())
		           ^
pkg/provider/gitea/gitea.go:62:2: G117: Exported struct field "Password" (JSON key "Password") matches secret pattern (gosec)
	Password     string
	^
pkg/provider/gitea/test/setup.go:32:15: G705: XSS via taint analysis (gosec)
		fmt.Fprintln(os.Stderr, "\t"+req.URL.String())
		           ^
pkg/provider/gitlab/test/test.go:26:15: G705: XSS via taint analysis (gosec)
		fmt.Fprintln(os.Stderr, "\t"+req.URL.String())
		           ^
pkg/test/github/github.go:40:15: G705: XSS via taint analysis (gosec)
		fmt.Fprintln(os.Stderr, "\t"+req.URL.String())
		           ^
pkg/test/nonoai/main.go:219:13: G706: Log injection via taint analysis (gosec)
		log.Printf("📨 OpenAI request from %s", r.RemoteAddr)
		         ^
pkg/test/nonoai/main.go:317:13: G706: Log injection via taint analysis (gosec)
		log.Printf("📨 Gemini request from %s", r.RemoteAddr)
		         ^
test/pkg/gitea/scm.go:78:28: G704: SSRF via taint analysis (gosec)
	resp, err := httpClient.Do(req)
	                         ^
test/pkg/github/instrumentation.go:231:24: G703: Path traversal via taint analysis (gosec)
	if err := os.WriteFile(filepath, jsonData, 0o600); err != nil {
	                     ^
test/pkg/options/options.go:12:2: G117: Exported struct field "Password" (JSON key "Password") matches secret pattern (gosec)
	Password           string
	^
test/pkg/payload/send.go:60:24: G704: SSRF via taint analysis (gosec)
	resp, err := client.Do(req)
	                     ^
pkg/llm/providers/common.go:109:4: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
			promptBuilder.WriteString(fmt.Sprintf("=== %s ===\n", strings.ToUpper(key)))
			^
pkg/llm/providers/common.go:121:5: QF1012: Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...)) (staticcheck)
				promptBuilder.WriteString(fmt.Sprintf("%v", v))
				^
28 issues:
* gosec: 26
* staticcheck: 2
```

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [x] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
