### PR TITLE
fix: Handle non-http(s) URLs in assembleTaskFQDNs

### DIFF
--- a/pkg/resolve/remote.go
+++ b/pkg/resolve/remote.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -30,6 +31,14 @@ func alreadyFetchedResource[T NamedItem](resources map[string]T, resourceName st
 func assembleTaskFQDNs(pipelineURL string, tasks []string) ([]string, error) {
 	if pipelineURL == "" {
 		return tasks, nil // no pipeline URL, return tasks as is
+	}
+
+	// Only HTTP(S) URLs can serve as base for relative task resolution.
+	// Hub catalog references (e.g., "catalog://resource:version") use a
+	// different scheme where relative paths are meaningless.
+	lowered := strings.ToLower(pipelineURL)
+	if !strings.HasPrefix(lowered, "http://") && !strings.HasPrefix(lowered, "https://") {
+		return tasks, nil
 	}
 
 	pURL, err := url.Parse(pipelineURL)


### PR DESCRIPTION
## 📝 Description of the Change

Added validation to the `assembleTaskFQDNs` function to ensure that only HTTP(S) URLs are used as a base for resolving relative task URLs. Previously, the function would attempt to resolve relative paths against any URL scheme, including custom catalog references (e.g., `foo://python-build-test-tag-bar:1.2`), which led to incorrect URL resolution.

The fix adds a case-insensitive check that returns tasks unchanged when the pipeline URL uses a non-HTTP(S) scheme, since relative path resolution is only meaningful for HTTP(S) URLs.

**Changes:**
- Added scheme validation in `pkg/resolve/remote.go` (`assembleTaskFQDNs:36-41`)
- Added comprehensive unit tests covering hub catalogs, empty URLs, and HTTP(S) URLs with various casings

## 👨🏻‍ Linked Jira

https://issues.redhat.com/browse/SRVKP-10880

## 🔗 Linked GitHub Issue

N/A

## 🚀 Type of Change

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [x] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center