### PR TITLE
feat: Allow custom user agent for Gitea/Forgejo

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -448,6 +448,17 @@ spec:
                         - roles
                         - secret_ref
                       type: object
+                    forgejo:
+                      description: Forgejo contains Forgejo/Gitea-specific settings.
+                      properties:
+                        user_agent:
+                          description: |-
+                            UserAgent sets the User-Agent header on API requests to the Gitea/Forgejo instance.
+                            This is useful when the instance is behind an AI scraping protection proxy (e.g. Anubis)
+                            that blocks requests without a recognized User-Agent.
+                            Defaults to "pipelines-as-code/<version>" when left empty.
+                          type: string
+                      type: object
                     github:
                       properties:
                         comment_strategy:

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -192,6 +192,23 @@ spec:
       comment_strategy: "disable_all"
 ```
 
+### Forgejo/Gitea
+
+You can configure a custom `User-Agent` header for API requests to
+Forgejo/Gitea instances. This is useful when the instance is behind an AI
+scraping protection proxy (such as [Anubis](https://anubis.techaro.lol/)) that
+blocks requests without a recognized `User-Agent`.
+
+By default, Pipelines-as-Code sends `pipelines-as-code/<version>` as the
+`User-Agent`. You can override it per repository:
+
+```yaml
+spec:
+  settings:
+    forgejo:
+      user_agent: "my-custom-agent"
+```
+
 ## Concurrency
 
 `concurrency_limit` allows you to define the maximum number of PipelineRuns running at any time for a Repository.

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -161,6 +161,10 @@ type Settings struct {
 
 	Github *GithubSettings `json:"github,omitempty"`
 
+	// Forgejo contains Forgejo/Gitea-specific settings.
+	// +optional
+	Forgejo *ForgejoSettings `json:"forgejo,omitempty"`
+
 	// AIAnalysis contains AI/LLM analysis configuration for automated CI/CD pipeline analysis.
 	// +optional
 	AIAnalysis *AIAnalysisConfig `json:"ai,omitempty"`
@@ -186,6 +190,15 @@ type GithubSettings struct {
 	CommentStrategy string `json:"comment_strategy,omitempty"`
 }
 
+type ForgejoSettings struct {
+	// UserAgent sets the User-Agent header on API requests to the Gitea/Forgejo instance.
+	// This is useful when the instance is behind an AI scraping protection proxy (e.g. Anubis)
+	// that blocks requests without a recognized User-Agent.
+	// Defaults to "pipelines-as-code/<version>" when left empty.
+	// +optional
+	UserAgent string `json:"user_agent,omitempty"`
+}
+
 func (s *Settings) Merge(newSettings *Settings) {
 	if newSettings.PipelineRunProvenance != "" && s.PipelineRunProvenance == "" {
 		s.PipelineRunProvenance = newSettings.PipelineRunProvenance
@@ -195,6 +208,9 @@ func (s *Settings) Merge(newSettings *Settings) {
 	}
 	if newSettings.GithubAppTokenScopeRepos != nil && s.GithubAppTokenScopeRepos == nil {
 		s.GithubAppTokenScopeRepos = newSettings.GithubAppTokenScopeRepos
+	}
+	if newSettings.Forgejo != nil && s.Forgejo == nil {
+		s.Forgejo = newSettings.Forgejo
 	}
 	if newSettings.AIAnalysis != nil && s.AIAnalysis == nil {
 		s.AIAnalysis = newSettings.AIAnalysis

--- a/pkg/apis/pipelinesascode/v1alpha1/types_test.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types_test.go
@@ -118,6 +118,56 @@ func TestMergeSpecs(t *testing.T) {
 			},
 		},
 		{
+			name: "forgejo settings from global",
+			local: &RepositorySpec{
+				Settings:    &Settings{},
+				GitProvider: &GitProvider{},
+			},
+			global: RepositorySpec{
+				Settings: &Settings{
+					Forgejo: &ForgejoSettings{
+						UserAgent: "my-custom-agent",
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+			expected: &RepositorySpec{
+				Settings: &Settings{
+					Forgejo: &ForgejoSettings{
+						UserAgent: "my-custom-agent",
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+		},
+		{
+			name: "local forgejo settings take precedence",
+			local: &RepositorySpec{
+				Settings: &Settings{
+					Forgejo: &ForgejoSettings{
+						UserAgent: "local-agent",
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+			global: RepositorySpec{
+				Settings: &Settings{
+					Forgejo: &ForgejoSettings{
+						UserAgent: "global-agent",
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+			expected: &RepositorySpec{
+				Settings: &Settings{
+					Forgejo: &ForgejoSettings{
+						UserAgent: "local-agent",
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+		},
+		{
 			name: "different git providers",
 			local: &RepositorySpec{
 				GitProvider: &GitProvider{


### PR DESCRIPTION
## 📝 Description of the Change

This PR adds support for configuring a custom `User-Agent` header for API requests to Gitea/Forgejo instances. This enhancement addresses scenarios where Gitea/Forgejo instances are protected by AI scraping prevention proxies (such as [Anubis](https://anubis.techaro.lol/)) that block requests without a recognized User-Agent header.

**Key changes:**

- Added `UserAgent` field to `GiteaSettings` struct in the Repository CRD
- Implemented per-repository User-Agent configuration via `spec.settings.gitea.user_agent`
- Defaults to `pipelines-as-code/<version>` when not specified
- Updated settings merge logic to properly inherit Gitea settings from global to local scope
- Modified Gitea provider client initialization to use the configured User-Agent
- Added comprehensive unit tests for settings inheritance behavior
- Updated CRD schema and documentation

**Use case:**
Fedora's Forgejo instance uses an AI scraping protection proxy that requires a specific User-Agent. This feature allows administrators to configure PAC to work with such protected instances without code changes.

## 👨🏻‍ Linked Jira

Jira: https://issues.redhat.com/browse/SRVKP-10579

## 🔗 Linked GitHub Issue

Fixes #

## 🚀 Type of Change

- [ ] 🐛 Bug fix (`fix:`)
- [x] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

**Unit tests added:**
- Settings merge behavior when both global and local Gitea settings are present
- Settings inheritance when only global settings exist
- Verification that User-Agent is properly passed to Gitea client

**Manual testing:**
- Tested against Fedora's Forgejo instance with Anubis proxy
- Verified default User-Agent works with standard Gitea instances
- Confirmed custom User-Agent overrides work correctly

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [x] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [x] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [x] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center