### PR TITLE
fix(gitea): preserve source_url on retest comment reruns

### DIFF
--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -475,6 +475,12 @@ func (v *Provider) GetCommitInfo(_ context.Context, runevent *info.Event) error 
 		runevent.SHA = pr.Head.Sha
 		runevent.HeadBranch = pr.Head.Ref
 		runevent.BaseBranch = pr.Base.Ref
+		if runevent.HeadURL == "" && pr.Head.Repository != nil {
+			runevent.HeadURL = pr.Head.Repository.HTMLURL
+		}
+		if runevent.BaseURL == "" && pr.Base.Repository != nil {
+			runevent.BaseURL = pr.Base.Repository.HTMLURL
+		}
 		sha = pr.Head.Sha
 	}
 	commit, _, err := v.Client().GetSingleCommit(runevent.Organization, runevent.Repository, sha)

--- a/pkg/provider/gitea/parse_payload.go
+++ b/pkg/provider/gitea/parse_payload.go
@@ -2,7 +2,6 @@ package gitea
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -13,6 +12,30 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea/forgejostructs"
 )
+
+func populateEventFromGiteaPullRequest(event *info.Event, pr *forgejostructs.PullRequest) {
+	if pr == nil {
+		return
+	}
+
+	event.PullRequestTitle = pr.Title
+	if pr.Head != nil {
+		event.SHA = pr.Head.Sha
+		event.HeadBranch = pr.Head.Ref
+		if pr.Head.Repository != nil {
+			event.HeadURL = pr.Head.Repository.HTMLURL
+		}
+	}
+	if pr.Base != nil {
+		event.BaseBranch = pr.Base.Ref
+		if pr.Base.Repository != nil {
+			event.BaseURL = pr.Base.Repository.HTMLURL
+		}
+	}
+	if pr.HTMLURL != "" && event.SHA != "" {
+		event.SHAURL = fmt.Sprintf("%s/commit/%s", pr.HTMLURL, event.SHA)
+	}
+}
 
 func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.Request,
 	payload string,
@@ -30,71 +53,99 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 	if err != nil {
 		return nil, err
 	}
-	_ = json.Unmarshal(payloadB, &eventInt)
 
 	switch gitEvent := eventInt.(type) {
 	case *forgejostructs.PullRequestPayload:
 		processedEvent = info.NewEvent()
 		// // Organization:  event.GetRepo().GetOwner().GetLogin(),
-		processedEvent.Sender = gitEvent.Sender.UserName
-		processedEvent.DefaultBranch = gitEvent.Repository.DefaultBranch
-		processedEvent.URL = gitEvent.Repository.HTMLURL
-		processedEvent.SHA = gitEvent.PullRequest.Head.Sha
-		processedEvent.SHAURL = fmt.Sprintf("%s/commit/%s", gitEvent.PullRequest.HTMLURL, processedEvent.SHA)
-		processedEvent.HeadBranch = gitEvent.PullRequest.Head.Ref
-		processedEvent.BaseBranch = gitEvent.PullRequest.Base.Ref
-		processedEvent.HeadURL = gitEvent.PullRequest.Head.Repository.HTMLURL
-		processedEvent.BaseURL = gitEvent.PullRequest.Base.Repository.HTMLURL
+		if gitEvent.Sender != nil {
+			processedEvent.Sender = gitEvent.Sender.UserName
+		}
+		if gitEvent.Repository != nil {
+			processedEvent.DefaultBranch = gitEvent.Repository.DefaultBranch
+			processedEvent.URL = gitEvent.Repository.HTMLURL
+			processedEvent.Repository = gitEvent.Repository.Name
+			if gitEvent.Repository.Owner != nil {
+				processedEvent.Organization = gitEvent.Repository.Owner.UserName
+			}
+		}
+		populateEventFromGiteaPullRequest(processedEvent, gitEvent.PullRequest)
 		processedEvent.PullRequestNumber = int(gitEvent.Index)
-		processedEvent.PullRequestTitle = gitEvent.PullRequest.Title
-		processedEvent.Organization = gitEvent.Repository.Owner.UserName
-		processedEvent.Repository = gitEvent.Repository.Name
 		processedEvent.TriggerTarget = triggertype.PullRequest
 		processedEvent.EventType = triggertype.PullRequest.String()
 		if provider.Valid(string(gitEvent.Action), []string{pullRequestLabelUpdated}) {
 			processedEvent.EventType = string(triggertype.PullRequestLabeled)
 		}
-		for _, label := range gitEvent.PullRequest.Labels {
-			processedEvent.PullRequestLabel = append(processedEvent.PullRequestLabel, label.Name)
+		if gitEvent.PullRequest != nil {
+			for _, label := range gitEvent.PullRequest.Labels {
+				if label == nil {
+					continue
+				}
+				processedEvent.PullRequestLabel = append(processedEvent.PullRequestLabel, label.Name)
+			}
 		}
 		if gitEvent.Action == forgejostructs.HookIssueClosed {
 			processedEvent.TriggerTarget = triggertype.PullRequestClosed
 		}
 	case *forgejostructs.PushPayload:
 		processedEvent = info.NewEvent()
-		processedEvent.SHA = gitEvent.HeadCommit.ID
+		if gitEvent.HeadCommit != nil {
+			processedEvent.SHA = gitEvent.HeadCommit.ID
+			processedEvent.SHAURL = gitEvent.HeadCommit.URL
+			processedEvent.SHATitle = gitEvent.HeadCommit.Message
+		}
 		if processedEvent.SHA == "" {
 			processedEvent.SHA = gitEvent.Before
 		}
-		processedEvent.SHAURL = gitEvent.HeadCommit.URL
-		processedEvent.SHATitle = gitEvent.HeadCommit.Message
-		processedEvent.Organization = gitEvent.Repo.Owner.UserName
-		processedEvent.Repository = gitEvent.Repo.Name
-		processedEvent.DefaultBranch = gitEvent.Repo.DefaultBranch
-		processedEvent.URL = gitEvent.Repo.HTMLURL
-		processedEvent.Sender = gitEvent.Sender.UserName
+		if gitEvent.Repo != nil {
+			if gitEvent.Repo.Owner != nil {
+				processedEvent.Organization = gitEvent.Repo.Owner.UserName
+			}
+			processedEvent.Repository = gitEvent.Repo.Name
+			processedEvent.DefaultBranch = gitEvent.Repo.DefaultBranch
+			processedEvent.URL = gitEvent.Repo.HTMLURL
+			processedEvent.BaseURL = gitEvent.Repo.HTMLURL
+			processedEvent.HeadURL = processedEvent.BaseURL // in push events Head URL is the same as BaseURL
+		}
+		if gitEvent.Sender != nil {
+			processedEvent.Sender = gitEvent.Sender.UserName
+		}
 		processedEvent.BaseBranch = gitEvent.Ref
 		processedEvent.EventType = eventType
 		processedEvent.HeadBranch = processedEvent.BaseBranch // in push events Head Branch is the same as Basebranch
-		processedEvent.BaseURL = gitEvent.Repo.HTMLURL
-		processedEvent.HeadURL = processedEvent.BaseURL // in push events Head URL is the same as BaseURL
 		processedEvent.TriggerTarget = "push"
 	case *forgejostructs.IssueCommentPayload:
-		if gitEvent.Issue.PullRequest == nil {
+		if gitEvent.Issue == nil || gitEvent.Issue.PullRequest == nil {
 			return info.NewEvent(), fmt.Errorf("issue comment is not coming from a pull_request")
 		}
 		processedEvent = info.NewEvent()
-		processedEvent.Organization = gitEvent.Repository.Owner.UserName
-		processedEvent.Repository = gitEvent.Repository.Name
-		processedEvent.Sender = gitEvent.Sender.UserName
-		processedEvent.TriggerTarget = triggertype.PullRequest
-		opscomments.SetEventTypeAndTargetPR(processedEvent, gitEvent.Comment.Body)
-		processedEvent.PullRequestNumber, err = convertPullRequestURLtoNumber(gitEvent.Issue.URL)
-		if err != nil {
-			return nil, err
+		if gitEvent.Repository != nil {
+			if gitEvent.Repository.Owner != nil {
+				processedEvent.Organization = gitEvent.Repository.Owner.UserName
+			}
+			processedEvent.Repository = gitEvent.Repository.Name
+			processedEvent.URL = gitEvent.Repository.HTMLURL
+			processedEvent.DefaultBranch = gitEvent.Repository.DefaultBranch
 		}
-		processedEvent.URL = gitEvent.Repository.HTMLURL
-		processedEvent.DefaultBranch = gitEvent.Repository.DefaultBranch
+		if gitEvent.Sender != nil {
+			processedEvent.Sender = gitEvent.Sender.UserName
+		}
+		processedEvent.TriggerTarget = triggertype.PullRequest
+		if gitEvent.Comment != nil {
+			opscomments.SetEventTypeAndTargetPR(processedEvent, gitEvent.Comment.Body)
+		}
+		populateEventFromGiteaPullRequest(processedEvent, gitEvent.PullRequest)
+		if gitEvent.Issue.URL != "" {
+			processedEvent.PullRequestNumber, err = convertPullRequestURLtoNumber(gitEvent.Issue.URL)
+			if err != nil {
+				if gitEvent.PullRequest == nil || gitEvent.PullRequest.Index == 0 {
+					return nil, err
+				}
+				processedEvent.PullRequestNumber = int(gitEvent.PullRequest.Index)
+			}
+		} else if gitEvent.PullRequest != nil {
+			processedEvent.PullRequestNumber = int(gitEvent.PullRequest.Index)
+		}
 	default:
 		return nil, fmt.Errorf("event %s is not supported", eventType)
 	}

--- a/pkg/provider/gitea/parse_payload_test.go
+++ b/pkg/provider/gitea/parse_payload_test.go
@@ -1,0 +1,126 @@
+package gitea
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	"gotest.tools/v3/assert"
+)
+
+func TestParsePayloadIssueCommentPullRequestData(t *testing.T) {
+	const payloadWithPR = `{
+		"action": "created",
+		"issue": {
+			"url": "https://gitea.example/api/v1/repos/test-org/test-repo/issues/42",
+			"number": 42,
+			"pull_request": {"html_url": "https://gitea.example/test-org/test-repo/pulls/42"}
+		},
+		"pull_request": {
+			"number": 42,
+			"title": "Test PR",
+			"head": {
+				"ref": "feature",
+				"sha": "abc123",
+				"repo": {"html_url": "https://gitea.example/testuser/test-repo-fork"}
+			},
+			"base": {
+				"ref": "main",
+				"repo": {"html_url": "https://gitea.example/test-org/test-repo"}
+			},
+			"html_url": "https://gitea.example/test-org/test-repo/pulls/42"
+		},
+		"comment": {"body": "/retest"},
+		"repository": {
+			"name": "test-repo",
+			"owner": {"login": "test-org"},
+			"html_url": "https://gitea.example/test-org/test-repo",
+			"default_branch": "main"
+		},
+		"sender": {"login": "testuser"}
+	}`
+
+	tests := []struct {
+		name         string
+		eventType    string
+		payload      string
+		wantErr      string
+		wantHeadURL  string
+		wantBaseURL  string
+		wantPRNumber int
+		wantSHA      string
+	}{
+		{
+			name:         "issue_comment populates source and target urls",
+			eventType:    "issue_comment",
+			payload:      payloadWithPR,
+			wantHeadURL:  "https://gitea.example/testuser/test-repo-fork",
+			wantBaseURL:  "https://gitea.example/test-org/test-repo",
+			wantPRNumber: 42,
+			wantSHA:      "abc123",
+		},
+		{
+			name:         "pull_request_comment populates source and target urls",
+			eventType:    "pull_request_comment",
+			payload:      payloadWithPR,
+			wantHeadURL:  "https://gitea.example/testuser/test-repo-fork",
+			wantBaseURL:  "https://gitea.example/test-org/test-repo",
+			wantPRNumber: 42,
+			wantSHA:      "abc123",
+		},
+		{
+			name:      "non pull request issue comment still fails",
+			eventType: "issue_comment",
+			payload: `{
+				"action": "created",
+				"issue": {"url": "https://gitea.example/api/v1/repos/test-org/test-repo/issues/7"},
+				"comment": {"body": "/retest"},
+				"repository": {"name": "test-repo", "owner": {"login": "test-org"}},
+				"sender": {"login": "testuser"}
+			}`,
+			wantErr: "issue comment is not coming from a pull_request",
+		},
+		{
+			name:      "missing head repo does not panic and leaves head url empty",
+			eventType: "issue_comment",
+			payload: `{
+				"action": "created",
+				"issue": {
+					"url": "https://gitea.example/api/v1/repos/test-org/test-repo/issues/44",
+					"pull_request": {"html_url": "https://gitea.example/test-org/test-repo/pulls/44"}
+				},
+				"pull_request": {
+					"number": 44,
+					"head": {"ref": "feature", "sha": "abc999"},
+					"base": {"ref": "main", "repo": {"html_url": "https://gitea.example/test-org/test-repo"}},
+					"html_url": "https://gitea.example/test-org/test-repo/pulls/44"
+				},
+				"comment": {"body": "/retest"},
+				"repository": {"name": "test-repo", "owner": {"login": "test-org"}}
+			}`,
+			wantHeadURL:  "",
+			wantBaseURL:  "https://gitea.example/test-org/test-repo",
+			wantPRNumber: 44,
+			wantSHA:      "abc999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &http.Request{Header: http.Header{"X-Gitea-Event-Type": []string{tt.eventType}}}
+			got, err := (&Provider{}).ParsePayload(context.Background(), nil, req, tt.payload)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Assert(t, got != nil)
+			assert.Equal(t, got.TriggerTarget, triggertype.PullRequest)
+			assert.Equal(t, got.PullRequestNumber, tt.wantPRNumber)
+			assert.Equal(t, got.HeadURL, tt.wantHeadURL)
+			assert.Equal(t, got.BaseURL, tt.wantBaseURL)
+			assert.Equal(t, got.SHA, tt.wantSHA)
+		})
+	}
+}


### PR DESCRIPTION
## 📝 Description of the Change

When Gitea/Forgejo processes comment events (`issue_comment`,
`pull_request_comment`), the PR object's source/target fields (head URL,
base URL, SHA, branch names) were not extracted. This caused `/retest` comment
reruns to lose fork repository information, breaking `source_url` CEL
expressions.

The fix extracts a common PR field population helper in both the runtime parser
(`pkg/provider/gitea/parse_payload.go`) and the CEL parser
(`pkg/cmd/tknpac/cel/parser.go`), then calls it for all event types that carry
a PR object. Nil-safety is added throughout payload parsing.

## 👨🏻‍ Linked Jira

https://issues.redhat.com/browse/SRVKP-10575

## 🔗 Linked GitHub Issue

Fixes #2496

## 🚀 Type of Change

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [x] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's commit message guide.
- [x] ✨ I have ensured my commit message prefix (`fix:`) matches the "Type of Change" selected above.
- [x] ♽ I have run `make test` and `make lint` locally.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [x] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center