### PR TITLE
feat: Add comment strategy support for Gitea provider

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -451,6 +451,17 @@ spec:
                     forgejo:
                       description: Forgejo contains Forgejo/Gitea-specific settings.
                       properties:
+                        comment_strategy:
+                          description: |-
+                            CommentStrategy defines how Forgejo/Gitea comments are handled for pipeline results.
+                            Options:
+                            - 'disable_all': Disables all comments on pull requests
+                            - 'update': Updates a single comment per PipelineRun on every trigger.
+                          enum:
+                            - ""
+                            - disable_all
+                            - update
+                          type: string
                         user_agent:
                           description: |-
                             UserAgent sets the User-Agent header on API requests to the Gitea/Forgejo instance.

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -128,7 +128,7 @@ access to the infrastructure.
 
 ## Controlling Pull/Merge Request comment volume
 
-For GitHub (Webhook) and GitLab integrations, you can control the types
+For GitHub (Webhook), GitLab, and Gitea/Forgejo integrations, you can control the types
 of Pull/Merge request comments that Pipelines as Code emits using
 the `spec.<provider>.comment_strategy` setting. This can
 help reduce notification volume for repositories that use long-lasting

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -197,6 +197,14 @@ type ForgejoSettings struct {
 	// Defaults to "pipelines-as-code/<version>" when left empty.
 	// +optional
 	UserAgent string `json:"user_agent,omitempty"`
+
+	// CommentStrategy defines how Forgejo/Gitea comments are handled for pipeline results.
+	// Options:
+	// - 'disable_all': Disables all comments on pull requests
+	// - 'update': Updates a single comment per PipelineRun on every trigger.
+	// +optional
+	// +kubebuilder:validation:Enum="";disable_all;update
+	CommentStrategy string `json:"comment_strategy,omitempty"`
 }
 
 func (s *Settings) Merge(newSettings *Settings) {

--- a/pkg/provider/gitea/testdata/TestCreateStatusUpdateCommentNormalizesBreaks.golden
+++ b/pkg/provider/gitea/testdata/TestCreateStatusUpdateCommentNormalizesBreaks.golden
@@ -1,0 +1,1 @@
+{"body":"\u003c!-- pac-status-demo --\u003e\n🚀 **CI has Started: Pipelines as Code CI/demo for abc123**\n\nline1\nline2\n\n\u003csmall\u003eFull log available [here](https://example.test/log)\u003c/small\u003e"}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -242,10 +242,13 @@ const (
 func IsCommentStrategyUpdate(repo *v1alpha1.Repository) bool {
 	var commentStrategy string
 	if repo != nil && repo.Spec.Settings != nil {
-		if repo.Spec.Settings.Gitlab != nil {
+		switch {
+		case repo.Spec.Settings.Gitlab != nil:
 			commentStrategy = repo.Spec.Settings.Gitlab.CommentStrategy
-		} else if repo.Spec.Settings.Github != nil {
+		case repo.Spec.Settings.Github != nil:
 			commentStrategy = repo.Spec.Settings.Github.CommentStrategy
+		case repo.Spec.Settings.Forgejo != nil:
+			commentStrategy = repo.Spec.Settings.Forgejo.CommentStrategy
 		}
 	}
 

--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -18,7 +18,10 @@ import (
 
 var universalDeserializer = serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer()
 
-var allowedGitlabDisableCommentStrategyOnMr = sets.NewString("", provider.DisableAllCommentStrategy, provider.UpdateCommentStrategy)
+var (
+	allowedGitlabDisableCommentStrategyOnMr = sets.NewString("", provider.DisableAllCommentStrategy, provider.UpdateCommentStrategy)
+	allowedForgejoCommentStrategyOnPr       = sets.NewString("", provider.DisableAllCommentStrategy, provider.UpdateCommentStrategy)
+)
 
 // Path implements AdmissionController.
 func (ac *reconciler) Path() string {
@@ -65,6 +68,12 @@ func (ac *reconciler) Admit(_ context.Context, request *v1.AdmissionRequest) *v1
 	if repo.Spec.Settings != nil && repo.Spec.Settings.Gitlab != nil {
 		if !allowedGitlabDisableCommentStrategyOnMr.Has(repo.Spec.Settings.Gitlab.CommentStrategy) {
 			return webhook.MakeErrorStatus("comment strategy '%s' is not supported for Gitlab MRs", repo.Spec.Settings.Gitlab.CommentStrategy)
+		}
+	}
+
+	if repo.Spec.Settings != nil && repo.Spec.Settings.Forgejo != nil {
+		if !allowedForgejoCommentStrategyOnPr.Has(repo.Spec.Settings.Forgejo.CommentStrategy) {
+			return webhook.MakeErrorStatus("comment strategy '%s' is not supported for Forgejo/Gitea PRs", repo.Spec.Settings.Forgejo.CommentStrategy)
 		}
 	}
 


### PR DESCRIPTION
## 📝 Description of the Change

Added `comment_strategy` configuration to the Gitea provider settings to control how pipeline result comments are handled on pull requests.

### Features:
- **`disable_all`**: Prevents status comments from being created on pull requests
- **`update`**: Modifies a single existing comment per PipelineRun instead of creating new ones on every trigger

### Changes:
- Added `comment_strategy` field to repository configuration
- Implemented comment strategy support in Gitea provider
- Updated status creation methods to accept execution context for proper comment handling
- Fixed update marker regex by escaping meta characters
- Added comprehensive unit and e2e tests

Gitea provider now supports configuration of how pipeline status comments are created on pull requests through the new `comment_strategy` field. This allows users to either disable comments entirely or update a single comment per PipelineRun instead of creating multiple comments.

## 👨🏻‍ Linked Jira

Jira: https://issues.redhat.com/browse/SRVKP-10900

## 🔗 Linked GitHub Issue

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] ✨ New feature (`feat:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [x] End-to-end tests

## 🤖 AI Assistance

- [x] I have used AI assistance for this PR.

**Which LLM was used?**

- [x] Claude (Anthropic)

**Extent of AI Assistance:**

- [x] Code generation (parts of the code)

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [x] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [x] Gitea/Forgejo