### PR TITLE
revert GitHub comment workaround

### DIFF
--- a/pkg/provider/github/profiler.go
+++ b/pkg/provider/github/profiler.go
@@ -117,6 +117,7 @@ func (v *Provider) logAPICall(operation string, duration time.Duration, resp *gi
 		logFields = append(logFields,
 			"url_path", resp.Request.URL.Path,
 			"rate_limit_remaining", remaining,
+			"github_request_id", resp.Header.Get("X-GitHub-Request-Id"),
 		)
 		if resp.StatusCode > 0 {
 			logFields = append(logFields, "status_code", resp.StatusCode)


### PR DESCRIPTION
Remove the dedup workaround (jitter, post-create reconciliation, ensureSingleMarkerComment) and replace it with targeted debug enhancements that improve diagnostics without changing behavior:

- Add githubRequestID() helper to extract X-GitHub-Request-Id from API responses for server-side correlation with GitHub support
- Add bodyHash() helper (8-char SHA-256) to fingerprint comment bodies at create/edit time for duplicate body detection
- Log pagination warning when listCommentsByMarker fetches exactly 100 comments (PerPage limit), indicating potential missed matches
- Log "no_marker" phase when updateMarker is empty so unprotected comment creates are visible in the trace system
- Add github_request_id to profiler logAPICall for all API calls
- Simplify CreateComment to edit first matching comment or create new, removing the jitter and post-create dedup logic

Jira: https://issues.redhat.com/browse/SRVKP-10938

## 📝 Description of the Change

This PR removes the complex dedup workaround in the GitHub provider that used jitter and post-create reconciliation to avoid duplicate comments. It replaces this with cleaner, debug-focused enhancements that improve diagnostics without changing behavior. The changes include new helper functions for extracting GitHub request IDs and fingerprinting comment bodies, enhanced logging for pagination and unprotected comment creation, and simplified CreateComment logic that edits existing comments when possible.

## 👨🏻‍ Linked Jira

https://issues.redhat.com/browse/SRVKP-10938

## 🔗 Linked GitHub Issue

<!-- Optional: Link to GitHub issue if applicable -->

## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [x] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center