### PR TITLE
test: Implement file based configuration for test environments

### DIFF
--- a/hack/check-e2e-test-naming.sh
+++ b/hack/check-e2e-test-naming.sh
@@ -17,8 +17,8 @@ if [[ ${#testfiles[@]} -eq 0 ]]; then
     exit 0
 fi
 
-# Extract all Test* function names
-all_tests=$(grep -hE '^func[[:space:]]+Test[[:alnum:]_]+' "${testfiles[@]}" | sed -E 's/^func[[:space:]]+([[:alnum:]_]+).*/\1/')
+# Extract all Test* function names (excluding TestMain which is a Go test harness, not a test)
+all_tests=$(grep -hE '^func[[:space:]]+Test[[:alnum:]_]+' "${testfiles[@]}" | sed -E 's/^func[[:space:]]+([[:alnum:]_]+).*/\1/' | grep -v '^TestMain$')
 
 # Valid patterns: TestGithub*, TestGitea*, TestGitlab*, TestBitbucket*, TestOthers*, or *Concurrency*
 valid_pattern='^Test(Github|Gitea|Gitlab|Bitbucket|Others)|Concurrency'

--- a/test/README.md
+++ b/test/README.md
@@ -62,6 +62,31 @@ this repo should differ from the one which is configured as part of `TEST_GITHUB
 
 You don't need to configure all of those if you restrict running your e2e tests to a subset.
 
+### YAML Configuration File
+
+Instead of setting individual environment variables, you can use a YAML
+configuration file. Set `PAC_E2E_CONFIG` to the path of your config file:
+
+```shell
+PAC_E2E_CONFIG=./test/e2e-config.yaml make test-e2e
+```
+
+Copy the example file and fill in the values for the providers you want to test:
+
+```shell
+cp test/e2e-config.yaml.example test/e2e-config.yaml
+# edit test/e2e-config.yaml with your values
+```
+
+The YAML file groups settings by provider section (`common`, `github`,
+`github_enterprise`, `gitlab`, `gitea`, `bitbucket_cloud`,
+`bitbucket_server`). See `test/e2e-config.yaml.example` for the full list of
+fields.
+
+Environment variables always take precedence over YAML values, so you can use
+the config file for base settings and override specific values via env vars
+(useful for CI secrets).
+
 ## Running
 
 As long you have env variables set, you can just do a :

--- a/test/e2e-config.yaml.example
+++ b/test/e2e-config.yaml.example
@@ -1,0 +1,76 @@
+# Pipelines-as-Code E2E Test Configuration
+#
+# Copy this file and fill in the values for the providers you want to test:
+#   cp e2e-config.yaml.example e2e-config.yaml
+#
+# Then run tests with:
+#   PAC_E2E_CONFIG=./test/e2e-config.yaml make test-e2e
+#
+# You only need to fill in the sections for the providers you are testing.
+# Environment variables always take precedence over values in this file.
+
+# Common settings shared across providers
+common:
+  # The controller public URL (ingress or OpenShift route)
+  controller_url: "https://pac-controller.example.com"
+  # Webhook secret configured on the controller
+  webhook_secret: ""
+  # Set to "true" to skip cleanup after tests (useful for debugging)
+  # no_cleanup: "true"
+
+# GitHub (public)
+github:
+  api_url: "https://api.github.com"
+  token: ""
+  # Repository configured with GitHub Apps (format: org/repo)
+  repo_owner_githubapp: ""
+  # Repository configured with webhooks (format: org/repo, must differ from githubapp repo)
+  repo_owner_webhook: ""
+  # Installation ID from GitHub App webhook deliveries
+  repo_installation_id: ""
+  # Private remote task for scoped token tests (optional)
+  # private_task_name: "task-remote"
+  # private_task_url: "https://github.com/org/private-repo/blob/main/task.yaml"
+
+# GitHub Enterprise (second controller)
+github_enterprise:
+  api_url: ""
+  token: ""
+  controller_url: ""
+  repo_owner_githubapp: ""
+  repo_installation_id: ""
+
+# GitLab
+gitlab:
+  api_url: "https://gitlab.com"
+  token: ""
+  # Project ID (find in repo Settings > General)
+  project_id: ""
+
+# Gitea / Forgejo
+gitea:
+  api_url: "http://localhost:3000"
+  # Internal URL for in-cluster access (optional)
+  # internal_url: "http://forgejo-http.forgejo.svc.cluster.local:3000"
+  password: "pac"
+  username: "pac"
+  repo_owner: "pac/pac"
+  smee_url: ""
+
+# Bitbucket Cloud
+bitbucket_cloud:
+  api_url: "https://api.bitbucket.org/2.0"
+  # Username from "Personal Bitbucket settings"
+  user: ""
+  token: ""
+  # Format: workspace/repo
+  e2e_repository: ""
+
+# Bitbucket Data Center (Server)
+bitbucket_server:
+  api_url: ""
+  user: ""
+  token: ""
+  # Format: project/repo
+  e2e_repository: ""
+  webhook_secret: ""

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -1,0 +1,21 @@
+//go:build e2e
+
+package test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/configfile"
+)
+
+func TestMain(m *testing.M) {
+	if configPath := os.Getenv("PAC_E2E_CONFIG"); configPath != "" {
+		if err := configfile.LoadConfig(configPath); err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading E2E config %s: %v\n", configPath, err)
+			os.Exit(1)
+		}
+	}
+	os.Exit(m.Run())
+}

--- a/test/pkg/configfile/config.go
+++ b/test/pkg/configfile/config.go
@@ -1,0 +1,124 @@
+package configfile
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+
+	"sigs.k8s.io/yaml"
+)
+
+type E2EConfig struct {
+	Common           CommonConfig           `json:"common"            yaml:"common"`
+	GitHub           GitHubConfig           `json:"github"            yaml:"github"`
+	GitHubEnterprise GitHubEnterpriseConfig `json:"github_enterprise" yaml:"github_enterprise"`
+	GitLab           GitLabConfig           `json:"gitlab"            yaml:"gitlab"`
+	Gitea            GiteaConfig            `json:"gitea"             yaml:"gitea"`
+	BitbucketCloud   BitbucketCloudConfig   `json:"bitbucket_cloud"   yaml:"bitbucket_cloud"`
+	BitbucketServer  BitbucketServerConfig  `json:"bitbucket_server"  yaml:"bitbucket_server"`
+}
+
+type CommonConfig struct {
+	ControllerURL string `env:"TEST_EL_URL"            json:"controller_url" yaml:"controller_url"`
+	WebhookSecret string `env:"TEST_EL_WEBHOOK_SECRET" json:"webhook_secret" yaml:"webhook_secret"`
+	NoCleanup     string `env:"TEST_NOCLEANUP"         json:"no_cleanup"     yaml:"no_cleanup"`
+}
+
+type GitHubConfig struct {
+	APIURL             string `env:"TEST_GITHUB_API_URL"              json:"api_url"              yaml:"api_url"`
+	Token              string `env:"TEST_GITHUB_TOKEN"                json:"token"                yaml:"token"`
+	RepoOwnerGithubApp string `env:"TEST_GITHUB_REPO_OWNER_GITHUBAPP" json:"repo_owner_githubapp" yaml:"repo_owner_githubapp"`
+	RepoOwnerWebhook   string `env:"TEST_GITHUB_REPO_OWNER_WEBHOOK"   json:"repo_owner_webhook"   yaml:"repo_owner_webhook"`
+	RepoInstallationID string `env:"TEST_GITHUB_REPO_INSTALLATION_ID" json:"repo_installation_id" yaml:"repo_installation_id"`
+	PrivateTaskName    string `env:"TEST_GITHUB_PRIVATE_TASK_NAME"    json:"private_task_name"    yaml:"private_task_name"`
+	PrivateTaskURL     string `env:"TEST_GITHUB_PRIVATE_TASK_URL"     json:"private_task_url"     yaml:"private_task_url"`
+}
+
+type GitHubEnterpriseConfig struct {
+	APIURL             string `env:"TEST_GITHUB_SECOND_API_URL"              json:"api_url"              yaml:"api_url"`
+	Token              string `env:"TEST_GITHUB_SECOND_TOKEN"                json:"token"                yaml:"token"`
+	ControllerURL      string `env:"TEST_GITHUB_SECOND_EL_URL"               json:"controller_url"       yaml:"controller_url"`
+	RepoOwnerGithubApp string `env:"TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP" json:"repo_owner_githubapp" yaml:"repo_owner_githubapp"`
+	RepoInstallationID string `env:"TEST_GITHUB_SECOND_REPO_INSTALLATION_ID" json:"repo_installation_id" yaml:"repo_installation_id"`
+}
+
+type GitLabConfig struct {
+	APIURL    string `env:"TEST_GITLAB_API_URL"    json:"api_url"    yaml:"api_url"`
+	Token     string `env:"TEST_GITLAB_TOKEN"      json:"token"      yaml:"token"`
+	ProjectID string `env:"TEST_GITLAB_PROJECT_ID" json:"project_id" yaml:"project_id"`
+}
+
+type GiteaConfig struct {
+	APIURL      string `env:"TEST_GITEA_API_URL"      json:"api_url"      yaml:"api_url"`
+	InternalURL string `env:"TEST_GITEA_INTERNAL_URL" json:"internal_url" yaml:"internal_url"`
+	Password    string `env:"TEST_GITEA_PASSWORD"     json:"password"     yaml:"password"`
+	Username    string `env:"TEST_GITEA_USERNAME"     json:"username"     yaml:"username"`
+	RepoOwner   string `env:"TEST_GITEA_REPO_OWNER"   json:"repo_owner"   yaml:"repo_owner"`
+	SmeeURL     string `env:"TEST_GITEA_SMEEURL"      json:"smee_url"     yaml:"smee_url"`
+}
+
+type BitbucketCloudConfig struct {
+	APIURL        string `env:"TEST_BITBUCKET_CLOUD_API_URL"        json:"api_url"        yaml:"api_url"`
+	User          string `env:"TEST_BITBUCKET_CLOUD_USER"           json:"user"           yaml:"user"`
+	Token         string `env:"TEST_BITBUCKET_CLOUD_TOKEN"          json:"token"          yaml:"token"`
+	E2ERepository string `env:"TEST_BITBUCKET_CLOUD_E2E_REPOSITORY" json:"e2e_repository" yaml:"e2e_repository"`
+}
+
+type BitbucketServerConfig struct {
+	APIURL        string `env:"TEST_BITBUCKET_SERVER_API_URL"        json:"api_url"        yaml:"api_url"`
+	User          string `env:"TEST_BITBUCKET_SERVER_USER"           json:"user"           yaml:"user"`
+	Token         string `env:"TEST_BITBUCKET_SERVER_TOKEN"          json:"token"          yaml:"token"`
+	E2ERepository string `env:"TEST_BITBUCKET_SERVER_E2E_REPOSITORY" json:"e2e_repository" yaml:"e2e_repository"`
+	WebhookSecret string `env:"TEST_BITBUCKET_SERVER_WEBHOOK_SECRET" json:"webhook_secret" yaml:"webhook_secret"`
+}
+
+// LoadConfig reads a YAML config file and sets environment variables for any
+// field that has an `env` struct tag. Existing environment variables take
+// precedence over values from the config file.
+func LoadConfig(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading config file %s: %w", path, err)
+	}
+
+	var cfg E2EConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parsing config file %s: %w", path, err)
+	}
+
+	setEnvsFromStruct(reflect.ValueOf(cfg))
+	return nil
+}
+
+// setEnvsFromStruct walks all fields of a struct (recursing into nested
+// structs) and calls os.Setenv for each field that has an `env` tag, but only
+// when the environment variable is not already set and the YAML value is
+// non-empty.
+func setEnvsFromStruct(v reflect.Value) {
+	t := v.Type()
+	for i := range t.NumField() {
+		field := t.Field(i)
+		value := v.Field(i)
+
+		if field.Type.Kind() == reflect.Struct {
+			setEnvsFromStruct(value)
+			continue
+		}
+
+		envKey := field.Tag.Get("env")
+		if envKey == "" {
+			continue
+		}
+
+		yamlVal := value.String()
+		if yamlVal == "" {
+			continue
+		}
+
+		if _, exists := os.LookupEnv(envKey); exists {
+			continue
+		}
+
+		os.Setenv(envKey, yamlVal)
+	}
+}

--- a/test/pkg/configfile/config_test.go
+++ b/test/pkg/configfile/config_test.go
@@ -1,0 +1,227 @@
+package configfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestLoadConfigValid(t *testing.T) {
+	content := `
+common:
+  controller_url: "https://controller.example.com"
+  webhook_secret: "my-secret"
+github:
+  api_url: "https://api.github.com"
+  token: "ghp_test123"
+gitea:
+  api_url: "http://localhost:3000"
+  password: "pac"
+  username: "pac"
+  repo_owner: "pac/pac"
+  smee_url: "https://smee.io/test"
+`
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	assert.NilError(t, os.WriteFile(configPath, []byte(content), 0o600))
+
+	// Clear any pre-existing env vars that could interfere
+	envVars := []string{
+		"TEST_EL_URL", "TEST_EL_WEBHOOK_SECRET",
+		"TEST_GITHUB_API_URL", "TEST_GITHUB_TOKEN",
+		"TEST_GITEA_API_URL", "TEST_GITEA_PASSWORD",
+		"TEST_GITEA_USERNAME", "TEST_GITEA_REPO_OWNER",
+		"TEST_GITEA_SMEEURL",
+	}
+	for _, env := range envVars {
+		t.Setenv(env, "")
+		os.Unsetenv(env)
+	}
+
+	assert.NilError(t, LoadConfig(configPath))
+
+	assert.Equal(t, os.Getenv("TEST_EL_URL"), "https://controller.example.com")
+	assert.Equal(t, os.Getenv("TEST_EL_WEBHOOK_SECRET"), "my-secret")
+	assert.Equal(t, os.Getenv("TEST_GITHUB_API_URL"), "https://api.github.com")
+	assert.Equal(t, os.Getenv("TEST_GITHUB_TOKEN"), "ghp_test123")
+	assert.Equal(t, os.Getenv("TEST_GITEA_API_URL"), "http://localhost:3000")
+	assert.Equal(t, os.Getenv("TEST_GITEA_PASSWORD"), "pac")
+	assert.Equal(t, os.Getenv("TEST_GITEA_USERNAME"), "pac")
+	assert.Equal(t, os.Getenv("TEST_GITEA_REPO_OWNER"), "pac/pac")
+	assert.Equal(t, os.Getenv("TEST_GITEA_SMEEURL"), "https://smee.io/test")
+}
+
+func TestLoadConfigEnvVarOverride(t *testing.T) {
+	content := `
+github:
+  api_url: "https://from-yaml.example.com"
+  token: "yaml-token"
+`
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	assert.NilError(t, os.WriteFile(configPath, []byte(content), 0o600))
+
+	t.Setenv("TEST_GITHUB_API_URL", "https://from-env.example.com")
+	os.Unsetenv("TEST_GITHUB_TOKEN")
+
+	assert.NilError(t, LoadConfig(configPath))
+
+	// Env var should win over YAML
+	assert.Equal(t, os.Getenv("TEST_GITHUB_API_URL"), "https://from-env.example.com")
+	// YAML value should be used when env var is not set
+	assert.Equal(t, os.Getenv("TEST_GITHUB_TOKEN"), "yaml-token")
+}
+
+func TestLoadConfigMissingFile(t *testing.T) {
+	err := LoadConfig("/nonexistent/path/config.yaml")
+	assert.ErrorContains(t, err, "reading config file")
+}
+
+func TestLoadConfigPartial(t *testing.T) {
+	content := `
+gitea:
+  api_url: "http://localhost:3000"
+  password: "pac"
+`
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	assert.NilError(t, os.WriteFile(configPath, []byte(content), 0o600))
+
+	envVars := []string{
+		"TEST_GITEA_API_URL", "TEST_GITEA_PASSWORD",
+		"TEST_GITHUB_API_URL", "TEST_EL_URL",
+	}
+	for _, env := range envVars {
+		t.Setenv(env, "")
+		os.Unsetenv(env)
+	}
+
+	assert.NilError(t, LoadConfig(configPath))
+
+	assert.Equal(t, os.Getenv("TEST_GITEA_API_URL"), "http://localhost:3000")
+	assert.Equal(t, os.Getenv("TEST_GITEA_PASSWORD"), "pac")
+	// Unset fields should not produce env vars
+	assert.Equal(t, os.Getenv("TEST_GITHUB_API_URL"), "")
+	assert.Equal(t, os.Getenv("TEST_EL_URL"), "")
+}
+
+func TestLoadConfigInvalidYAML(t *testing.T) {
+	content := `{invalid yaml: [`
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	assert.NilError(t, os.WriteFile(configPath, []byte(content), 0o600))
+
+	err := LoadConfig(configPath)
+	assert.ErrorContains(t, err, "parsing config file")
+}
+
+func TestLoadConfigAllProviders(t *testing.T) {
+	content := `
+common:
+  controller_url: "https://ctrl.example.com"
+  webhook_secret: "secret123"
+  no_cleanup: "true"
+github:
+  api_url: "https://api.github.com"
+  token: "ghp_abc"
+  repo_owner_githubapp: "org/repo"
+  repo_owner_webhook: "org/repo-webhook"
+  repo_installation_id: "12345"
+  private_task_name: "task-remote"
+  private_task_url: "https://github.com/org/repo/blob/main/task.yaml"
+github_enterprise:
+  api_url: "https://ghe.example.com/api/v3"
+  token: "ghe-token"
+  controller_url: "https://ghe-ctrl.example.com"
+  repo_owner_githubapp: "ghe-org/repo"
+  repo_installation_id: "1"
+gitlab:
+  api_url: "https://gitlab.com"
+  token: "glpat-xyz"
+  project_id: "42"
+gitea:
+  api_url: "http://localhost:3000"
+  internal_url: "http://forgejo:3000"
+  password: "pac"
+  username: "pac"
+  repo_owner: "pac/pac"
+  smee_url: "https://smee.io/test"
+bitbucket_cloud:
+  api_url: "https://api.bitbucket.org/2.0"
+  user: "bbuser"
+  token: "bb-token"
+  e2e_repository: "workspace/repo"
+bitbucket_server:
+  api_url: "https://bitbucket.example.com"
+  user: "bbsuser"
+  token: "bbs-token"
+  e2e_repository: "project/repo"
+  webhook_secret: "bbs-secret"
+`
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	assert.NilError(t, os.WriteFile(configPath, []byte(content), 0o600))
+
+	// Clear all env vars
+	allEnvVars := []string{
+		"TEST_EL_URL", "TEST_EL_WEBHOOK_SECRET", "TEST_NOCLEANUP",
+		"TEST_GITHUB_API_URL", "TEST_GITHUB_TOKEN",
+		"TEST_GITHUB_REPO_OWNER_GITHUBAPP", "TEST_GITHUB_REPO_OWNER_WEBHOOK",
+		"TEST_GITHUB_REPO_INSTALLATION_ID",
+		"TEST_GITHUB_PRIVATE_TASK_NAME", "TEST_GITHUB_PRIVATE_TASK_URL",
+		"TEST_GITHUB_SECOND_API_URL", "TEST_GITHUB_SECOND_TOKEN",
+		"TEST_GITHUB_SECOND_EL_URL", "TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP",
+		"TEST_GITHUB_SECOND_REPO_INSTALLATION_ID",
+		"TEST_GITLAB_API_URL", "TEST_GITLAB_TOKEN", "TEST_GITLAB_PROJECT_ID",
+		"TEST_GITEA_API_URL", "TEST_GITEA_INTERNAL_URL", "TEST_GITEA_PASSWORD",
+		"TEST_GITEA_USERNAME", "TEST_GITEA_REPO_OWNER", "TEST_GITEA_SMEEURL",
+		"TEST_BITBUCKET_CLOUD_API_URL", "TEST_BITBUCKET_CLOUD_USER",
+		"TEST_BITBUCKET_CLOUD_TOKEN", "TEST_BITBUCKET_CLOUD_E2E_REPOSITORY",
+		"TEST_BITBUCKET_SERVER_API_URL", "TEST_BITBUCKET_SERVER_USER",
+		"TEST_BITBUCKET_SERVER_TOKEN", "TEST_BITBUCKET_SERVER_E2E_REPOSITORY",
+		"TEST_BITBUCKET_SERVER_WEBHOOK_SECRET",
+	}
+	for _, env := range allEnvVars {
+		t.Setenv(env, "")
+		os.Unsetenv(env)
+	}
+
+	assert.NilError(t, LoadConfig(configPath))
+
+	expected := map[string]string{
+		"TEST_EL_URL":                             "https://ctrl.example.com",
+		"TEST_EL_WEBHOOK_SECRET":                  "secret123",
+		"TEST_NOCLEANUP":                          "true",
+		"TEST_GITHUB_API_URL":                     "https://api.github.com",
+		"TEST_GITHUB_TOKEN":                       "ghp_abc",
+		"TEST_GITHUB_REPO_OWNER_GITHUBAPP":        "org/repo",
+		"TEST_GITHUB_REPO_OWNER_WEBHOOK":          "org/repo-webhook",
+		"TEST_GITHUB_REPO_INSTALLATION_ID":        "12345",
+		"TEST_GITHUB_PRIVATE_TASK_NAME":           "task-remote",
+		"TEST_GITHUB_PRIVATE_TASK_URL":            "https://github.com/org/repo/blob/main/task.yaml",
+		"TEST_GITHUB_SECOND_API_URL":              "https://ghe.example.com/api/v3",
+		"TEST_GITHUB_SECOND_TOKEN":                "ghe-token",
+		"TEST_GITHUB_SECOND_EL_URL":               "https://ghe-ctrl.example.com",
+		"TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP": "ghe-org/repo",
+		"TEST_GITHUB_SECOND_REPO_INSTALLATION_ID": "1",
+		"TEST_GITLAB_API_URL":                     "https://gitlab.com",
+		"TEST_GITLAB_TOKEN":                       "glpat-xyz",
+		"TEST_GITLAB_PROJECT_ID":                  "42",
+		"TEST_GITEA_API_URL":                      "http://localhost:3000",
+		"TEST_GITEA_INTERNAL_URL":                 "http://forgejo:3000",
+		"TEST_GITEA_PASSWORD":                     "pac",
+		"TEST_GITEA_USERNAME":                     "pac",
+		"TEST_GITEA_REPO_OWNER":                   "pac/pac",
+		"TEST_GITEA_SMEEURL":                      "https://smee.io/test",
+		"TEST_BITBUCKET_CLOUD_API_URL":            "https://api.bitbucket.org/2.0",
+		"TEST_BITBUCKET_CLOUD_USER":               "bbuser",
+		"TEST_BITBUCKET_CLOUD_TOKEN":              "bb-token",
+		"TEST_BITBUCKET_CLOUD_E2E_REPOSITORY":     "workspace/repo",
+		"TEST_BITBUCKET_SERVER_API_URL":           "https://bitbucket.example.com",
+		"TEST_BITBUCKET_SERVER_USER":              "bbsuser",
+		"TEST_BITBUCKET_SERVER_TOKEN":             "bbs-token",
+		"TEST_BITBUCKET_SERVER_E2E_REPOSITORY":    "project/repo",
+		"TEST_BITBUCKET_SERVER_WEBHOOK_SECRET":    "bbs-secret",
+	}
+
+	for envVar, expectedVal := range expected {
+		assert.Equal(t, os.Getenv(envVar), expectedVal, "env var %s", envVar)
+	}
+}


### PR DESCRIPTION
## 📝 Description of the Change

This PR implements a YAML-based configuration mechanism for the E2E testing framework. The changes enable test engineers to define provider-specific settings in a single `e2e-config.yaml` file instead of managing numerous individual environment variables across different git providers (GitHub, GitLab, Bitbucket, Gitea, Forgejo).

### Key Improvements

- **Centralized Configuration**: Single YAML file (`e2e-config.yaml`) replaces scattered environment variables
- **Provider Flexibility**: Supports all 7 git providers with provider-specific configuration sections
- **Environment Variable Precedence**: Env vars can still override YAML values for selective testing needs
- **Automatic Loading**: Configuration automatically loads when `PAC_E2E_CONFIG` env var is set
- **Comprehensive Testing**: 227 lines of unit tests covering full YAML parsing, env var override, error handling, and edge cases

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #1519 

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🚀 Type of Change

- [x] ✨ New feature (`feat:`)
- [ ] 🐛 Bug fix (`fix:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [x] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center