### PR TITLE
fix(github): validate repo URL path for scoping

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -661,6 +661,12 @@ func (v *Provider) CreateToken(ctx context.Context, repository []string, event *
 		}
 
 		split := strings.Split(r, "/")
+		// Validate the URLs do not include additional path segments (like https://github.com/org/repo/extra).
+		// This validation is not required for glob as a pattern like "org/*/*" would not be matched.
+		if len(split) > 2 {
+			return "", fmt.Errorf("github repository URL must follow org/repo format without subgroups (found %d path segments, expected 2): %s", len(split), r)
+		}
+
 		infoData, _, err := wrapAPI(v, "get_repository", func() (*github.Repository, *github.Response, error) {
 			return v.Client().Repositories.Get(ctx, split[0], split[1])
 		})

--- a/pkg/provider/github/scope.go
+++ b/pkg/provider/github/scope.go
@@ -115,5 +115,11 @@ func getURLPathData(urlInfo string) ([]string, error) {
 	if err != nil {
 		return []string{}, err
 	}
-	return strings.Split(urlData.Path, "/"), nil
+
+	split := strings.Split(urlData.Path, "/")
+	if len(split) != 3 {
+		return []string{}, fmt.Errorf("github repository URL must follow https://github.com/org/repo format without subgroups (found %d path segments, expected 2): %s", len(split)-1, urlInfo)
+	}
+
+	return split, nil
 }

--- a/pkg/provider/github/scope_test.go
+++ b/pkg/provider/github/scope_test.go
@@ -140,6 +140,33 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 		},
 	}
 
+	// Malformed repository URLs for testing validation
+	malformedRepoURL := "https://org.com/owner/repo/subgroup"
+	repoDataMalformed := &v1alpha1.Repository{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "malformedrepo",
+			Namespace: testNamespace.Name,
+		},
+		Spec: v1alpha1.RepositorySpec{
+			URL: malformedRepoURL,
+		},
+	}
+
+	repoDataMalformedPattern := &v1alpha1.Repository{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "publicrepo-malformed-pattern",
+			Namespace: testNamespace.Name,
+		},
+		Spec: v1alpha1.RepositorySpec{
+			URL: repoFromWhichEventComes,
+			Settings: &v1alpha1.Settings{
+				GithubAppTokenScopeRepos: []string{"owner/repo/extra"},
+			},
+		},
+	}
+
 	tests := []struct {
 		name                     string
 		tData                    testclient.Data
@@ -308,6 +335,66 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			},
 			repoListsByGlobalConf: "owner1/[invalid",
 			wantError:             "invalid repo glob specified",
+			wantToken:             "",
+		},
+		{
+			name: "malformed repository URL with extra path segments returns error",
+			tData: testclient.Data{
+				Namespaces: []*corev1.Namespace{testNamespace},
+				Secret:     []*corev1.Secret{validSecret},
+				Repositories: []*v1alpha1.Repository{
+					repoData, repoDataMalformed,
+				},
+			},
+			repository: &v1alpha1.Repository{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "publicrepo",
+					Namespace: testNamespace.Name,
+				},
+				Spec: v1alpha1.RepositorySpec{
+					URL: repoFromWhichEventComes,
+					Settings: &v1alpha1.Settings{
+						GithubAppTokenScopeRepos: []string{"owner/repo/subgroup"},
+					},
+				},
+			},
+			repoListsByGlobalConf: "",
+			wantError:             "github repository URL must follow https://github.com/org/repo format without subgroups",
+			wantToken:             "",
+		},
+		{
+			name: "malformed pattern with extra path segments returns error",
+			tData: testclient.Data{
+				Namespaces: []*corev1.Namespace{testNamespace},
+				Secret:     []*corev1.Secret{validSecret},
+				Repositories: []*v1alpha1.Repository{
+					repoDataMalformedPattern, repoData1,
+				},
+			},
+			repository:            repoDataMalformedPattern,
+			repoListsByGlobalConf: "",
+			wantError:             "failed to scope GitHub token as repo with pattern owner/repo/extra does not exist in namespace",
+			wantToken:             "",
+		},
+		{
+			name: "malformed pattern in global config with extra path segments returns error",
+			tData: testclient.Data{
+				Namespaces: []*corev1.Namespace{testNamespace},
+				Secret:     []*corev1.Secret{validSecret},
+			},
+			repository: &v1alpha1.Repository{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "publicrepo",
+					Namespace: testNamespace.Name,
+				},
+				Spec: v1alpha1.RepositorySpec{
+					URL: repoFromWhichEventComes,
+				},
+			},
+			repoListsByGlobalConf: "owner/repo/extra",
+			wantError:             "github repository URL must follow",
 			wantToken:             "",
 		},
 	}

--- a/pkg/test/repository/repository.go
+++ b/pkg/test/repository/repository.go
@@ -16,6 +16,7 @@ type RepoTestcreationOpts struct {
 	SecretName        string
 	WebhookSecretName string
 	ProviderURL       string
+	GitProviderType   string
 	CreateTime        metav1.Time
 	RepoStatus        []v1alpha1.RepositoryRunStatus
 	ConcurrencyLimit  int
@@ -78,7 +79,7 @@ func NewRepo(opts RepoTestcreationOpts) *v1alpha1.Repository {
 		repo.Spec.ConcurrencyLimit = &opts.ConcurrencyLimit
 	}
 
-	if opts.SecretName != "" || opts.ProviderURL != "" || opts.WebhookSecretName != "" {
+	if opts.SecretName != "" || opts.ProviderURL != "" || opts.WebhookSecretName != "" || opts.GitProviderType != "" {
 		repo.Spec.GitProvider = &v1alpha1.GitProvider{
 			Secret: &v1alpha1.Secret{},
 		}
@@ -97,6 +98,10 @@ func NewRepo(opts RepoTestcreationOpts) *v1alpha1.Repository {
 		repo.Spec.GitProvider.WebhookSecret = &v1alpha1.Secret{
 			Name: opts.WebhookSecretName,
 		}
+	}
+
+	if opts.GitProviderType != "" {
+		repo.Spec.GitProvider.Type = opts.GitProviderType
 	}
 
 	if opts.Params != nil {

--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -2,8 +2,12 @@ package webhook
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"net/url"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	pac "github.com/openshift-pipelines/pipelines-as-code/pkg/generated/listers/pipelinesascode/v1alpha1"
@@ -42,13 +46,8 @@ func (ac *reconciler) Admit(_ context.Context, request *v1.AdmissionRequest) *v1
 			return webhook.MakeErrorStatus("URL must be set")
 		}
 
-		parsed, err := url.Parse(repo.Spec.URL)
-		if err != nil {
-			return webhook.MakeErrorStatus("invalid URL format: %v", err)
-		}
-
-		if parsed.Scheme != "http" && parsed.Scheme != "https" {
-			return webhook.MakeErrorStatus("URL scheme must be http or https")
+		if err := validateRepositoryURL(repo.Spec.URL); err != nil {
+			return webhook.MakeErrorStatus("%s", err.Error())
 		}
 	}
 
@@ -93,4 +92,62 @@ func checkIfRepoExist(pac pac.RepositoryLister, repo *v1alpha1.Repository, ns st
 		}
 	}
 	return false, nil
+}
+
+func validateRepositoryURL(repoURL string) error {
+	parsedURL, err := url.Parse(repoURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL format: %w", err)
+	}
+
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return fmt.Errorf("URL scheme must be http or https")
+	}
+
+	// Validate github repository URL does not include additional path segments
+	// (like https://github.com/org/repo/extra).
+	// Detect if this is a GitHub instance (github.com or GHE) by checking headers
+	//  and API endpoints.
+	if isGitHubInstance(parsedURL.Host, parsedURL.Scheme) {
+		// Remove leading and trailing "/"
+		repoPath := strings.Trim(parsedURL.Path, "/")
+
+		split := strings.Split(repoPath, "/")
+		if len(split) != 2 {
+			return fmt.Errorf("github repository URL must follow https://github.com/org/repo format without subgroups (found %d path segments, expected 2): %s", len(split), repoURL)
+		}
+	}
+
+	return nil
+}
+
+// isGitHubInstance detects if a host is github.com or a GitHub Enterprise instance.
+// It checks the server header and /api/v3/meta endpoint.
+func isGitHubInstance(host, scheme string) bool {
+	if host == "github.com" {
+		return true
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	client := &http.Client{}
+
+	// Try HEAD request to check the server header.
+	url := fmt.Sprintf("%s://%s", scheme, host)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return false
+	}
+
+	resp, err := client.Do(req)
+	if err == nil {
+		defer resp.Body.Close()
+		server := resp.Header.Get("Server")
+		if strings.Contains(strings.ToLower(server), "github.com") {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -103,6 +103,73 @@ func TestReconciler_Admit(t *testing.T) {
 			allowed: false,
 			result:  "repository already exists with URL: https://pac.test/already/installed",
 		},
+		{
+			name: "reject github.com URL with subgroup, GitHub auto-detected",
+			repo: testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
+				Name:             "test-run",
+				InstallNamespace: "namespace",
+				URL:              "https://github.com/owner/repo/subgroup",
+			}),
+			allowed: false,
+			result:  "github repository URL must follow https://github.com/org/repo format without subgroups (found 3 path segments, expected 2): https://github.com/owner/repo/subgroup",
+		},
+		{
+			name: "allow github.com URL with correct format, GitHub auto-detected",
+			repo: testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
+				Name:             "test-run",
+				InstallNamespace: "namespace",
+				URL:              "https://github.com/owner/repo",
+			}),
+			allowed: true,
+		},
+		{
+			name: "reject GitHub repository URL with subgroup",
+			repo: testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
+				Name:             "test-run",
+				InstallNamespace: "namespace",
+				URL:              "https://ghe.pipelinesascode.com/owner/repo/subgroup",
+			}),
+			allowed: false,
+			result:  "github repository URL must follow https://github.com/org/repo format without subgroups (found 3 path segments, expected 2): https://ghe.pipelinesascode.com/owner/repo/subgroup",
+		},
+		{
+			name: "reject GitHub repository URL with multiple subgroups",
+			repo: testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
+				Name:             "test-run",
+				InstallNamespace: "namespace",
+				URL:              "https://github.com/owner/repo/subgroup/extra",
+			}),
+			allowed: false,
+			result:  "github repository URL must follow https://github.com/org/repo format without subgroups (found 4 path segments, expected 2): https://github.com/owner/repo/subgroup/extra",
+		},
+		{
+			name: "allow GitLab repository URL with subgroups",
+			repo: testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
+				Name:             "test-run",
+				InstallNamespace: "namespace",
+				URL:              "https://gitlab.com/owner/group/repo",
+			}),
+			allowed: true,
+		},
+		{
+			name: "allow Bitbucket repository URL with subgroups",
+			repo: testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
+				Name:             "test-run",
+				InstallNamespace: "namespace",
+				URL:              "https://bitbucket.org/workspace/project/repo",
+			}),
+			allowed: true,
+		},
+		{
+			name: "allow GitHub URL with correct format",
+			repo: testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
+				Name:             "test-run",
+				InstallNamespace: "namespace",
+				URL:              "https://ghe.company.com/owner/repo",
+				GitProviderType:  "github",
+			}),
+			allowed: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION

## 📝 Description of the Change
Reject Repository CRs with malformed GitHub URLs that include extra
path segments (e.g., https://github.com/org/repo/extra). These URLs
previously passed admission and were truncated during token scoping,
allowing bypass of namespace guards.

Add GitHub Enterprise detection to accurately validate repository
URLs. Detects GHE via Server header and /api/v3/meta endpoint,
then enforces org/repo format without additional path segments.
This prevents malformed URLs during admission and token scoping.

## 👨🏻‍ Linked Jira
Jira: https://issues.redhat.com/browse/SRVKP-10943

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #2395

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
