### PR TITLE
fix(e2e): add SinceSeconds support to pod log helpers

### DIFF
--- a/test/bitbucket_datacenter_dynamic_variables_test.go
+++ b/test/bitbucket_datacenter_dynamic_variables_test.go
@@ -65,6 +65,6 @@ func TestBitbucketDataCenterDynamicVariables(t *testing.T) {
 	wait.Succeeded(ctx, t, runcnx, opts, successOpts)
 
 	reg := *regexp.MustCompile(fmt.Sprintf("event: repo:refs_changed, refId: refs/heads/%s, message: %s", targetNS, commitMsg))
-	err = wait.RegexpMatchingInPodLog(ctx, runcnx, targetNS, "pipelinesascode.tekton.dev/original-prname=pipelinerun-dynamic-vars", "step-task", reg, "", 2)
+	err = wait.RegexpMatchingInPodLog(ctx, runcnx, targetNS, "pipelinesascode.tekton.dev/original-prname=pipelinerun-dynamic-vars", "step-task", reg, "", 2, nil)
 	assert.NilError(t, err)
 }

--- a/test/gitea_access_control_test.go
+++ b/test/gitea_access_control_test.go
@@ -259,7 +259,7 @@ func TestGiteaACLCommentsAllowing(t *testing.T) {
 			tgitea.WaitForPullRequestCommentMatch(t, topts)
 			tgitea.WaitForStatus(t, topts, topts.PullRequest.Head.Sha, "", false)
 			// checking the pod log to make sure /test <prname> works
-			err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, "pipelinesascode.tekton.dev/event-type=pull_request", "step-task", *regexp.MustCompile(".*MOTO"), "", 2)
+			err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, "pipelinesascode.tekton.dev/event-type=pull_request", "step-task", *regexp.MustCompile(".*MOTO"), "", 2, nil)
 			assert.NilError(t, err, "Error while checking the logs of the pods")
 		})
 	}

--- a/test/gitea_custom_params_cel_test.go
+++ b/test/gitea_custom_params_cel_test.go
@@ -62,7 +62,7 @@ func TestGiteaCustomParamsInCELExpression(t *testing.T) {
 	output := `Custom params: enable_ci=true environment=staging`
 	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS,
 		fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=custom-params-cel-test", prs.Items[0].Name),
-		"step-test-custom-params-cel", *regexp.MustCompile(output), "", 2)
+		"step-test-custom-params-cel", *regexp.MustCompile(output), "", 2, nil)
 	assert.NilError(t, err)
 }
 
@@ -124,13 +124,13 @@ func TestGiteaCustomParamsFromSecretsInCEL(t *testing.T) {
 	output := `Secret params verified: api_key=super-secret-api-key-12345 deploy_token=deploy-token-xyz-789`
 	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS,
 		"tekton.dev/pipelineTask=cel-secret-params-test",
-		"step-test-cel-secret-params", *regexp.MustCompile(output), "", 2)
+		"step-test-cel-secret-params", *regexp.MustCompile(output), "", 2, nil)
 	assert.NilError(t, err)
 
 	// Verify secrets are not leaked in controller logs
 	maxLines := int64(1000)
 	secretLeakRegex := regexp.MustCompile(`super-secret-api-key-12345|deploy-token-xyz-789`)
-	err = twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *secretLeakRegex, 2, "controller", &maxLines)
+	err = twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *secretLeakRegex, 2, "controller", &maxLines, nil)
 	if err == nil {
 		t.Fatal("Secret values were found in controller logs - this is a security issue!")
 	}
@@ -234,6 +234,6 @@ func TestGiteaOnCommentParamsReResolved(t *testing.T) {
 	output := `Trigger type verified: trigger_type=comment`
 	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS,
 		"tekton.dev/pipelineTask=on-comment-cel-test",
-		"step-test-on-comment-cel", *regexp.MustCompile(output), "", 2)
+		"step-test-on-comment-cel", *regexp.MustCompile(output), "", 2, nil)
 	assert.NilError(t, err)
 }

--- a/test/gitea_gitops_commands_test.go
+++ b/test/gitea_gitops_commands_test.go
@@ -114,7 +114,7 @@ func TestGiteaOnCommentAnnotation(t *testing.T) {
 	last := repo.Status[len(repo.Status)-1]
 	twait.GoldenPodLog(context.Background(), t, topts.ParamsRun, topts.TargetNS,
 		fmt.Sprintf("tekton.dev/pipelineRun=%s", last.PipelineRunName),
-		"step-task", strings.ReplaceAll(fmt.Sprintf("%s-pipelinerun-on-comment-annotation.golden", t.Name()), "/", "-"), 2)
+		"step-task", strings.ReplaceAll(fmt.Sprintf("%s-pipelinerun-on-comment-annotation.golden", t.Name()), "/", "-"), 2, nil)
 
 	tgitea.PostCommentOnPullRequest(t, topts, fmt.Sprintf(`%s revision=main custom1=thisone custom2="another one" custom_no_initial_value="a \"quote\""`, triggerComment))
 	waitOpts.MinNumberStatus = 4
@@ -125,7 +125,7 @@ func TestGiteaOnCommentAnnotation(t *testing.T) {
 	// now we should have only 3 status, the last one is the on comment match with an argument redefining the revision which is a standard parameter
 
 	last = repo.Status[len(repo.Status)-1]
-	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s", last.PipelineRunName), "step-task", regexp.Regexp{}, t.Name(), 2)
+	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s", last.PipelineRunName), "step-task", regexp.Regexp{}, t.Name(), 2, nil)
 	assert.NilError(t, err)
 }
 
@@ -175,7 +175,7 @@ func TestGiteaTestPipelineRunExplicitlyWithTestComment(t *testing.T) {
 		"we didn't target the proper pipelinerun, we tested: %s", repo.Status[0].PipelineRunName)
 
 	last := repo.Status[len(repo.Status)-1]
-	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s", last.PipelineRunName), "step-task", *regexp.MustCompile("custom is awesome"), "", 2)
+	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s", last.PipelineRunName), "step-task", *regexp.MustCompile("custom is awesome"), "", 2, nil)
 	assert.NilError(t, err)
 }
 

--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -111,6 +111,7 @@ func TestGiteaRetestPreservesSourceURL(t *testing.T) {
 		fmt.Sprintf("tekton.dev/pipelineRun=%s", firstPR.Name),
 		"step-test-standard-params-value",
 		&numLines,
+		nil,
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, firstOut != "")
@@ -170,6 +171,7 @@ func TestGiteaRetestPreservesSourceURL(t *testing.T) {
 		fmt.Sprintf("tekton.dev/pipelineRun=%s", retestPR.Name),
 		"step-test-standard-params-value",
 		&numLines,
+		nil,
 	)
 	assert.NilError(t, err)
 	assert.Assert(t, out != "")
@@ -321,6 +323,7 @@ func TestGiteaGlobalRepoParams(t *testing.T) {
 		regexp.Regexp{},
 		t.Name(),
 		2,
+		nil,
 	)
 	assert.NilError(t, err)
 }
@@ -399,6 +402,7 @@ func TestGiteaGlobalRepoUseLocalDef(t *testing.T) {
 		regexp.Regexp{},
 		t.Name(),
 		2,
+		nil,
 	)
 	assert.NilError(t, err)
 }
@@ -484,7 +488,7 @@ func TestGiteaParamsOnRepoCR(t *testing.T) {
 	assert.NilError(t,
 		twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=params",
 			repo.Status[0].PipelineRunName), "step-test-params-value", *regexp.MustCompile(
-			"I am the most Kawaī params\nSHHHHHHH\nFollow me on my ig #nofilter\n{{ no_match }}\nHey I show up from a payload match\n{{ secret_nothere }}\n{{ no_initial_value }}"), "", 2))
+			"I am the most Kawaī params\nSHHHHHHH\nFollow me on my ig #nofilter\n{{ no_match }}\nHey I show up from a payload match\n{{ secret_nothere }}\n{{ no_initial_value }}"), "", 2, nil))
 }
 
 // TestGiteaParamsBodyHeadersCEL Test that we can access the pull request body and headers in params
@@ -515,7 +519,7 @@ func TestGiteaParamsBodyHeadersCEL(t *testing.T) {
 	output := `Look mum I know that we are acting on a pull_request
 my email is a true beauty and like groot, I AM pac`
 	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=cel-pullrequest-params",
-		repo.Status[0].PipelineRunName), "step-test-cel-params-value", *regexp.MustCompile(output), "", 2)
+		repo.Status[0].PipelineRunName), "step-test-cel-params-value", *regexp.MustCompile(output), "", 2, nil)
 	assert.NilError(t, err)
 
 	// Merge the pull request so we can generate a push event and wait that it is updated
@@ -553,7 +557,7 @@ my email is a true beauty and like groot, I AM pac`
 	// push matching the expanded CEL body and headers values
 	output = `Look mum I know that we are acting on a push
 my email is a true beauty and you can call me pacman`
-	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=cel-push-params", sortedstatus[0].PipelineRunName), "step-test-cel-params-value", *regexp.MustCompile(output), "", 2)
+	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=cel-push-params", sortedstatus[0].PipelineRunName), "step-test-cel-params-value", *regexp.MustCompile(output), "", 2, nil)
 	assert.NilError(t, err)
 }
 
@@ -599,7 +603,7 @@ func TestGiteaParamsChangedFilesCEL(t *testing.T) {
 	assert.Equal(t, len(repo.Status), 1, repo.Status)
 	twait.GoldenPodLog(context.Background(), t, topts.ParamsRun, topts.TargetNS,
 		fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=changed-files-pullrequest-params", repo.Status[0].PipelineRunName),
-		"step-test-changed-files-params-pull", strings.ReplaceAll(fmt.Sprintf("%s-changed-files-pullrequest-params-1.golden", t.Name()), "/", "-"), 2)
+		"step-test-changed-files-params-pull", strings.ReplaceAll(fmt.Sprintf("%s-changed-files-pullrequest-params-1.golden", t.Name()), "/", "-"), 2, nil)
 	// ======================================================================================================================
 	// Merge the pull request so we can generate a push event and wait that it is updated
 	// ======================================================================================================================
@@ -633,7 +637,7 @@ func TestGiteaParamsChangedFilesCEL(t *testing.T) {
 
 	twait.GoldenPodLog(context.Background(), t, topts.ParamsRun, topts.TargetNS,
 		fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=changed-files-push-params", sortedstatus[0].PipelineRunName),
-		"step-test-changed-files-params-push", strings.ReplaceAll(fmt.Sprintf("%s-changed-files-push-params-1.golden", t.Name()), "/", "-"), 2)
+		"step-test-changed-files-params-push", strings.ReplaceAll(fmt.Sprintf("%s-changed-files-push-params-1.golden", t.Name()), "/", "-"), 2, nil)
 
 	// ======================================================================================================================
 	// Create second pull request with all change types
@@ -645,7 +649,7 @@ func TestGiteaParamsChangedFilesCEL(t *testing.T) {
 	assert.Equal(t, len(repo.Status), 3, repo.Status)
 	twait.GoldenPodLog(context.Background(), t, topts.ParamsRun, topts.TargetNS,
 		fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=changed-files-pullrequest-params", repo.Status[2].PipelineRunName),
-		"step-test-changed-files-params-pull", strings.ReplaceAll(fmt.Sprintf("%s-changed-files-pullrequest-params-2.golden", t.Name()), "/", "-"), 2)
+		"step-test-changed-files-params-pull", strings.ReplaceAll(fmt.Sprintf("%s-changed-files-pullrequest-params-2.golden", t.Name()), "/", "-"), 2, nil)
 
 	// ======================================================================================================================
 	// Merge the pull request so we can generate a second push event and wait that it is updated
@@ -681,7 +685,7 @@ func TestGiteaParamsChangedFilesCEL(t *testing.T) {
 	// push matching the expanded CEL body and headers values
 	twait.GoldenPodLog(context.Background(), t, topts.ParamsRun, topts.TargetNS,
 		fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=changed-files-push-params", sortedstatus[0].PipelineRunName),
-		"step-test-changed-files-params-push", strings.ReplaceAll(fmt.Sprintf("%s-changed-files-push-params-2.golden", t.Name()), "/", "-"), 2)
+		"step-test-changed-files-params-push", strings.ReplaceAll(fmt.Sprintf("%s-changed-files-push-params-2.golden", t.Name()), "/", "-"), 2, nil)
 }
 
 // TestGiteaParamsCelPrefix tests the cel: prefix for arbitrary CEL expressions.
@@ -721,6 +725,7 @@ func TestGiteaParamsCelPrefix(t *testing.T) {
 		regexp.Regexp{},
 		t.Name(),
 		2,
+		nil,
 	)
 	assert.NilError(t, err)
 }

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -144,7 +144,7 @@ func TestGiteaPullRequestResolvedTektonParamsRemotePipeline(t *testing.T) {
 	err := twait.RegexpMatchingInPodLog(context.Background(),
 		topts.ParamsRun,
 		topts.TargetNS, "pipelinesascode.tekton.dev/event-type=pull_request", "step-task",
-		*regexp.MustCompile("Hello " + topts.TargetRepoName), "", 2)
+		*regexp.MustCompile("Hello " + topts.TargetRepoName), "", 2, nil)
 	assert.NilError(t, err)
 }
 
@@ -162,7 +162,7 @@ func TestGiteaPullRequestPrivateRepository(t *testing.T) {
 	defer f()
 	reg := regexp.MustCompile(".*successfully fetched git-clone task from default configured catalog Hub")
 	maxLines := int64(1000)
-	err := twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *reg, 20, "controller", &maxLines)
+	err := twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *reg, 20, "controller", &maxLines, nil)
 	assert.NilError(t, err)
 	tgitea.WaitForSecretDeletion(t, topts, topts.TargetRefName)
 }
@@ -255,7 +255,7 @@ func TestGiteaBadYamlValidation(t *testing.T) {
 	maxLines := int64(1000)
 	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *regexp.MustCompile(
 		"cannot read the PipelineRun: pr-bad-format.yaml, error: yaml validation error: line 3: could not find expected ':'"),
-		10, "controller", &maxLines))
+		10, "controller", &maxLines, nil))
 }
 
 // TestGiteaInvalidSpecValues tests invalid field values of a PipelinRun and ensures that these
@@ -950,7 +950,7 @@ func TestGiteaOnPullRequestLabels(t *testing.T) {
 	assert.NilError(t, err)
 	twait.GoldenPodLog(context.Background(), t, topts.ParamsRun, topts.TargetNS,
 		fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=task", repo.Status[0].PipelineRunName),
-		"step-success", strings.ReplaceAll(fmt.Sprintf("%s.golden", t.Name()), "/", "-"), 2)
+		"step-success", strings.ReplaceAll(fmt.Sprintf("%s.golden", t.Name()), "/", "-"), 2, nil)
 
 	// Make sure the on-label pr has triggered and post status
 	topts.Regexp = regexp.MustCompile(fmt.Sprintf("Pipelines as Code CI/%s.* has <b>successfully</b> validated your commit", prName))
@@ -999,7 +999,7 @@ func TestGiteaBadLinkOfTask(t *testing.T) {
 	defer f()
 	errre := regexp.MustCompile("There was an error starting the PipelineRun")
 	maxLines := int64(1000)
-	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *errre, 10, "controller", &maxLines))
+	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *errre, 10, "controller", &maxLines, nil))
 }
 
 // TestGiteaPipelineRunWithSameName checks that we fail properly with the error from the
@@ -1162,7 +1162,7 @@ func verifyProvenance(t *testing.T, topts *tgitea.TestOpts, expectedOutput, cNam
 
 	// check the output of the PipelineRun logs
 	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, "pipelinesascode.tekton.dev/event-type=pull_request",
-		cName, *regexp.MustCompile(expectedOutput), "", 2)
+		cName, *regexp.MustCompile(expectedOutput), "", 2, nil)
 	assert.NilError(t, err)
 }
 

--- a/test/github_incoming_test.go
+++ b/test/github_incoming_test.go
@@ -311,7 +311,7 @@ func verifyIncomingWebhook(t *testing.T, randomedString, pipelinerunName string,
 		}
 		assert.Assert(t, prName == "pipelinerun-incoming", "Expected PipelineRun name 'pipelinerun-incoming', got '%s'", prName)
 
-		err = wait.RegexpMatchingInPodLog(context.Background(), runcnx, randomedString, "pipelinesascode.tekton.dev/event-type=incoming", "step-task", *regexp.MustCompile(".*It's a Bird... It's a Plane... It's Superman"), "", 2)
+		err = wait.RegexpMatchingInPodLog(context.Background(), runcnx, randomedString, "pipelinesascode.tekton.dev/event-type=incoming", "step-task", *regexp.MustCompile(".*It's a Bird... It's a Plane... It's Superman"), "", 2, nil)
 		assert.NilError(t, err, "Error while checking the logs of the pods")
 	} else {
 		runcnx.Clients.Log.Infof("Successfully verified no PipelineRun was created for non-matching branch %s with targets %v", randomedString, targets)

--- a/test/github_pullrequest_privaterepository_test.go
+++ b/test/github_pullrequest_privaterepository_test.go
@@ -29,9 +29,9 @@ func TestGithubGHEPullRequestGitCloneTask(t *testing.T) {
 	ctx, err := cctx.GetControllerCtxInfo(ctx, g.Cnx)
 	assert.NilError(t, err)
 
-	maxLines := int64(1000)
+	sinceSeconds := int64(20)
 	assert.NilError(t, wait.RegexpMatchingInControllerLog(ctx, g.Cnx, *regexp.MustCompile(".*fetched git-clone task"),
-		10, "ghe-controller", &maxLines), "Error while checking the logs of the pipelines-as-code controller pod")
+		10, "ghe-controller", nil, &sinceSeconds), "Error while checking the logs of the pipelines-as-code controller pod")
 	defer g.TearDown(ctx, t)
 }
 

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -752,7 +752,7 @@ func TestGithubGHEPullandPushMatchTriggerOnlyPull(t *testing.T) {
 
 	reg := regexp.MustCompile(fmt.Sprintf("Skipping push event for commit.*as it belongs to pull request #%d", g.PRNumber))
 	maxLines := int64(1000)
-	err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *reg, 20, "ghe-controller", &maxLines)
+	err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *reg, 20, "ghe-controller", &maxLines, nil)
 	assert.NilError(t, err)
 }
 
@@ -813,7 +813,7 @@ func TestGithubGHEIgnoreTagPushCommitsFromSkipPushEventsSetting(t *testing.T) {
 
 	reg := regexp.MustCompile(fmt.Sprintf("Processing tag push event for commit %s despite skip-push-events-for-pr-commits being enabled.*", g.SHA))
 	maxLines := int64(1000)
-	err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *reg, 20, "ghe-controller", &maxLines)
+	err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *reg, 20, "ghe-controller", &maxLines, nil)
 	assert.NilError(t, err)
 
 	g.Cnx.Clients.Log.Infof("Deleting tag %s", tag)
@@ -867,6 +867,7 @@ func TestGithubGHEPullRequestCelPrefix(t *testing.T) {
 		regexp.Regexp{},
 		t.Name(),
 		2,
+		nil,
 	)
 	assert.NilError(t, err)
 }

--- a/test/github_pullrequest_test_comment_test.go
+++ b/test/github_pullrequest_test_comment_test.go
@@ -90,10 +90,10 @@ func TestGithubGHEOnCommentAnnotation(t *testing.T) {
 	assert.Equal(t, *repo.Status[len(repo.Status)-1].EventType, opscomments.OnCommentEventType.String())
 	lastPrName := repo.Status[len(repo.Status)-1].PipelineRunName
 
-	err = twait.RegexpMatchingInPodLog(context.Background(), g.Cnx, g.TargetNamespace, fmt.Sprintf("tekton.dev/pipelineRun=%s", lastPrName), "step-task", *regexp.MustCompile(triggerComment), "", 2)
+	err = twait.RegexpMatchingInPodLog(context.Background(), g.Cnx, g.TargetNamespace, fmt.Sprintf("tekton.dev/pipelineRun=%s", lastPrName), "step-task", *regexp.MustCompile(triggerComment), "", 2, nil)
 	assert.NilError(t, err)
 
 	err = twait.RegexpMatchingInPodLog(context.Background(), g.Cnx, g.TargetNamespace, fmt.Sprintf("tekton.dev/pipelineRun=%s", lastPrName), "step-task", *regexp.MustCompile(fmt.Sprintf(
-		"The event is %s", opscomments.OnCommentEventType.String())), "", 2)
+		"The event is %s", opscomments.OnCommentEventType.String())), "", 2, nil)
 	assert.NilError(t, err)
 }

--- a/test/github_push_retest_test.go
+++ b/test/github_push_retest_test.go
@@ -84,7 +84,8 @@ func TestGithubGHEPushRequestGitOpsCommentOnComment(t *testing.T) {
 		"step-task",
 		*regexp.MustCompile(opsComment),
 		"",
-		2)
+		2,
+		nil)
 
 	assert.NilError(t, err)
 }
@@ -202,7 +203,7 @@ func TestGithubGHEPushRequestGitOpsCommentCancel(t *testing.T) {
 	if err != nil {
 		numLines := int64(1000)
 		reg := regexp.MustCompile(".*cancel-in-progress:.*pipelinerun.*on-push.*")
-		logErr := twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *reg, 10, "ghe-controller", &numLines)
+		logErr := twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *reg, 10, "ghe-controller", &numLines, nil)
 		if logErr != nil {
 			t.Errorf("neither a cancelled pipelinerun in repo status or a cancellation request in the controller log was found: status wait error: %s, log wait error: %s", err.Error(), logErr.Error())
 		}
@@ -329,6 +330,6 @@ func TestGithubGHEPullRequestRetestPullRequestNumberSubstitution(t *testing.T) {
 	err = twait.RegexpMatchingInPodLog(ctx, g.Cnx, g.TargetNamespace,
 		fmt.Sprintf("pipelinesascode.tekton.dev/event-type=%s",
 			opscomments.RetestSingleCommentEventType.String()),
-		"step-task", *regex, "", 2)
+		"step-task", *regex, "", 2, nil)
 	assert.NilError(t, err)
 }

--- a/test/github_skip_ci_test.go
+++ b/test/github_skip_ci_test.go
@@ -44,7 +44,7 @@ func verifySkipCI(ctx context.Context, t *testing.T, g *tgithub.PRTest, eventTyp
 	}
 	numLines := int64(1000)
 	skipLogRegex := regexp.MustCompile(fmt.Sprintf("CI skipped for %s event.*contains skip command in message", eventType))
-	err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *skipLogRegex, 10, controllerName, &numLines)
+	err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *skipLogRegex, 10, controllerName, &numLines, nil)
 	assert.NilError(t, err, "Expected controller logs to mention CI skip due to skip command")
 
 	g.Cnx.Clients.Log.Infof("✓ Verified controller logs mention skip command detection")
@@ -115,7 +115,7 @@ func TestGithubGHESkipCITestCommand(t *testing.T) {
 	// Verify controller logs mention skip command detection
 	numLines := int64(1000)
 	skipLogRegex := regexp.MustCompile("CI skipped for pull request event.*contains skip command in message")
-	err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *skipLogRegex, 10, "ghe-controller", &numLines)
+	err = twait.RegexpMatchingInControllerLog(ctx, g.Cnx, *skipLogRegex, 10, "ghe-controller", &numLines, nil)
 	assert.NilError(t, err, "Expected controller logs to mention CI skip due to skip command")
 
 	g.Cnx.Clients.Log.Infof("✓ Verified controller logs mention skip command detection")

--- a/test/gitlab_delete_tag_event_test.go
+++ b/test/gitlab_delete_tag_event_test.go
@@ -48,7 +48,7 @@ func TestGitlabDeleteTagEvent(t *testing.T) {
 
 	logLinesToCheck := int64(1000)
 	reg := regexp.MustCompile("event Delete Tag Push Hook is not supported.*")
-	err = twait.RegexpMatchingInControllerLog(ctx, runcnx, *reg, 10, "controller", &logLinesToCheck)
+	err = twait.RegexpMatchingInControllerLog(ctx, runcnx, *reg, 10, "controller", &logLinesToCheck, nil)
 	assert.NilError(t, err)
 }
 

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -276,7 +276,7 @@ func TestGitlabOnComment(t *testing.T) {
 	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
 	lastPrName := repo.Status[len(repo.Status)-1].PipelineRunName
 
-	err = twait.RegexpMatchingInPodLog(context.Background(), runcnx, targetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s", lastPrName), "step-task", *regexp.MustCompile(triggerComment), "", 2)
+	err = twait.RegexpMatchingInPodLog(context.Background(), runcnx, targetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s", lastPrName), "step-task", *regexp.MustCompile(triggerComment), "", 2, nil)
 	assert.NilError(t, err)
 }
 
@@ -1028,6 +1028,7 @@ func TestGitlabMergeRequestCelPrefix(t *testing.T) {
 		regexp.Regexp{},
 		t.Name(),
 		2,
+		nil,
 	)
 	assert.NilError(t, err)
 }
@@ -1113,6 +1114,7 @@ func TestGitlabMergeRequestVariableSubs(t *testing.T) {
 		*regexp.MustCompile(regexp.QuoteMeta(commitTitle)),
 		"",
 		2,
+		nil,
 	)
 	assert.NilError(t, err, "PipelineRun logs should contain the commit message: %s", commitTitle)
 }

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -635,7 +635,7 @@ func GetStandardParams(t *testing.T, topts *TestOpts, eventType string) (repoURL
 		topts.ParamsRun.Clients.Kube.CoreV1(),
 		topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s",
 			prs.Items[0].Name), "step-test-standard-params-value",
-		&numLines)
+		&numLines, nil)
 	assert.NilError(t, err)
 	assert.Assert(t, out != "")
 	out = strings.TrimSpace(out)

--- a/test/pkg/github/instrumentation.go
+++ b/test/pkg/github/instrumentation.go
@@ -62,7 +62,7 @@ func (g *PRTest) collectGitHubAPICalls(ctx context.Context, _ *testing.T) {
 	)
 
 	logContent, source, err := tlogs.GetControllerLogByName(
-		ctx, g.Cnx.Clients.Kube.CoreV1(), ns, controllerName, &numLines,
+		ctx, g.Cnx.Clients.Kube.CoreV1(), ns, controllerName, &numLines, nil,
 	)
 	if err != nil {
 		g.Logger.Warnf("Failed to get controller logs: %v", err)

--- a/test/pkg/wait/logs.go
+++ b/test/pkg/wait/logs.go
@@ -15,7 +15,7 @@ import (
 	"gotest.tools/v3/golden"
 )
 
-func RegexpMatchingInControllerLog(ctx context.Context, clients *params.Run, reg regexp.Regexp, maxNumberOfLoop int, controllerName string, lines *int64) error {
+func RegexpMatchingInControllerLog(ctx context.Context, clients *params.Run, reg regexp.Regexp, maxNumberOfLoop int, controllerName string, lines, sinceSeconds *int64) error {
 	ns := info.GetNS(ctx)
 	clients.Clients.Log.Infof(
 		`looking for regexp "%s" in %s for controller "%s" namespace "%s"`,
@@ -23,7 +23,7 @@ func RegexpMatchingInControllerLog(ctx context.Context, clients *params.Run, reg
 	)
 	for i := 0; i <= maxNumberOfLoop; i++ {
 		output, source, err := tlogs.GetControllerLogByName(
-			ctx, clients.Clients.Kube.CoreV1(), ns, controllerName, lines,
+			ctx, clients.Clients.Kube.CoreV1(), ns, controllerName, lines, sinceSeconds,
 		)
 		if err != nil {
 			return err
@@ -44,7 +44,7 @@ func RegexpMatchingInControllerLog(ctx context.Context, clients *params.Run, reg
 	)
 }
 
-func RegexpMatchingInPodLog(ctx context.Context, clients *params.Run, ns, labelselector, containerName string, reg regexp.Regexp, goldenFile string, maxNumberOfLoop int) error {
+func RegexpMatchingInPodLog(ctx context.Context, clients *params.Run, ns, labelselector, containerName string, reg regexp.Regexp, goldenFile string, maxNumberOfLoop int, sinceSeconds *int64) error {
 	var err error
 	output := ""
 	if goldenFile != "" {
@@ -57,7 +57,7 @@ func RegexpMatchingInPodLog(ctx context.Context, clients *params.Run, ns, labels
 	}
 	numLines := int64(10)
 	for i := 0; i <= maxNumberOfLoop; i++ {
-		output, err = tlogs.GetPodLog(ctx, clients.Clients.Kube.CoreV1(), ns, labelselector, containerName, &numLines)
+		output, err = tlogs.GetPodLog(ctx, clients.Clients.Kube.CoreV1(), ns, labelselector, containerName, &numLines, sinceSeconds)
 		if err != nil {
 			return err
 		}
@@ -78,12 +78,12 @@ func RegexpMatchingInPodLog(ctx context.Context, clients *params.Run, ns, labels
 }
 
 // GoldenPodLog is a helper function to get the logs of a pod and compare it to a golden file.
-func GoldenPodLog(ctx context.Context, t *testing.T, clients *params.Run, ns, labelselector, containerName, goldenFile string, maxNumberOfLoop int) {
+func GoldenPodLog(ctx context.Context, t *testing.T, clients *params.Run, ns, labelselector, containerName, goldenFile string, maxNumberOfLoop int, sinceSeconds *int64) {
 	var err error
 	numLines := int64(10)
 	for i := 0; i <= maxNumberOfLoop; i++ {
 		var output string
-		output, err = tlogs.GetPodLog(ctx, clients.Clients.Kube.CoreV1(), ns, labelselector, containerName, &numLines)
+		output, err = tlogs.GetPodLog(ctx, clients.Clients.Kube.CoreV1(), ns, labelselector, containerName, &numLines, sinceSeconds)
 		if err != nil {
 			time.Sleep(5 * time.Second)
 			continue


### PR DESCRIPTION
The GetPodLog, GetControllerLogByName, RegexpMatchingInControllerLog, RegexpMatchingInPodLog, and GoldenPodLog functions now accept an optional sinceSeconds parameter, which maps to the Kubernetes PodLogOptions.SinceSeconds field.

When kubelet rotates CRI container logs (e.g. containerd splitting 0.log into 0.log.<timestamp> and a new 0.log), the TailLines option may only read from the current log file, causing regexp assertions to miss matching lines that landed in the rotated segment. This was observed in TestGithubGHEPullRequestGitCloneTask where the "fetched git-clone task" message was written at 06:30:09, CRI rotation occurred at 06:30:13, and the test checked at 06:30:21 finding only 2 lines in the new 0.log.

SinceSeconds uses timestamps rather than byte offsets, so it reads across rotated CRI log files reliably. Callers that do not need time-based filtering pass nil to preserve existing behaviour.


Assisted-by: Claude Opus 4.6 (via Claude Code)

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [x] Documentation and research only
- [ ] Unit tests or E2E tests only
- [x] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [x] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
