### PR TITLE
test: workaround /test tag cross-test cross fails

### DIFF
--- a/test/gitlab_push_gitops_command_test.go
+++ b/test/gitlab_push_gitops_command_test.go
@@ -180,59 +180,47 @@ func TestGitlabGitOpsCommandTestOnTag(t *testing.T) {
 		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 	}
 
-	tagName := "v1.0.0"
+	tagName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("v1.0")
 	comment := "/test tag:" + tagName
 	sha := ""
 	targetBranch := "release-" + tagName
-	numberOfPRs := 1
+	numberOfPRs := 2
 
 	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNs, nil)
 	assert.NilError(t, err)
 
 	runcnx.Clients.Log.Infof("Repository %s has been created successfully", targetNs)
 
-	tag, resp, err := glprovider.Client().Tags.GetTag(opts.ProjectID, tagName)
-	if err != nil && resp.StatusCode == http.StatusNotFound {
-		runcnx.Clients.Log.Infof("Tag %s not found in repository %s", tagName, projectinfo.Name)
-		runcnx.Clients.Log.Infof("Creating tag %s in repository %s", tagName, projectinfo.Name)
+	entries, err := payload.GetEntries(map[string]string{
+		".tekton/pipelinerun-on-tag.yaml": "testdata/pipelinerun-on-tag.yaml",
+	}, targetNs, "refs/tags/*", triggertype.Push.String(), map[string]string{})
+	assert.NilError(t, err)
 
-		entries, err := payload.GetEntries(map[string]string{
-			".tekton/pipelinerun-on-tag.yaml": "testdata/pipelinerun-on-tag.yaml",
-		}, targetNs, "refs/tags/*", triggertype.Push.String(), map[string]string{})
-		assert.NilError(t, err)
+	cloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, "git", *glprovider.Token)
+	assert.NilError(t, err)
 
-		cloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, "git", *glprovider.Token)
-		assert.NilError(t, err)
-
-		scmOpts := &scm.Opts{
-			GitURL:        cloneURL,
-			Log:           runcnx.Clients.Log,
-			WebURL:        projectinfo.WebURL,
-			TargetRefName: targetBranch,
-			BaseRefName:   projectinfo.DefaultBranch,
-			CommitTitle:   "Test GitOps Commands on Tag - " + targetNs,
-		}
-		_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-
-		branch, _, err := glprovider.Client().Branches.GetBranch(opts.ProjectID, targetBranch)
-		assert.NilError(t, err)
-
-		sha = branch.Commit.ID
-
-		_, _, err = glprovider.Client().Tags.CreateTag(opts.ProjectID, &gitlab.CreateTagOptions{
-			TagName: gitlab.Ptr(tagName),
-			Ref:     gitlab.Ptr(targetBranch),
-		})
-		assert.NilError(t, err)
-
-		// as we're creating a tag, we need to increment the number of PRs
-		// because the tag creation will also trigger a new PipelineRun
-		numberOfPRs++
-	} else {
-		runcnx.Clients.Log.Infof("Tag %s already created in repository %s", tagName, projectinfo.Name)
-		sha = tag.Commit.ID
+	scmOpts := &scm.Opts{
+		GitURL:        cloneURL,
+		Log:           runcnx.Clients.Log,
+		WebURL:        projectinfo.WebURL,
+		TargetRefName: targetBranch,
+		BaseRefName:   projectinfo.DefaultBranch,
+		CommitTitle:   "Test GitOps Commands on Tag - " + targetNs,
 	}
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, "", targetNs, opts.ProjectID)
+	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
+
+	branch, _, err := glprovider.Client().Branches.GetBranch(opts.ProjectID, targetBranch)
+	assert.NilError(t, err)
+	sha = branch.Commit.ID
+
+	_, _, err = glprovider.Client().Tags.CreateTag(opts.ProjectID, &gitlab.CreateTagOptions{
+		TagName: gitlab.Ptr(tagName),
+		Ref:     gitlab.Ptr(targetBranch),
+	})
+	assert.NilError(t, err)
+
+	defer tgitlab.CleanTag(glprovider.Client(), opts.ProjectID, tagName)
+	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, targetBranch, targetNs, opts.ProjectID)
 
 	cc, _, err := glprovider.Client().Commits.PostCommitComment(opts.ProjectID, sha, &gitlab.PostCommitCommentOptions{
 		Note: gitlab.Ptr(comment),


### PR DESCRIPTION
Workaround for intermittent e2e flake seen during investigation: a delayed GitLab '/test tag' note can be replayed later and match the currently active Repository CR (URL-only matching), creating an extra PipelineRun in another test namespace.

This test previously reused a fixed tag (v1.0.0), which made stale tag/comment activity easier to collide with later runs.

Apply a containment workaround in TestGitlabGitOpsCommandTestOnTag:

- use a unique tag per run
- always create a fresh branch+tag
- clean up both tag and branch

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] 🎨 Style (`style:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [ ] ✅ Test (`test:`)
- [ ] 🏗️ Build (`build:`)
- [ ] 👷 CI (`ci:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] ⏪ Revert (`revert:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
