### PR TITLE
test: use dynamic projects and smee for GitLab E2E

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -88,7 +88,6 @@ jobs:
       TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP: pipelines-as-code/e2e
       TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
       TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
-      TEST_GITLAB_PROJECT_ID: ${{ vars.TEST_GITLAB_PROJECT_ID }}
       TEST_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -320,6 +319,20 @@ jobs:
         run: |
           nohup gosmee client --saveDir /tmp/gosmee-replay "${TEST_GITEA_SMEEURL}" "https://${CONTROLLER_DOMAIN_URL}" >> /tmp/gosmee-main.log 2>&1 &
 
+      - name: Generate unique gosmee URL for GitLab tests
+        if: matrix.provider == 'gitlab_bitbucket'
+        id: gosmee-gitlab-url
+        run: |
+          SMEE_URL=$(curl -s https://hook.pipelinesascode.com -o /dev/null -w '%{redirect_url}')
+          echo "Generated unique GitLab smee URL: ${SMEE_URL}"
+          echo "url=${SMEE_URL}" >> "$GITHUB_OUTPUT"
+          echo "TEST_GITLAB_SMEEURL=${SMEE_URL}" >> "$GITHUB_ENV"
+
+      - name: Run gosmee for GitLab tests
+        if: matrix.provider == 'gitlab_bitbucket'
+        run: |
+          nohup gosmee client --saveDir /tmp/gosmee-replay-gitlab "${TEST_GITLAB_SMEEURL}" "https://${CONTROLLER_DOMAIN_URL}" >> /tmp/gosmee-gitlab.log 2>&1 &
+
       - name: Run gosmee for second controller (GHE)
         if: startsWith(matrix.provider, 'github_ghe') || matrix.provider == 'concurrency'
         run: |
@@ -366,7 +379,8 @@ jobs:
           TEST_GITHUB_SECOND_WEBHOOK_SECRET: ${{ secrets.TEST_GITHUB_SECOND_WEBHOOK_SECRET }}
           TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
           TEST_GITLAB_API_URL: https://gitlab.com
-          TEST_GITLAB_PROJECT_ID: ${{ vars.TEST_GITLAB_PROJECT_ID }}
+          TEST_GITLAB_GROUP: pac-e2e-tests
+          TEST_GITLAB_SMEEURL: ${{ env.TEST_GITLAB_SMEEURL }}
           TEST_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
           TEST_PROVIDER: ${{ matrix.provider }}
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
@@ -466,6 +480,7 @@ jobs:
         if: ${{ always() }}
         env:
           TEST_GITHUB_SECOND_SMEE_URL: ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}
+          TEST_GITLAB_SMEEURL: ${{ steps.gosmee-gitlab-url.outputs.url }}
         run: |
           ./hack/gh-workflow-ci.sh collect_logs
 

--- a/hack/cleanup-gitlab-projects.py
+++ b/hack/cleanup-gitlab-projects.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env -S uv --quiet run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "requests",
+# ]
+# ///
+"""Clean up GitLab projects older than a given number of days in a group.
+
+Uses TEST_GITLAB_API_URL, TEST_GITLAB_TOKEN, and TEST_GITLAB_GROUP environment
+variables by default (same as the E2E test suite), but all values can be
+overridden via CLI flags.
+
+Examples:
+    # Dry-run (default) — show what would be deleted:
+    ./hack/cleanup-gitlab-projects.py
+
+    # Actually delete:
+    ./hack/cleanup-gitlab-projects.py --force
+
+    # Custom age threshold:
+    ./hack/cleanup-gitlab-projects.py --days 3 --force
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+
+import requests
+
+
+def get_projects(base_url: str, token: str, group: str) -> list[dict]:
+    """Return all projects in the given group, handling pagination."""
+    headers = {"PRIVATE-TOKEN": token}
+    url = f"{base_url}/api/v4/groups/{requests.utils.quote(group, safe='')}/projects"
+    params: dict = {"per_page": 100, "page": 1, "include_subgroups": False}
+    projects: list[dict] = []
+    while True:
+        resp = requests.get(url, headers=headers, params=params, timeout=30)
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+        projects.extend(batch)
+        params["page"] += 1
+    return projects
+
+
+def delete_project(base_url: str, token: str, project_id: int) -> None:
+    headers = {"PRIVATE-TOKEN": token}
+    url = f"{base_url}/api/v4/projects/{project_id}"
+    resp = requests.delete(url, headers=headers, timeout=30)
+    resp.raise_for_status()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--api-url",
+        default=os.getenv("TEST_GITLAB_API_URL", "https://gitlab.pipelinesascode.com"),
+        help="GitLab API base URL (default: $TEST_GITLAB_API_URL)",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.getenv("TEST_GITLAB_TOKEN", ""),
+        help="GitLab private token (default: $TEST_GITLAB_TOKEN)",
+    )
+    parser.add_argument(
+        "--group",
+        default=os.getenv("TEST_GITLAB_GROUP", "pac-e2e-tests"),
+        help="GitLab group path (default: $TEST_GITLAB_GROUP)",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=7,
+        help="Delete projects older than this many days (default: 7)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Actually delete projects (default is dry-run)",
+    )
+    args = parser.parse_args()
+
+    if not args.token:
+        print(
+            "ERROR: GitLab token is required. Set TEST_GITLAB_TOKEN or pass --token.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    base_url = args.api_url.rstrip("/")
+    now = datetime.now(tz=timezone.utc)
+
+    print(f"Listing projects in group '{args.group}' on {base_url} ...")
+    projects = get_projects(base_url, args.token, args.group)
+    print(f"Found {len(projects)} project(s).")
+
+    to_delete = []
+    for proj in projects:
+        created = datetime.fromisoformat(proj["created_at"])
+        age = now - created
+        if age.days >= args.days:
+            to_delete.append((proj, age))
+
+    if not to_delete:
+        print(f"No projects older than {args.days} day(s). Nothing to do.")
+        return
+
+    print(f"\n{len(to_delete)} project(s) older than {args.days} day(s):\n")
+    for proj, age in to_delete:
+        print(
+            f"  {proj['path_with_namespace']} (ID {proj['id']}, created {proj['created_at']}, {age.days}d old)"
+        )
+
+    if not args.force:
+        print("\nDry-run mode. Pass --force to delete these projects.")
+        return
+
+    print()
+    errors = 0
+    for proj, age in to_delete:
+        name = proj["path_with_namespace"]
+        try:
+            delete_project(base_url, args.token, proj["id"])
+            print(f"  Deleted {name} (ID {proj['id']})")
+        except requests.HTTPError as exc:
+            print(f"  ERROR deleting {name}: {exc}", file=sys.stderr)
+            errors += 1
+
+    deleted = len(to_delete) - errors
+    print(f"\nDone. Deleted {deleted} project(s).", end="")
+    if errors:
+        print(f" {errors} error(s).", end="")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -5,6 +5,7 @@ set -exufo pipefail
 
 export PAC_API_INSTRUMENTATION_DIR=/tmp/api-instrumentation
 export TEST_GITLAB_API_URL=https://gitlab.pipelinesascode.com
+export TEST_GITLAB_GROUP=pac-e2e-tests
 
 create_pac_github_app_secret() {
   # Read from environment variables instead of arguments
@@ -231,6 +232,7 @@ collect_logs() {
   # Read from environment variables (use default empty value for optional vars)
   local test_gitea_smee_url="${TEST_GITEA_SMEEURL:-}"
   local github_ghe_smee_url="${TEST_GITHUB_SECOND_SMEE_URL:-}"
+  local test_gitlab_smee_url="${TEST_GITLAB_SMEEURL:-}"
 
   mkdir -p /tmp/logs
   # Output logs to stdout so we can see via the web interface directly
@@ -244,6 +246,8 @@ collect_logs() {
   [[ -d /tmp/gosmee-replay-ghe ]] && cp -a /tmp/gosmee-replay-ghe /tmp/logs/gosmee/replay-ghe
   [[ -f /tmp/gosmee-main.log ]] && cp /tmp/gosmee-main.log /tmp/logs/gosmee/main.log
   [[ -f /tmp/gosmee-ghe.log ]] && cp /tmp/gosmee-ghe.log /tmp/logs/gosmee/ghe.log
+  [[ -d /tmp/gosmee-replay-gitlab ]] && cp -a /tmp/gosmee-replay-gitlab /tmp/logs/gosmee/replay-gitlab
+  [[ -f /tmp/gosmee-gitlab.log ]] && cp /tmp/gosmee-gitlab.log /tmp/logs/gosmee/gitlab.log
 
   kubectl get pipelineruns -A -o yaml >/tmp/logs/pac-pipelineruns.yaml
   kubectl get repositories.pipelinesascode.tekton.dev -A -o yaml >/tmp/logs/pac-repositories.yaml
@@ -264,7 +268,7 @@ collect_logs() {
     cp -a ${PAC_API_INSTRUMENTATION_DIR} /tmp/logs/$(basename ${PAC_API_INSTRUMENTATION_DIR})
   fi
 
-  for url in "${test_gitea_smee_url}" "${github_ghe_smee_url}"; do
+  for url in "${test_gitea_smee_url}" "${github_ghe_smee_url}" "${test_gitlab_smee_url}"; do
     [[ -z "${url}" ]] && continue
     find /tmp/logs -type f -exec grep -l "${url}" {} \; | xargs -r sed -i "s|${url}|SMEE_URL|g"
   done

--- a/test/README.md
+++ b/test/README.md
@@ -45,8 +45,9 @@ this repo should differ from the one which is configured as part of `TEST_GITHUB
 - `TEST_BITBUCKET_CLOUD_E2E_REPOSITORY` - Bitbucket Cloud repository (i.e. `project/repo`)
 - `TEST_BITBUCKET_CLOUD_TOKEN` - Bitbucket Cloud token
 - `TEST_GITLAB_API_URL` - Gitlab API URL i.e: `https://gitlab.com`
-- `TEST_GITLAB_PROJECT_ID` - Gitlab project ID (you can get it in the repo details/settings)
+- `TEST_GITLAB_GROUP` - Gitlab group/namespace where test projects will be created and deleted
 - `TEST_GITLAB_TOKEN` - Gitlab Token
+- `TEST_GITLAB_SMEEURL` - Smee URL for forwarding GitLab webhooks to the controller
 - `TEST_GITEA_API_URL` - URL where GITEA is running (i.e: [GITEA_HOST](http://localhost:3000))
 - `TEST_GITEA_SMEEURL` - URL of smee
 - `TEST_GITEA_PASSWORD` - set password as **pac**
@@ -102,6 +103,52 @@ You can specify only a subsets of test to run with :
 ```
 
 same goes for `TestGitlab` or other methods.
+
+### Running GitLab tests manually
+
+GitLab tests require a smee URL to forward webhooks from the external GitLab
+instance to your local controller (the same pattern as Gitea tests).
+
+1. Create your own group on the GitLab instance
+   (e.g. `https://gitlab.pipelinesascode.com`) to hold the temporary test
+   projects. Each test run creates a project inside this group and deletes it
+   on cleanup. Use `TEST_GITLAB_GROUP` to point to your group.
+
+2. Generate a smee channel and start the gosmee client to forward webhooks to
+   your controller:
+
+   ```shell
+   # Generate a new smee channel URL
+   SMEE_URL=$(curl -s https://hook.pipelinesascode.com -o /dev/null -w '%{redirect_url}')
+
+   # Start forwarding webhooks to your controller
+   gosmee client "${SMEE_URL}" "https://your-controller-url"
+   ```
+
+3. Set the required environment variables (or use a
+   [YAML config file](#yaml-configuration-file)):
+
+   ```shell
+   export TEST_GITLAB_API_URL=https://gitlab.pipelinesascode.com
+   export TEST_GITLAB_TOKEN=<your-token>
+   export TEST_GITLAB_GROUP=<your-group>
+   export TEST_GITLAB_SMEEURL="${SMEE_URL}"
+   export TEST_EL_URL=https://your-controller-url
+   export TEST_EL_WEBHOOK_SECRET=<your-webhook-secret>
+   ```
+
+4. Run the tests:
+
+   ```shell
+   cd test/; go test -tags=e2e -v -run TestGitlab .
+   ```
+
+To clean up stale test projects (older than 7 days) left from previous runs:
+
+```shell
+./hack/cleanup-gitlab-projects.py        # dry-run
+./hack/cleanup-gitlab-projects.py --force # actually delete
+```
 
 If you need to update the golden files in the end-to-end test, add the `-update` flag to the [go test](https://pkg.go.dev/cmd/go#hdr-Test_packages) command to refresh those files. First, run it if you expect the test output to change (or for a new test), then run it again without the flag to ensure everything is correct.
 

--- a/test/e2e-config.yaml.example
+++ b/test/e2e-config.yaml.example
@@ -44,8 +44,9 @@ github_enterprise:
 gitlab:
   api_url: "https://gitlab.com"
   token: ""
-  # Project ID (find in repo Settings > General)
-  project_id: ""
+  # Group/namespace where test projects will be created and deleted
+  group: "pac-e2e-tests"
+  smee_url: ""  # Auto-generated in CI; set manually for local testing
 
 # Gitea / Forgejo
 gitea:

--- a/test/gitlab_delete_tag_event_test.go
+++ b/test/gitlab_delete_tag_event_test.go
@@ -3,12 +3,9 @@
 package test
 
 import (
-	"context"
-	"net/http"
 	"regexp"
 	"testing"
 
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
 	"github.com/tektoncd/pipeline/pkg/names"
@@ -16,39 +13,25 @@ import (
 )
 
 func TestGitlabDeleteTagEvent(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing with Gitlab")
-
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		NoMRCreation: true,
 	}
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, "", targetNS, opts.ProjectID)
-
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
 	tagName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("v1.0")
-	err = tgitlab.CreateTag(glprovider.Client(), int(projectinfo.ID), tagName)
-	// if something goes wrong in creating tag and tag remains in
-	// repository CleanTag will clear that and doesn't throw any error.
-	defer tgitlab.CleanTag(glprovider.Client(), int(projectinfo.ID), tagName)
+	err := tgitlab.CreateTag(topts.GLProvider.Client(), topts.ProjectID, tagName)
+	defer tgitlab.CleanTag(topts.GLProvider.Client(), topts.ProjectID, tagName)
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Created Tag %s in %s repository", tagName, projectinfo.Name)
+	topts.ParamsRun.Clients.Log.Infof("Created Tag %s in project %d", tagName, topts.ProjectID)
 
-	err = tgitlab.DeleteTag(glprovider.Client(), int(projectinfo.ID), tagName)
+	err = tgitlab.DeleteTag(topts.GLProvider.Client(), topts.ProjectID, tagName)
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Deleted Tag %s in %s repository", tagName, projectinfo.Name)
+	topts.ParamsRun.Clients.Log.Infof("Deleted Tag %s in project %d", tagName, topts.ProjectID)
 
 	logLinesToCheck := int64(1000)
 	reg := regexp.MustCompile("event Delete Tag Push Hook is not supported.*")
-	err = twait.RegexpMatchingInControllerLog(ctx, runcnx, *reg, 10, "controller", &logLinesToCheck, nil)
+	err = twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *reg, 10, "controller", &logLinesToCheck, nil)
 	assert.NilError(t, err)
 }
 

--- a/test/gitlab_incoming_webhook_test.go
+++ b/test/gitlab_incoming_webhook_test.go
@@ -3,7 +3,6 @@
 package test
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,13 +11,11 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
-	"github.com/tektoncd/pipeline/pkg/names"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -34,72 +31,60 @@ func TestGitlabIncomingWebhookJsonBody(t *testing.T) {
 }
 
 func testGitlabIncomingWebhook(t *testing.T, useLegacy bool) {
-	randomedString := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing with Gitlab")
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
-	}
-
-	incoming := &[]v1alpha1.Incoming{
-		{
-			Type: "webhook-url",
-			Secret: v1alpha1.Secret{
-				Name: incomingSecretName,
-				Key:  "incoming",
+	topts := &tgitlab.TestOpts{
+		NoMRCreation: true,
+		Incomings: &[]v1alpha1.Incoming{
+			{
+				Type: "webhook-url",
+				Secret: v1alpha1.Secret{
+					Name: incomingSecretName,
+					Key:  "incoming",
+				},
+				Targets: []string{}, // filled in by TestMR
 			},
-			Targets: []string{randomedString},
 		},
 	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, randomedString, incoming)
+	// Update the incoming target to match the actual TargetNS and recreate the CRD
+	// The CRD was already created by TestMR, but we need the incoming secret
+	err := secret.Create(ctx, topts.ParamsRun, map[string]string{"incoming": incomingSecreteValue}, topts.TargetNS, incomingSecretName)
 	assert.NilError(t, err)
 
-	err = secret.Create(ctx, runcnx, map[string]string{"incoming": incomingSecreteValue}, randomedString, incomingSecretName)
-	assert.NilError(t, err)
-
+	// Push files for incoming webhook
 	entries, err := payload.GetEntries(map[string]string{
 		".tekton/pipelinerun-incoming.yaml": "testdata/pipelinerun-incoming.yaml",
 		".tekton/subdir/pr.yaml":            "testdata/pipelinerun-clone.yaml",
-	}, randomedString, randomedString, triggertype.Incoming.String(), map[string]string{})
+	}, topts.TargetNS, topts.TargetNS, triggertype.Incoming.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	title := "TestIncomingWebhook - " + randomedString
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
+	title := "TestIncomingWebhook - " + topts.TargetNS
 	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: randomedString,
-		BaseRefName:   projectinfo.DefaultBranch,
+		GitURL:        topts.GitCloneURL,
+		Log:           topts.ParamsRun.Clients.Log,
+		WebURL:        topts.GitHTMLURL,
+		TargetRefName: topts.TargetNS,
+		BaseRefName:   topts.DefaultBranch,
 		CommitTitle:   title,
 	}
 	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", randomedString)
+	topts.ParamsRun.Clients.Log.Infof("Branch %s has been created and pushed with files", topts.TargetNS)
 
 	var req *http.Request
 	var incomingURL string
 	client := &http.Client{}
 
 	if useLegacy {
-		// Legacy URL query parameters method
 		incomingURL = fmt.Sprintf("%s/incoming?repository=%s&branch=%s&pipelinerun=%s&secret=%s",
-			opts.ControllerURL, randomedString, randomedString, "pipelinerun-incoming", incomingSecreteValue)
+			topts.Opts.ControllerURL, topts.TargetNS, topts.TargetNS, "pipelinerun-incoming", incomingSecreteValue)
 		req, err = http.NewRequestWithContext(ctx, http.MethodPost, incomingURL, nil)
 		assert.NilError(t, err)
 	} else {
-		// JSON body method
-		incomingURL = fmt.Sprintf("%s/incoming", opts.ControllerURL)
+		incomingURL = fmt.Sprintf("%s/incoming", topts.Opts.ControllerURL)
 		jsonBody := map[string]interface{}{
-			"repository":  randomedString,
-			"branch":      randomedString,
+			"repository":  topts.TargetNS,
+			"branch":      topts.TargetNS,
 			"pipelinerun": "pipelinerun-incoming",
 			"secret":      incomingSecreteValue,
 		}
@@ -113,19 +98,18 @@ func testGitlabIncomingWebhook(t *testing.T, useLegacy bool) {
 	httpResp, err := client.Do(req)
 	assert.NilError(t, err)
 	defer httpResp.Body.Close()
-	runcnx.Clients.Log.Infof("Kicked off on incoming-webhook URL: %s", incomingURL)
+	topts.ParamsRun.Clients.Log.Infof("Kicked off on incoming-webhook URL: %s", incomingURL)
 	assert.Assert(t, httpResp.StatusCode >= 200 && httpResp.StatusCode < 300)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, randomedString, randomedString, opts.ProjectID)
 
 	sopt := wait.SuccessOpt{
 		Title:           title,
 		OnEvent:         triggertype.Incoming.String(),
-		TargetNS:        randomedString,
+		TargetNS:        topts.TargetNS,
 		NumberofPRMatch: 1,
 		SHA:             "",
 	}
-	wait.Succeeded(ctx, t, runcnx, opts, sopt)
-	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(randomedString).List(ctx, metav1.ListOptions{})
+	wait.Succeeded(ctx, t, topts.ParamsRun, topts.Opts, sopt)
+	prsNew, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prsNew.Items) == 1)
 

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -5,7 +5,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"regexp"
 	"testing"
 	"time"
@@ -17,7 +16,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
@@ -33,70 +31,42 @@ import (
 )
 
 func TestGitlabMergeRequest(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing with Gitlab")
-
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/pipelinerun.yaml":       "testdata/pipelinerun.yaml",
+			".tekton/pipelinerun-clone.yaml": "testdata/pipelinerun-clone.yaml",
+		},
 	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
-
-	entries, err := payload.GetEntries(map[string]string{
-		".tekton/pipelinerun.yaml":       "testdata/pipelinerun.yaml",
-		".tekton/pipelinerun-clone.yaml": "testdata/pipelinerun-clone.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
-		triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-
-	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
-	commitTitle := "Committing files from test on " + targetRefName
-	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		CommitTitle:   commitTitle,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
-	}
-	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetRefName)
-	mrTitle := "TestMergeRequest - " + targetRefName
-	mrID, err := tgitlab.CreateMR(glprovider.Client(), opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, int(int64(mrID)), targetRefName, targetNS, opts.ProjectID)
+	commitTitle := "Committing files from test on " + topts.TargetRefName
 
 	// Send another Push to make an update and make sure we react to it
-	entries, err = payload.GetEntries(map[string]string{
+	entries, err := payload.GetEntries(map[string]string{
 		"hello-world.yaml": "testdata/pipelinerun.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
+	}, topts.TargetNS, topts.DefaultBranch,
 		triggertype.PullRequest.String(), map[string]string{})
 	assert.NilError(t, err)
-	scmOpts.BaseRefName = targetRefName
+	scmOpts := &scm.Opts{
+		GitURL:        topts.GitCloneURL,
+		Log:           topts.ParamsRun.Clients.Log,
+		WebURL:        topts.GitHTMLURL,
+		TargetRefName: topts.TargetRefName,
+		BaseRefName:   topts.TargetRefName,
+	}
 	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
 
 	sopt := twait.SuccessOpt{
 		Title:           commitTitle,
 		OnEvent:         "Merge Request",
-		TargetNS:        targetNS,
+		TargetNS:        topts.TargetNS,
 		NumberofPRMatch: 4,
 		SHA:             "",
 	}
-	twait.Succeeded(ctx, t, runcnx, opts, sopt)
-	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+	twait.Succeeded(ctx, t, topts.ParamsRun, topts.Opts, sopt)
+	prsNew, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prsNew.Items) == 4)
 
@@ -105,18 +75,18 @@ func TestGitlabMergeRequest(t *testing.T) {
 	}
 
 	// Get the MR to fetch the SHA
-	mr, _, err := glprovider.Client().MergeRequests.GetMergeRequest(opts.ProjectID, int64(mrID), nil)
+	mr, _, err := topts.GLProvider.Client().MergeRequests.GetMergeRequest(topts.ProjectID, int64(topts.MRNumber), nil)
 	assert.NilError(t, err)
 
 	// Check GitLab pipelines via API - should have 1 pipeline from normal MR processing
-	pipelines, _, err := glprovider.Client().Pipelines.ListProjectPipelines(opts.ProjectID, &clientGitlab.ListProjectPipelinesOptions{
+	pipelines, _, err := topts.GLProvider.Client().Pipelines.ListProjectPipelines(topts.ProjectID, &clientGitlab.ListProjectPipelinesOptions{
 		SHA: &mr.SHA,
 	})
 	assert.NilError(t, err)
 	assert.Assert(t, len(pipelines) == 1, "Expected 1 GitLab pipeline from normal MR processing, got %d", len(pipelines))
 
-	runcnx.Clients.Log.Infof("Sending /test comment on MergeRequest %s/-/merge_requests/%d", projectinfo.WebURL, mrID)
-	_, _, err = glprovider.Client().Notes.CreateMergeRequestNote(opts.ProjectID, int64(mrID), &clientGitlab.CreateMergeRequestNoteOptions{
+	topts.ParamsRun.Clients.Log.Infof("Sending /test comment on MergeRequest %s/-/merge_requests/%d", topts.GitHTMLURL, topts.MRNumber)
+	_, _, err = topts.GLProvider.Client().Notes.CreateMergeRequestNote(topts.ProjectID, int64(topts.MRNumber), &clientGitlab.CreateMergeRequestNoteOptions{
 		Body: clientGitlab.Ptr("/test"),
 	})
 	assert.NilError(t, err)
@@ -124,78 +94,44 @@ func TestGitlabMergeRequest(t *testing.T) {
 	sopt = twait.SuccessOpt{
 		Title:           commitTitle,
 		OnEvent:         opscomments.TestAllCommentEventType.String(),
-		TargetNS:        targetNS,
+		TargetNS:        topts.TargetNS,
 		NumberofPRMatch: 5, // this is the max we get in repos status
 		SHA:             mr.SHA,
 	}
-	twait.Succeeded(ctx, t, runcnx, opts, sopt)
+	twait.Succeeded(ctx, t, topts.ParamsRun, topts.Opts, sopt)
 }
 
 func TestGitlabOnLabel(t *testing.T) {
 	prName := "on-label"
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing with Gitlab")
-
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			fmt.Sprintf(".tekton/%s.yaml", prName): "testdata/pipelinerun-on-label.yaml",
+		},
 	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
-
-	entries, err := payload.GetEntries(map[string]string{
-		fmt.Sprintf(".tekton/%s.yaml", prName): "testdata/pipelinerun-on-label.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
-		triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
-	commitTitle := "Committing files from test on " + targetRefName
-	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		CommitTitle:   commitTitle,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
-	}
-	scm.PushFilesToRefGit(t, scmOpts, entries)
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetRefName)
-
-	mrTitle := "TestMergeRequest - " + targetRefName
-	mrID, err := tgitlab.CreateMR(glprovider.Client(), opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, int(int64(mrID)), targetRefName, targetNS, opts.ProjectID)
-
-	runcnx.Clients.Log.Infof("waiting 5 seconds until we make sure nothing happened")
+	topts.ParamsRun.Clients.Log.Infof("waiting 5 seconds until we make sure nothing happened")
 	time.Sleep(5 * time.Second)
-	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+	prsNew, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prsNew.Items) == 0)
 
 	// now add a Label
-	mr, _, err := glprovider.Client().MergeRequests.UpdateMergeRequest(opts.ProjectID, int64(mrID), &clientGitlab.UpdateMergeRequestOptions{
+	mr, _, err := topts.GLProvider.Client().MergeRequests.UpdateMergeRequest(topts.ProjectID, int64(topts.MRNumber), &clientGitlab.UpdateMergeRequestOptions{
 		Labels: &clientGitlab.LabelOptions{"bug"},
 	})
 	assert.NilError(t, err)
 
 	waitOpts := twait.Opts{
-		RepoName:        targetNS,
-		Namespace:       targetNS,
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       mr.SHA,
 	}
-	repo, err := twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	repo, err := twait.UntilRepositoryUpdated(ctx, topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 	assert.Assert(t, len(repo.Status) > 0)
 	assert.Equal(t, *repo.Status[0].EventType, triggertype.PullRequestLabeled.String())
@@ -203,237 +139,138 @@ func TestGitlabOnLabel(t *testing.T) {
 
 func TestGitlabOnComment(t *testing.T) {
 	triggerComment := "/hello-world"
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing Gitlab on Comment matches")
-
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/pipelinerun.yaml": "testdata/pipelinerun-on-comment-annotation.yaml",
+		},
 	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
-
-	entries, err := payload.GetEntries(map[string]string{
-		".tekton/pipelinerun.yaml": "testdata/pipelinerun-on-comment-annotation.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
-		triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-
-	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
-	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
-	}
-	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetRefName)
-	mrTitle := "TestMergeRequest - " + targetRefName
-	mrID, err := tgitlab.CreateMR(glprovider.Client(), opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, int(int64(mrID)), targetRefName, targetNS, opts.ProjectID)
-
-	note, _, err := glprovider.Client().Notes.CreateMergeRequestNote(opts.ProjectID, int64(mrID), &clientGitlab.CreateMergeRequestNoteOptions{
+	note, _, err := topts.GLProvider.Client().Notes.CreateMergeRequestNote(topts.ProjectID, int64(topts.MRNumber), &clientGitlab.CreateMergeRequestNoteOptions{
 		Body: github.Ptr(triggerComment),
 	})
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Note %s/-/merge_requests/%d/notes/%d has been created", projectinfo.WebURL, int64(mrID), note.ID)
+	topts.ParamsRun.Clients.Log.Infof("Note %s/-/merge_requests/%d/notes/%d has been created", topts.GitHTMLURL, int64(topts.MRNumber), note.ID)
 
 	sopt := twait.SuccessOpt{
 		OnEvent:         opscomments.OnCommentEventType.String(),
-		TargetNS:        targetNS,
+		TargetNS:        topts.TargetNS,
 		NumberofPRMatch: 1,
-		Title:           "Committing files from test on " + targetRefName,
+		Title:           "Committing files from test on " + topts.TargetRefName,
 	}
-	twait.Succeeded(ctx, t, runcnx, opts, sopt)
+	twait.Succeeded(ctx, t, topts.ParamsRun, topts.Opts, sopt)
 
 	// get pull request info
-	mr, _, err := glprovider.Client().MergeRequests.GetMergeRequest(opts.ProjectID, int64(mrID), nil)
+	mr, _, err := topts.GLProvider.Client().MergeRequests.GetMergeRequest(topts.ProjectID, int64(topts.MRNumber), nil)
 	assert.NilError(t, err)
 
 	waitOpts := twait.Opts{
-		RepoName:        targetNS,
-		Namespace:       targetNS,
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       mr.SHA,
 	}
-	repo, err := twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	repo, err := twait.UntilRepositoryUpdated(ctx, topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
+	topts.ParamsRun.Clients.Log.Infof("Check if we have the repository set as succeeded")
 	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
 	lastPrName := repo.Status[len(repo.Status)-1].PipelineRunName
 
-	err = twait.RegexpMatchingInPodLog(context.Background(), runcnx, targetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s", lastPrName), "step-task", *regexp.MustCompile(triggerComment), "", 2, nil)
+	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s", lastPrName), "step-task", *regexp.MustCompile(triggerComment), "", 2, nil)
 	assert.NilError(t, err)
 }
 
 func TestGitlabCancelInProgressOnChange(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing Gitlab cancel in progress on pr close")
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/in-progress.yaml": "testdata/pipelinerun-cancel-in-progress.yaml",
+		},
 	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
-
-	entries, err := payload.GetEntries(map[string]string{
-		".tekton/in-progress.yaml": "testdata/pipelinerun-cancel-in-progress.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
-		triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
-	mrTitle := "TestCancelInProgress initial commit - " + targetRefName
-	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
-		CommitTitle:   mrTitle,
-	}
-
-	oldSha := scm.PushFilesToRefGit(t, scmOpts, entries)
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetRefName)
-	mrID, err := tgitlab.CreateMR(glprovider.Client(), opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, int(int64(mrID)), targetRefName, targetNS, opts.ProjectID)
-
-	runcnx.Clients.Log.Infof("Waiting for the pipelinerun to be created")
+	topts.ParamsRun.Clients.Log.Infof("Waiting for the pipelinerun to be created")
 	originalPipelineWaitOpts := twait.Opts{
-		RepoName:        targetNS,
-		Namespace:       targetNS,
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
-		TargetSHA:       oldSha,
+		TargetSHA:       topts.SHA,
 	}
-	err = twait.UntilPipelineRunCreated(ctx, runcnx.Clients, originalPipelineWaitOpts)
+	err := twait.UntilPipelineRunCreated(ctx, topts.ParamsRun.Clients, originalPipelineWaitOpts)
 	assert.NilError(t, err)
 
 	newEntries := map[string]string{
 		"new-file.txt": "plz work",
 	}
 
-	changeTitle := "TestCancelInProgress second commit - " + targetRefName
-	scmOpts = &scm.Opts{
-		GitURL:        gitCloneURL,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   targetRefName,
+	changeTitle := "TestCancelInProgress second commit - " + topts.TargetRefName
+	scmOpts := &scm.Opts{
+		GitURL:        topts.GitCloneURL,
+		Log:           topts.ParamsRun.Clients.Log,
+		WebURL:        topts.GitHTMLURL,
+		TargetRefName: topts.TargetRefName,
+		BaseRefName:   topts.TargetRefName,
 		CommitTitle:   changeTitle,
 	}
 	newSha := scm.PushFilesToRefGit(t, scmOpts, newEntries)
 
-	runcnx.Clients.Log.Infof("Waiting for new pipeline to be created")
+	topts.ParamsRun.Clients.Log.Infof("Waiting for new pipeline to be created")
 	newPipelineWaitOpts := twait.Opts{
-		RepoName:        targetNS,
-		Namespace:       targetNS,
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       newSha,
 	}
-	err = twait.UntilPipelineRunCreated(ctx, runcnx.Clients, newPipelineWaitOpts)
+	err = twait.UntilPipelineRunCreated(ctx, topts.ParamsRun.Clients, newPipelineWaitOpts)
 	assert.NilError(t, err)
 
-	runcnx.Clients.Log.Infof("Waiting for old pipelinerun to be cancelled")
-	cancelledErr := twait.UntilPipelineRunHasReason(ctx, runcnx.Clients, v1.PipelineRunReasonCancelled, originalPipelineWaitOpts)
+	topts.ParamsRun.Clients.Log.Infof("Waiting for old pipelinerun to be cancelled")
+	cancelledErr := twait.UntilPipelineRunHasReason(ctx, topts.ParamsRun.Clients, v1.PipelineRunReasonCancelled, originalPipelineWaitOpts)
 	assert.NilError(t, cancelledErr)
 }
 
 func TestGitlabCancelInProgressOnPRClose(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing Gitlab cancel in progress on pr close")
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/in-progress.yaml": "testdata/pipelinerun-cancel-in-progress.yaml",
+		},
 	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
-
-	entries, err := payload.GetEntries(map[string]string{
-		".tekton/in-progress.yaml": "testdata/pipelinerun-cancel-in-progress.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
-		triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
-	mrTitle := "TestCancelInProgress - " + targetRefName
-	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
-		CommitTitle:   mrTitle,
-	}
-
-	sha := scm.PushFilesToRefGit(t, scmOpts, entries)
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetRefName)
-	mrID, err := tgitlab.CreateMR(glprovider.Client(), opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, int(int64(mrID)), targetRefName, targetNS, opts.ProjectID)
-
-	runcnx.Clients.Log.Infof("Waiting for the two pipelinerun to be created")
+	topts.ParamsRun.Clients.Log.Infof("Waiting for the pipelinerun to be created")
 	waitOpts := twait.Opts{
-		RepoName:        targetNS,
-		Namespace:       targetNS,
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
-		TargetSHA:       sha,
+		TargetSHA:       topts.SHA,
 	}
-	err = twait.UntilPipelineRunCreated(ctx, runcnx.Clients, waitOpts)
+	err := twait.UntilPipelineRunCreated(ctx, topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
-	_, _, err = glprovider.Client().MergeRequests.UpdateMergeRequest(opts.ProjectID, int64(mrID), &clientGitlab.UpdateMergeRequestOptions{
+	_, _, err = topts.GLProvider.Client().MergeRequests.UpdateMergeRequest(topts.ProjectID, int64(topts.MRNumber), &clientGitlab.UpdateMergeRequestOptions{
 		StateEvent: clientGitlab.Ptr("close"),
 	})
 	assert.NilError(t, err)
 
-	err = twait.UntilPipelineRunHasReason(ctx, runcnx.Clients, v1.PipelineRunReasonCancelled, waitOpts)
+	err = twait.UntilPipelineRunHasReason(ctx, topts.ParamsRun.Clients, v1.PipelineRunReasonCancelled, waitOpts)
 	assert.NilError(t, err)
 
-	prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(context.Background(), metav1.ListOptions{})
+	prs, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(context.Background(), metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(prs.Items), 1, "should have only one pipelinerun, but we have: %d", len(prs.Items))
 	assert.Equal(t, prs.Items[0].GetStatusCondition().GetCondition(apis.ConditionSucceeded).GetReason(), "Cancelled", "should have been cancelled")
 
 	// failing on `true` condition because for cancelled PipelineRun we want `false` condition.
 	waitOpts.FailOnRepoCondition = corev1.ConditionTrue
-	repo, err := twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	repo, err := twait.UntilRepositoryUpdated(ctx, topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 
 	laststatus := repo.Status[len(repo.Status)-1]
@@ -441,176 +278,101 @@ func TestGitlabCancelInProgressOnPRClose(t *testing.T) {
 }
 
 func TestGitlabIssueGitopsComment(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing Gitlabs test/retest comments")
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/no-match.yaml": "testdata/pipelinerun-nomatch.yaml",
+		},
 	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
-
-	entries, err := payload.GetEntries(map[string]string{
-		".tekton/no-match.yaml": "testdata/pipelinerun-nomatch.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
-		triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-
-	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
-	mrTitle := "TestMergeRequest - " + targetRefName
-	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
-		CommitTitle:   mrTitle,
-	}
-	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetRefName)
-	mrID, err := tgitlab.CreateMR(glprovider.Client(), opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, int(int64(mrID)), targetRefName, targetNS, opts.ProjectID)
-
-	_, _, err = glprovider.Client().Notes.CreateMergeRequestNote(opts.ProjectID, int64(mrID), &clientGitlab.CreateMergeRequestNoteOptions{
+	_, _, err := topts.GLProvider.Client().Notes.CreateMergeRequestNote(topts.ProjectID, int64(topts.MRNumber), &clientGitlab.CreateMergeRequestNoteOptions{
 		Body: clientGitlab.Ptr("/test no-match"),
 	})
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Created gitops comment /test no-match to get the no-match tested")
+	topts.ParamsRun.Clients.Log.Infof("Created gitops comment /test no-match to get the no-match tested")
 
+	commitTitle := "Committing files from test on " + topts.TargetRefName
 	sopt := twait.SuccessOpt{
-		Title:           mrTitle,
+		Title:           commitTitle,
 		OnEvent:         opscomments.TestSingleCommentEventType.String(),
-		TargetNS:        targetNS,
+		TargetNS:        topts.TargetNS,
 		NumberofPRMatch: 1,
 	}
-	twait.Succeeded(ctx, t, runcnx, opts, sopt)
+	twait.Succeeded(ctx, t, topts.ParamsRun, topts.Opts, sopt)
 }
 
 func TestGitlabDisableCommentsOnMRNotCreated(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing with Gitlab")
-
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Fatalf("Repository %s not found in %s", opts.Organization, opts.Repo) // Use Fatalf to stop test on critical error
-	}
-
-	settings := v1alpha1.Settings{
-		Gitlab: &v1alpha1.GitlabSettings{
-			CommentStrategy: "disable_all",
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		Settings: &v1alpha1.Settings{
+			Gitlab: &v1alpha1.GitlabSettings{
+				CommentStrategy: "disable_all",
+			},
+		},
+		YAMLFiles: map[string]string{
+			".tekton/pipelinerun.yaml": "testdata/pipelinerun.yaml",
 		},
 	}
-	opts.Settings = settings
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
-	entries, err := payload.GetEntries(map[string]string{
-		".tekton/pipelinerun.yaml": "testdata/pipelinerun.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
-		triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-
-	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
-	commitTitle := "Committing files from test on " + targetRefName
-	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		CommitTitle:   commitTitle,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
-	}
-	// NEW: Capture the commit SHA returned by the push operation.
-	sha := scm.PushFilesToRefGit(t, scmOpts, entries)
-	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to branch %s", sha, targetRefName)
-
-	mrTitle := "TestMergeRequest - " + targetRefName
-	mrID, err := tgitlab.CreateMR(glprovider.Client(), opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, int(int64(mrID)), targetRefName, targetNS, opts.ProjectID)
-
+	commitTitle := "Committing files from test on " + topts.TargetRefName
 	sopt := twait.SuccessOpt{
 		Title:           commitTitle,
 		OnEvent:         "Merge Request",
-		TargetNS:        targetNS,
+		TargetNS:        topts.TargetNS,
 		NumberofPRMatch: 1,
-		SHA:             sha, // NEW: Pass the captured SHA to ensure we wait for the correct PipelineRun
+		SHA:             topts.SHA,
 	}
-	twait.Succeeded(ctx, t, runcnx, opts, sopt)
-	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+	twait.Succeeded(ctx, t, topts.ParamsRun, topts.Opts, sopt)
+	prsNew, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prsNew.Items) == 1)
 
-	runcnx.Clients.Log.Infof("Checking status of GitLab pipeline for commit: %s", sha)
-	// Define constants for polling
+	topts.ParamsRun.Clients.Log.Infof("Checking status of GitLab pipeline for commit: %s", topts.SHA)
 	const pipelineCheckTimeout = 5 * time.Minute
 	const pipelineCheckInterval = 10 * time.Second
 
 	var pipeline *clientGitlab.Pipeline
-	// Use a polling mechanism to wait for the pipeline to succeed.
 	err = wait.PollUntilContextTimeout(ctx, pipelineCheckInterval, pipelineCheckTimeout, true, func(_ context.Context) (bool, error) {
-		// Find the pipeline associated with our specific commit SHA
-		pipelines, _, listErr := glprovider.Client().Pipelines.ListProjectPipelines(opts.ProjectID, &clientGitlab.ListProjectPipelinesOptions{
-			SHA: &sha,
+		pipelines, _, listErr := topts.GLProvider.Client().Pipelines.ListProjectPipelines(topts.ProjectID, &clientGitlab.ListProjectPipelinesOptions{
+			SHA: &topts.SHA,
 		})
 		if listErr != nil {
-			return false, listErr // Propagate API errors
+			return false, listErr
 		}
 		if len(pipelines) == 0 {
-			runcnx.Clients.Log.Info("Waiting for pipeline to be created...")
-			return false, nil // Pipeline not found yet, continue polling
+			topts.ParamsRun.Clients.Log.Info("Waiting for pipeline to be created...")
+			return false, nil
 		}
 		if len(pipelines) > 1 {
-			// This is unexpected, fail fast
-			return false, fmt.Errorf("expected 1 pipeline for SHA %s, but found %d", sha, len(pipelines))
+			return false, fmt.Errorf("expected 1 pipeline for SHA %s, but found %d", topts.SHA, len(pipelines))
 		}
 
-		// Get the latest status of our specific pipeline
-		p, _, getErr := glprovider.Client().Pipelines.GetPipeline(opts.ProjectID, pipelines[0].ID)
+		p, _, getErr := topts.GLProvider.Client().Pipelines.GetPipeline(topts.ProjectID, pipelines[0].ID)
 		if getErr != nil {
 			return false, getErr
 		}
 
-		runcnx.Clients.Log.Infof("Current pipeline status: %s", p.Status)
+		topts.ParamsRun.Clients.Log.Infof("Current pipeline status: %s", p.Status)
 		switch p.Status {
 		case "success":
 			pipeline = p
-			return true, nil // Success! Stop polling.
+			return true, nil
 		case "failed", "canceled", "skipped": //nolint:misspell
-			// The pipeline has finished but not successfully.
 			return false, fmt.Errorf("pipeline finished with non-success status: %s", p.Status)
 		default:
-			// The pipeline is still running or pending, continue polling.
 			return false, nil
 		}
 	})
 	assert.NilError(t, err, "failed while waiting for GitLab pipeline to succeed")
 	assert.Equal(t, "success", pipeline.Status, "The final pipeline status was not 'success'")
-	runcnx.Clients.Log.Infof("✅ GitLab pipeline ID %d has succeeded!", pipeline.ID)
+	topts.ParamsRun.Clients.Log.Infof("GitLab pipeline ID %d has succeeded!", pipeline.ID)
 
 	// No comments will be added related to pipelineruns info
-	notes, _, err := glprovider.Client().Notes.ListMergeRequestNotes(opts.ProjectID, int64(mrID), nil)
+	notes, _, err := topts.GLProvider.Client().Notes.ListMergeRequestNotes(topts.ProjectID, int64(topts.MRNumber), nil)
 
 	commentRegexp := regexp.MustCompile(`.*Pipelines as Code CI/*`)
 	assert.NilError(t, err)
@@ -626,73 +388,38 @@ func TestGitlabDisableCommentsOnMRNotCreated(t *testing.T) {
 }
 
 func TestGitlabMergeRequestOnUpdateAtAndLabelChange(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing with Gitlab")
-
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/pipelinerun.yaml":       "testdata/pipelinerun.yaml",
+			".tekton/pipelinerun-clone.yaml": "testdata/pipelinerun-clone.yaml",
+		},
 	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
-
-	entries, err := payload.GetEntries(map[string]string{
-		".tekton/pipelinerun.yaml":       "testdata/pipelinerun.yaml",
-		".tekton/pipelinerun-clone.yaml": "testdata/pipelinerun-clone.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
-		triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-
-	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
-	commitTitle := "Committing files from test on " + targetRefName
-	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		CommitTitle:   commitTitle,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
-	}
-	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetRefName)
-	mrTitle := "TestMergeRequest - " + targetRefName
-	mrID, err := tgitlab.CreateMR(glprovider.Client(), opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, int(int64(mrID)), targetRefName, targetNS, opts.ProjectID)
-
+	commitTitle := "Committing files from test on " + topts.TargetRefName
 	sopt := twait.SuccessOpt{
 		Title:           commitTitle,
 		OnEvent:         "Merge Request",
-		TargetNS:        targetNS,
+		TargetNS:        topts.TargetNS,
 		NumberofPRMatch: 2,
 		SHA:             "",
 	}
-	twait.Succeeded(ctx, t, runcnx, opts, sopt)
-	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+	twait.Succeeded(ctx, t, topts.ParamsRun, topts.Opts, sopt)
+	prsNew, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prsNew.Items) == 2)
 
-	runcnx.Clients.Log.Infof("Changing Title on MergeRequest %s/-/merge_requests/%d", projectinfo.WebURL, mrID)
-	_, _, err = glprovider.Client().MergeRequests.UpdateMergeRequest(opts.ProjectID, int64(mrID), &clientGitlab.UpdateMergeRequestOptions{
+	topts.ParamsRun.Clients.Log.Infof("Changing Title on MergeRequest %s/-/merge_requests/%d", topts.GitHTMLURL, topts.MRNumber)
+	_, _, err = topts.GLProvider.Client().MergeRequests.UpdateMergeRequest(topts.ProjectID, int64(topts.MRNumber), &clientGitlab.UpdateMergeRequestOptions{
 		Title: clientGitlab.Ptr("test"),
 	})
 	assert.NilError(t, err)
 
 	// let's wait 10 secs and check every second that a PipelineRun is created or not.
 	for i := 0; i < 10; i++ {
-		prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+		prs, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
 		assert.NilError(t, err)
 		assert.Assert(t, len(prs.Items) == 2)
 		time.Sleep(1 * time.Second)
@@ -700,102 +427,93 @@ func TestGitlabMergeRequestOnUpdateAtAndLabelChange(t *testing.T) {
 }
 
 func TestGitlabMergeRequestValidationErrorsFromFork(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing GitLab validation error commenting from fork scenario")
-
-	// Get the original project onboarded to PaC
-	originalProject, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %d not found", opts.ProjectID)
+	topts := &tgitlab.TestOpts{
+		NoMRCreation: true,
 	}
+	_, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
-	err = tgitlab.CreateCRD(ctx, originalProject, runcnx, opts, targetNS, nil)
+	topts.ParamsRun.Clients.Log.Info("Testing GitLab validation error commenting from fork scenario")
+
+	// Fork the project
+	forkProject, _, err := topts.GLProvider.Client().Projects.ForkProject(topts.ProjectID, &clientGitlab.ForkProjectOptions{})
 	assert.NilError(t, err)
+	topts.ParamsRun.Clients.Log.Infof("Forked project %s (ID: %d) from original project (ID: %d)",
+		forkProject.PathWithNamespace, forkProject.ID, topts.ProjectID)
 
-	// Get an existing fork of the original project
-	projectForks, _, err := glprovider.Client().Projects.ListProjectForks(opts.ProjectID, &clientGitlab.ListProjectsOptions{})
-	assert.NilError(t, err)
+	// Schedule fork project deletion
+	defer func() {
+		topts.ParamsRun.Clients.Log.Infof("Deleting fork project %d", forkProject.ID)
+		_, err := topts.GLProvider.Client().Projects.DeleteProject(forkProject.ID, nil)
+		if err != nil {
+			t.Logf("Error deleting fork project %d: %v", forkProject.ID, err)
+		}
+	}()
 
-	if len(projectForks) == 0 {
-		t.Fatal("No forks available for testing fork scenario. This test requires at least one fork of the project.")
-	}
-
-	forkProject := projectForks[0] // Use the first available fork
-	runcnx.Clients.Log.Infof("Using existing fork project: %s (ID: %d) from original: %s (ID: %d)",
-		forkProject.PathWithNamespace, forkProject.ID, originalProject.PathWithNamespace, originalProject.ID)
+	// Wait for fork to be ready
+	time.Sleep(5 * time.Second)
 
 	// Commit invalid .tekton files to the fork
 	entries, err := payload.GetEntries(map[string]string{
 		".tekton/bad-yaml.yaml": "testdata/failures/bad-yaml.yaml",
-	}, targetNS, originalProject.DefaultBranch,
+	}, topts.TargetNS, topts.DefaultBranch,
 		triggertype.PullRequest.String(), map[string]string{})
 	assert.NilError(t, err)
 
 	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-fork-test")
-	forkCloneURL, err := scm.MakeGitCloneURL(forkProject.WebURL, opts.UserName, opts.Password)
+	forkCloneURL, err := scm.MakeGitCloneURL(forkProject.WebURL, topts.Opts.UserName, topts.Opts.Password)
 	assert.NilError(t, err)
 
 	commitTitle := "Add invalid .tekton file from fork - " + targetRefName
 	scmOpts := &scm.Opts{
 		GitURL:        forkCloneURL,
 		CommitTitle:   commitTitle,
-		Log:           runcnx.Clients.Log,
+		Log:           topts.ParamsRun.Clients.Log,
 		WebURL:        forkProject.WebURL,
 		TargetRefName: targetRefName,
-		BaseRefName:   originalProject.DefaultBranch,
+		BaseRefName:   topts.DefaultBranch,
 	}
 	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-	runcnx.Clients.Log.Infof("Pushed invalid .tekton files to fork branch: %s", targetRefName)
+	topts.ParamsRun.Clients.Log.Infof("Pushed invalid .tekton files to fork branch: %s", targetRefName)
 
 	// Create merge request from fork to original project
 	mrTitle := "TestValidationErrorsFromFork - " + targetRefName
 	mrOptions := &clientGitlab.CreateMergeRequestOptions{
-		Title:        &mrTitle,
-		SourceBranch: &targetRefName,
-		TargetBranch: &originalProject.DefaultBranch,
-		// Create MR on the target project (original), not the source (fork)
-		TargetProjectID: &originalProject.ID,
+		Title:           &mrTitle,
+		SourceBranch:    &targetRefName,
+		TargetBranch:    &topts.DefaultBranch,
+		TargetProjectID: &topts.ProjectInfo.ID,
 	}
 
-	mr, _, err := glprovider.Client().MergeRequests.CreateMergeRequest(forkProject.ID, mrOptions)
+	mr, _, err := topts.GLProvider.Client().MergeRequests.CreateMergeRequest(forkProject.ID, mrOptions)
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Created merge request from fork to original: %s/-/merge_requests/%d",
-		originalProject.WebURL, mr.IID)
+	topts.ParamsRun.Clients.Log.Infof("Created merge request from fork to original: %s/-/merge_requests/%d",
+		topts.GitHTMLURL, mr.IID)
 
 	defer func() {
-		// Clean up MR and namespace using TearDown
-		tgitlab.TearDown(ctx, t, runcnx, glprovider, int(mr.IID), "", targetNS, int(originalProject.ID))
-
-		runcnx.Clients.Log.Infof("Deleting branch %s from fork project", targetRefName)
-		_, err := glprovider.Client().Branches.DeleteBranch(forkProject.ID, targetRefName)
+		// Close MR on original project
+		_, _, err := topts.GLProvider.Client().MergeRequests.UpdateMergeRequest(topts.ProjectID, mr.IID,
+			&clientGitlab.UpdateMergeRequestOptions{StateEvent: clientGitlab.Ptr("close")})
 		if err != nil {
-			runcnx.Clients.Log.Warnf("Failed to delete branch from fork: %v", err)
+			t.Logf("Error closing MR %d: %v", mr.IID, err)
 		}
 	}()
 
-	runcnx.Clients.Log.Info("Waiting for webhook validation to process MR and post validation comment...")
+	topts.ParamsRun.Clients.Log.Info("Waiting for webhook validation to process MR and post validation comment...")
 
-	maxLoop := 12 // Wait up to 72 seconds for webhook processing
+	maxLoop := 12
 	foundValidationComment := false
 
 	for i := 0; i < maxLoop; i++ {
-		notes, _, err := glprovider.Client().Notes.ListMergeRequestNotes(originalProject.ID, mr.IID, nil)
+		notes, _, err := topts.GLProvider.Client().Notes.ListMergeRequestNotes(topts.ProjectID, mr.IID, nil)
 		assert.NilError(t, err)
 
 		for _, note := range notes {
-			// Look for the validation error comment that PaC should post via webhook
 			if regexp.MustCompile(`.*There are some errors in your PipelineRun template.*`).MatchString(note.Body) &&
 				regexp.MustCompile(`.*bad-yaml\.yaml.*yaml validation error.*`).MatchString(note.Body) {
-				runcnx.Clients.Log.Info("Found validation error comment on original project's MR!")
+				topts.ParamsRun.Clients.Log.Info("Found validation error comment on original project's MR!")
 				foundValidationComment = true
 
-				// Verify the comment format matches PaC's validation error format
 				assert.Assert(t, regexp.MustCompile(`\[!CAUTION\]`).MatchString(note.Body), "Comment should contain caution header")
 				break
 			}
@@ -805,7 +523,7 @@ func TestGitlabMergeRequestValidationErrorsFromFork(t *testing.T) {
 			break
 		}
 
-		runcnx.Clients.Log.Infof("Loop %d/%d: Waiting for webhook validation to post comment (testing TargetProjectID fix)", i+1, maxLoop)
+		topts.ParamsRun.Clients.Log.Infof("Loop %d/%d: Waiting for webhook validation to post comment (testing TargetProjectID fix)", i+1, maxLoop)
 		time.Sleep(6 * time.Second)
 	}
 
@@ -813,80 +531,41 @@ func TestGitlabMergeRequestValidationErrorsFromFork(t *testing.T) {
 }
 
 func TestGitlabConsistentCommitStatusOnMR(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing GitLab consistent commit status on Merge Request scenario")
-
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %d not found", opts.ProjectID)
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/bad-pipelinerun.yaml":         "testdata/failures/bad-pipelinerun.yaml",
+			".tekton/always-good-pipelinerun.yaml": "testdata/always-good-pipelinerun.yaml",
+		},
 	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
+	commitTitle := "Committing files from test on " + topts.TargetRefName
+
+	// Get MR for SHA
+	mr, _, err := topts.GLProvider.Client().MergeRequests.GetMergeRequest(topts.ProjectID, int64(topts.MRNumber), nil)
 	assert.NilError(t, err)
-
-	entries, err := payload.GetEntries(map[string]string{
-		".tekton/bad-pipelinerun.yaml":         "testdata/failures/bad-pipelinerun.yaml",
-		".tekton/always-good-pipelinerun.yaml": "testdata/always-good-pipelinerun.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
-		triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-
-	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-	cloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
-
-	commitTitle := "Add invalid .tekton file - " + targetRefName
-	scmOpts := &scm.Opts{
-		GitURL:        cloneURL,
-		CommitTitle:   commitTitle,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
-	}
-	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-	runcnx.Clients.Log.Infof("Pushed invalid .tekton files to branch: %s", targetRefName)
-
-	mrTitle := "TestConsistentCommitStatusOnMR - " + targetRefName
-	mrOptions := &clientGitlab.CreateMergeRequestOptions{
-		Title:        &mrTitle,
-		SourceBranch: &targetRefName,
-		TargetBranch: &projectinfo.DefaultBranch,
-	}
-
-	mr, _, err := glprovider.Client().MergeRequests.CreateMergeRequest(projectinfo.ID, mrOptions)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Created merge request: %s", mr.WebURL)
-
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, int(mr.IID), targetRefName, targetNS, int(projectinfo.ID))
 
 	sopt := twait.SuccessOpt{
 		Title:           commitTitle,
 		OnEvent:         "Merge Request",
-		TargetNS:        targetNS,
-		NumberofPRMatch: 1, // there must be one PipelineRun because one is invalid
+		TargetNS:        topts.TargetNS,
+		NumberofPRMatch: 1,
 		SHA:             mr.SHA,
 	}
-	twait.Succeeded(ctx, t, runcnx, opts, sopt)
+	twait.Succeeded(ctx, t, topts.ParamsRun, topts.Opts, sopt)
 	labelSelector := fmt.Sprintf("%s=%s", keys.SHA, formatting.CleanValueKubernetes(mr.SHA))
-	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{
+	prsNew, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prsNew.Items) == 1)
 
-	commitStatuses, _, err := glprovider.Client().Commits.GetCommitStatuses(projectinfo.ID, mr.SHA, &clientGitlab.GetCommitStatusesOptions{})
+	commitStatuses, _, err := topts.GLProvider.Client().Commits.GetCommitStatuses(topts.ProjectID, mr.SHA, &clientGitlab.GetCommitStatusesOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(commitStatuses) == 2)
 
-	// here we don't know which status is returned first from  GitLab API
-	// so we need to check both by their names
 	for _, cs := range commitStatuses {
 		switch cs.Name {
 		case "Pipelines as Code CI / bad-converts-good-pipelinerun":
@@ -898,47 +577,46 @@ func TestGitlabConsistentCommitStatusOnMR(t *testing.T) {
 		}
 	}
 
-	entries, err = payload.GetEntries(map[string]string{
+	entries, err := payload.GetEntries(map[string]string{
 		".tekton/bad-pipelinerun.yaml":         "testdata/bad-converts-good-pipelinerun.yaml",
 		".tekton/always-good-pipelinerun.yaml": "testdata/always-good-pipelinerun.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
+	}, topts.TargetNS, topts.DefaultBranch,
 		triggertype.PullRequest.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	commitTitle = "Add good .tekton file - " + targetRefName
-	scmOpts = &scm.Opts{
-		GitURL:        cloneURL,
+	commitTitle = "Add good .tekton file - " + topts.TargetRefName
+	scmOpts := &scm.Opts{
+		GitURL:        topts.GitCloneURL,
 		CommitTitle:   commitTitle,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
+		Log:           topts.ParamsRun.Clients.Log,
+		WebURL:        topts.GitHTMLURL,
+		TargetRefName: topts.TargetRefName,
+		BaseRefName:   topts.DefaultBranch,
 		PushForce:     true,
 	}
 	newSHA := scm.PushFilesToRefGit(t, scmOpts, entries)
-	runcnx.Clients.Log.Infof("Pushed good .tekton files to branch: %s", targetRefName)
+	topts.ParamsRun.Clients.Log.Infof("Pushed good .tekton files to branch: %s", topts.TargetRefName)
 
 	sopt = twait.SuccessOpt{
 		Title:           commitTitle,
 		OnEvent:         "Merge Request",
-		TargetNS:        targetNS,
+		TargetNS:        topts.TargetNS,
 		NumberofPRMatch: 2,
 		SHA:             newSHA,
 	}
 
-	twait.Succeeded(ctx, t, runcnx, opts, sopt)
+	twait.Succeeded(ctx, t, topts.ParamsRun, topts.Opts, sopt)
 	labelSelector = fmt.Sprintf("%s=%s", keys.SHA, formatting.CleanValueKubernetes(newSHA))
-	prsNew, err = runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{
+	prsNew, err = topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prsNew.Items) == 2)
 
-	commitStatuses, _, err = glprovider.Client().Commits.GetCommitStatuses(projectinfo.ID, newSHA, &clientGitlab.GetCommitStatusesOptions{})
+	commitStatuses, _, err = topts.GLProvider.Client().Commits.GetCommitStatuses(topts.ProjectID, newSHA, &clientGitlab.GetCommitStatusesOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(commitStatuses) == 2)
 
-	// now both should be success
 	for _, cs := range commitStatuses {
 		switch cs.Name {
 		case "Pipelines as Code CI / bad-converts-good-pipelinerun", "Pipelines as Code CI / always-good-pipelinerun":
@@ -950,79 +628,34 @@ func TestGitlabConsistentCommitStatusOnMR(t *testing.T) {
 }
 
 // TestGitlabMergeRequestCelPrefix tests the cel: prefix for arbitrary CEL expressions.
-// The cel: prefix allows evaluating full CEL expressions with access to body, headers, files, and pac namespaces.
 func TestGitlabMergeRequestCelPrefix(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing cel: prefix with GitLab")
-
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/pipelinerun.yaml": "testdata/pipelinerun-cel-prefix-gitlab.yaml",
+		},
 	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
-
-	entries, err := payload.GetEntries(map[string]string{
-		".tekton/pipelinerun.yaml": "testdata/pipelinerun-cel-prefix-gitlab.yaml",
-	}, targetNS, projectinfo.DefaultBranch,
-		triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-
-	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
-	commitTitle := "Testing cel: prefix on " + targetRefName
-	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		CommitTitle:   commitTitle,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
-	}
-	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with cel: prefix test files", targetRefName)
-	mrTitle := "TestCelPrefix - " + targetRefName
-	mrID, err := tgitlab.CreateMR(glprovider.Client(), opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, mrID, targetRefName, targetNS, opts.ProjectID)
-
+	commitTitle := "Committing files from test on " + topts.TargetRefName
 	sopt := twait.SuccessOpt{
 		Title:           commitTitle,
 		OnEvent:         "Merge Request",
-		TargetNS:        targetNS,
+		TargetNS:        topts.TargetNS,
 		NumberofPRMatch: 1,
 		SHA:             "",
 	}
-	twait.Succeeded(ctx, t, runcnx, opts, sopt)
+	twait.Succeeded(ctx, t, topts.ParamsRun, topts.Opts, sopt)
 
-	prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+	prs, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prs.Items) >= 1, "Expected at least one PipelineRun, got %d", len(prs.Items))
 
-	// Verify cel: prefix expressions evaluated correctly using golden file
-	// Expected output:
-	// cel_ternary: new-mr (body.object_attributes.action == "open" for a new MR)
-	// cel_pac_branch: matched (pac.target_branch matches the target branch)
-	// cel_has_function: has-mr (body.object_attributes exists)
-	// cel_string_concat: Build on <target_branch>
-	// cel_files_check: has-files (files.all.size() > 0 since we have changed files)
-	// cel_gitlab_header: Merge Request Hook (X-Gitlab-Event header value)
-	// cel_error_handling: (empty string - cel: prefix returns empty on error)
 	err = twait.RegexpMatchingInPodLog(
 		ctx,
-		runcnx,
-		targetNS,
+		topts.ParamsRun,
+		topts.TargetNS,
 		fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=cel-prefix-test", prs.Items[0].Name),
 		"step-test-cel-prefix-values",
 		regexp.Regexp{},
@@ -1033,81 +666,65 @@ func TestGitlabMergeRequestCelPrefix(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-// TestGitlabMergeRequestVariableSubs tests variable substitution in PipelineRun annotations
-// by pushing a PipelineRun file to a branch, making a comment on the commit, and verifying
-// that the PipelineRun logs contain the commit message.
+// TestGitlabMergeRequestVariableSubs tests variable substitution in PipelineRun annotations.
 func TestGitlabMergeRequestVariableSubs(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing variable substitution with GitLab")
-
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		NoMRCreation: true,
 	}
-
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
 	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
 
 	entries, err := payload.GetEntries(map[string]string{
 		".tekton/pipelinerun-variable-subs.yaml": "testdata/pipelinerun-variable-subs.yaml",
-	}, targetNS, targetRefName,
+	}, topts.TargetNS, targetRefName,
 		triggertype.Push.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
 	commitTitle := "Testing variable substitution on " + targetRefName
 	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
+		GitURL:        topts.GitCloneURL,
 		CommitTitle:   commitTitle,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
+		Log:           topts.ParamsRun.Clients.Log,
+		WebURL:        topts.GitHTMLURL,
 		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
+		BaseRefName:   topts.DefaultBranch,
 	}
 	sha := scm.PushFilesToRefGit(t, scmOpts, entries)
 
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files, commit SHA: %s", targetRefName, sha)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, targetRefName, targetNS, opts.ProjectID)
+	topts.ParamsRun.Clients.Log.Infof("Branch %s has been created and pushed with files, commit SHA: %s", targetRefName, sha)
 
 	// Make a comment on the commit
-	runcnx.Clients.Log.Infof("Creating comment /test pipelinerun-variable-subs on commit %s", sha)
+	topts.ParamsRun.Clients.Log.Infof("Creating comment /test pipelinerun-variable-subs on commit %s", sha)
 	commentOpts := &clientGitlab.PostCommitCommentOptions{
 		Note: clientGitlab.Ptr(fmt.Sprintf("/test pipelinerun-variable-subs branch:%s", targetRefName)),
 	}
-	cc, _, err := glprovider.Client().Commits.PostCommitComment(opts.ProjectID, sha, commentOpts)
+	cc, _, err := topts.GLProvider.Client().Commits.PostCommitComment(topts.ProjectID, sha, commentOpts)
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
+	topts.ParamsRun.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
 
 	// Wait for PipelineRun creation
 	waitOpts := twait.Opts{
-		RepoName:        targetNS,
-		Namespace:       targetNS,
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       sha,
 	}
-	err = twait.UntilPipelineRunHasReason(ctx, runcnx.Clients, v1.PipelineRunReasonSuccessful, waitOpts)
+	err = twait.UntilPipelineRunHasReason(ctx, topts.ParamsRun.Clients, v1.PipelineRunReasonSuccessful, waitOpts)
 	assert.NilError(t, err)
 
 	// Get the PipelineRun
-	prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+	prs, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prs.Items) >= 1, "Expected at least one PipelineRun, got %d", len(prs.Items))
 
 	// Check that PipelineRun logs contain the commit message
 	err = twait.RegexpMatchingInPodLog(
 		ctx,
-		runcnx,
-		targetNS,
+		topts.ParamsRun,
+		topts.TargetNS,
 		fmt.Sprintf("pipelinesascode.tekton.dev/event-type=%s",
 			opscomments.TestSingleCommentEventType.String()),
 		"step-task",

--- a/test/gitlab_oktotest_thread_reply_test.go
+++ b/test/gitlab_oktotest_thread_reply_test.go
@@ -3,16 +3,11 @@
 package test
 
 import (
-	"context"
-	"net/http"
 	"testing"
 
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
-	"github.com/tektoncd/pipeline/pkg/names"
 	clientGitlab "gitlab.com/gitlab-org/api/client-go"
 	"gotest.tools/v3/assert"
 )
@@ -20,75 +15,41 @@ import (
 // TestGitlabOpsCommentInThreadReply verifies that a /test command placed
 // in a reply within a discussion thread on a Merge Request is honored.
 func TestGitlabOpsCommentInThreadReply(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing GitLab /test <PipelineRunName> in thread replies")
-
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/pipelinerun.yaml": "testdata/pipelinerun.yaml",
+		},
 	}
-
-	// Create Repository CRD
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
-	assert.NilError(t, err)
-
-	// Create a basic PipelineRun
-	entries, err := payload.GetEntries(map[string]string{
-		".tekton/pipelinerun.yaml": "testdata/pipelinerun.yaml",
-	}, targetNS, projectinfo.DefaultBranch, "pull_request", map[string]string{})
-	assert.NilError(t, err)
-
-	// Create a branch with files and open a merge request
-	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
-	commitTitle := "Committing files from test on " + targetRefName
-	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		CommitTitle:   commitTitle,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetRefName,
-		BaseRefName:   projectinfo.DefaultBranch,
-	}
-	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-	mrTitle := "TestMergeRequest - " + targetRefName
-	mrID, err := tgitlab.CreateMR(glprovider.Client(), opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
-	assert.NilError(t, err)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, mrID, targetRefName, targetNS, opts.ProjectID)
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
 	// Create a discussion thread with an initial note
-	disc, _, err := glprovider.Client().Discussions.CreateMergeRequestDiscussion(opts.ProjectID, int64(mrID), &clientGitlab.CreateMergeRequestDiscussionOptions{
+	disc, _, err := topts.GLProvider.Client().Discussions.CreateMergeRequestDiscussion(topts.ProjectID, int64(topts.MRNumber), &clientGitlab.CreateMergeRequestDiscussionOptions{
 		Body: clientGitlab.Ptr("random initial note"),
 	})
 	assert.NilError(t, err)
 
-	// Wait for repository status to reflect a successful run triggered by the comment
+	// Wait for repository status to reflect a successful run triggered by the MR
 	waitOpts := twait.Opts{
-		RepoName:        targetNS,
-		Namespace:       targetNS,
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       "",
 	}
-	_, err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	_, err = twait.UntilRepositoryUpdated(ctx, topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 
-	runcnx.Clients.Log.Info("Updating discussion with /test comment in a reply thread")
+	topts.ParamsRun.Clients.Log.Info("Updating discussion with /test comment in a reply thread")
 	// Add a reply to the discussion containing /test
-	_, _, err = glprovider.Client().Discussions.AddMergeRequestDiscussionNote(opts.ProjectID, int64(mrID), disc.ID, &clientGitlab.AddMergeRequestDiscussionNoteOptions{
+	_, _, err = topts.GLProvider.Client().Discussions.AddMergeRequestDiscussionNote(topts.ProjectID, int64(topts.MRNumber), disc.ID, &clientGitlab.AddMergeRequestDiscussionNoteOptions{
 		Body: clientGitlab.Ptr("/test"),
 	})
 	assert.NilError(t, err)
 	waitOpts.MinNumberStatus = 2
-	_, err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	_, err = twait.UntilRepositoryUpdated(ctx, topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 
-	runcnx.Clients.Log.Info("Repository status updated after /test comment")
+	topts.ParamsRun.Clients.Log.Info("Repository status updated after /test comment")
 }

--- a/test/gitlab_push_gitops_command_test.go
+++ b/test/gitlab_push_gitops_command_test.go
@@ -3,255 +3,195 @@
 package test
 
 import (
-	"context"
-	"net/http"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
-
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	"github.com/tektoncd/pipeline/pkg/names"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGitlabGitOpsCommandTestOnPush(t *testing.T) {
-	targetNs := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing with Gitlab")
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		NoMRCreation: true,
 	}
-
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNs, nil)
-	assert.NilError(t, err)
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
 	entries, err := payload.GetEntries(map[string]string{
 		".tekton/pipelinerun-on-push.yaml": "testdata/pipelinerun-on-push.yaml",
-	}, targetNs, targetNs, triggertype.Push.String(), map[string]string{})
+	}, topts.TargetNS, topts.TargetNS, triggertype.Push.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	title := "Test GitOps Commands on Push - " + targetNs
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
+	title := "Test GitOps Commands on Push - " + topts.TargetNS
 	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetNs,
-		BaseRefName:   projectinfo.DefaultBranch,
+		GitURL:        topts.GitCloneURL,
+		Log:           topts.ParamsRun.Clients.Log,
+		WebURL:        topts.GitHTMLURL,
+		TargetRefName: topts.TargetNS,
+		BaseRefName:   topts.DefaultBranch,
 		CommitTitle:   title,
 	}
 	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetNs)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, targetNs, targetNs, opts.ProjectID)
+	topts.ParamsRun.Clients.Log.Infof("Branch %s has been created and pushed with files", topts.TargetNS)
 
-	branch, _, err := glprovider.Client().Branches.GetBranch(opts.ProjectID, targetNs)
+	branch, _, err := topts.GLProvider.Client().Branches.GetBranch(topts.ProjectID, topts.TargetNS)
 	assert.NilError(t, err)
 
 	waitOpts := wait.Opts{
-		RepoName:        targetNs,
-		Namespace:       targetNs,
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     wait.DefaultTimeout,
 		TargetSHA:       branch.Commit.ID,
 	}
 
-	err = wait.UntilPipelineRunCreated(ctx, runcnx.Clients, waitOpts)
+	err = wait.UntilPipelineRunCreated(ctx, topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 
 	commentOpts := &gitlab.PostCommitCommentOptions{
-		Note: gitlab.Ptr("/test branch:" + targetNs),
+		Note: gitlab.Ptr("/test branch:" + topts.TargetNS),
 	}
-	cc, _, err := glprovider.Client().Commits.PostCommitComment(opts.ProjectID, branch.Commit.ID, commentOpts)
+	cc, _, err := topts.GLProvider.Client().Commits.PostCommitComment(topts.ProjectID, branch.Commit.ID, commentOpts)
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
+	topts.ParamsRun.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
 
 	sopt := wait.SuccessOpt{
 		Title:           title,
 		OnEvent:         opscomments.TestSingleCommentEventType.String(),
-		TargetNS:        targetNs,
+		TargetNS:        topts.TargetNS,
 		NumberofPRMatch: 2,
 	}
-	wait.Succeeded(ctx, t, runcnx, opts, sopt)
-	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNs).List(ctx, metav1.ListOptions{})
+	wait.Succeeded(ctx, t, topts.ParamsRun, topts.Opts, sopt)
+	prsNew, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prsNew.Items) == 2)
 }
 
 func TestGitlabGitOpsCommandCancelOnPush(t *testing.T) {
-	targetNs := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing with Gitlab")
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		NoMRCreation: true,
 	}
-
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNs, nil)
-	assert.NilError(t, err)
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
 	entries, err := payload.GetEntries(map[string]string{
 		".tekton/pipelinerun-on-push.yaml": "testdata/pipelinerun-on-push.yaml",
-	}, targetNs, targetNs, triggertype.Push.String(), map[string]string{})
+	}, topts.TargetNS, topts.TargetNS, triggertype.Push.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	title := "Test GitOps Commands on Push - " + targetNs
-	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
-	assert.NilError(t, err)
+	title := "Test GitOps Commands on Push - " + topts.TargetNS
 	scmOpts := &scm.Opts{
-		GitURL:        gitCloneURL,
-		Log:           runcnx.Clients.Log,
-		WebURL:        projectinfo.WebURL,
-		TargetRefName: targetNs,
-		BaseRefName:   projectinfo.DefaultBranch,
+		GitURL:        topts.GitCloneURL,
+		Log:           topts.ParamsRun.Clients.Log,
+		WebURL:        topts.GitHTMLURL,
+		TargetRefName: topts.TargetNS,
+		BaseRefName:   topts.DefaultBranch,
 		CommitTitle:   title,
 	}
 	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetNs)
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, targetNs, targetNs, opts.ProjectID)
+	topts.ParamsRun.Clients.Log.Infof("Branch %s has been created and pushed with files", topts.TargetNS)
 
-	branch, _, err := glprovider.Client().Branches.GetBranch(opts.ProjectID, targetNs)
+	branch, _, err := topts.GLProvider.Client().Branches.GetBranch(topts.ProjectID, topts.TargetNS)
 	assert.NilError(t, err)
 
 	commentOpts := &gitlab.PostCommitCommentOptions{
-		Note: gitlab.Ptr("/test branch:" + targetNs),
+		Note: gitlab.Ptr("/test branch:" + topts.TargetNS),
 	}
-	cc, _, err := glprovider.Client().Commits.PostCommitComment(opts.ProjectID, branch.Commit.ID, commentOpts)
+	cc, _, err := topts.GLProvider.Client().Commits.PostCommitComment(topts.ProjectID, branch.Commit.ID, commentOpts)
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
+	topts.ParamsRun.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
 
 	numberOfStatus := 2
 	waitOpts := wait.Opts{
-		RepoName:        targetNs,
-		Namespace:       targetNs,
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
 		MinNumberStatus: numberOfStatus,
 		PollTimeout:     wait.DefaultTimeout,
 		TargetSHA:       branch.Commit.ID,
 	}
 
-	err = wait.UntilPipelineRunCreated(ctx, runcnx.Clients, waitOpts)
+	err = wait.UntilPipelineRunCreated(ctx, topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 
-	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNs).List(ctx, metav1.ListOptions{})
+	prsNew, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prsNew.Items) == numberOfStatus)
 
 	commentOpts = &gitlab.PostCommitCommentOptions{
-		Note: gitlab.Ptr("/cancel pipelinerun-on-push branch:" + targetNs),
+		Note: gitlab.Ptr("/cancel pipelinerun-on-push branch:" + topts.TargetNS),
 	}
-	cc, _, err = glprovider.Client().Commits.PostCommitComment(opts.ProjectID, branch.Commit.ID, commentOpts)
+	cc, _, err = topts.GLProvider.Client().Commits.PostCommitComment(topts.ProjectID, branch.Commit.ID, commentOpts)
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
+	topts.ParamsRun.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
 
-	err = wait.UntilPipelineRunHasReason(ctx, runcnx.Clients, v1.PipelineRunReasonCancelled, waitOpts)
+	err = wait.UntilPipelineRunHasReason(ctx, topts.ParamsRun.Clients, v1.PipelineRunReasonCancelled, waitOpts)
 	assert.NilError(t, err)
 }
 
 func TestGitlabGitOpsCommandTestOnTag(t *testing.T) {
-	targetNs := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	ctx := context.Background()
-	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
-	assert.NilError(t, err)
-	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
-	assert.NilError(t, err)
-	runcnx.Clients.Log.Info("Testing with Gitlab")
-	projectinfo, resp, err := glprovider.Client().Projects.GetProject(opts.ProjectID, nil)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	topts := &tgitlab.TestOpts{
+		NoMRCreation: true,
 	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
 
 	tagName := "v1.0.0"
 	comment := "/test tag:" + tagName
-	sha := ""
 	targetBranch := "release-" + tagName
-	numberOfPRs := 1
+	numberOfPRs := 2
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNs, nil)
+	entries, err := payload.GetEntries(map[string]string{
+		".tekton/pipelinerun-on-tag.yaml": "testdata/pipelinerun-on-tag.yaml",
+	}, topts.TargetNS, "refs/tags/*", triggertype.Push.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	runcnx.Clients.Log.Infof("Repository %s has been created successfully", targetNs)
-
-	tag, resp, err := glprovider.Client().Tags.GetTag(opts.ProjectID, tagName)
-	if err != nil && resp.StatusCode == http.StatusNotFound {
-		runcnx.Clients.Log.Infof("Tag %s not found in repository %s", tagName, projectinfo.Name)
-		runcnx.Clients.Log.Infof("Creating tag %s in repository %s", tagName, projectinfo.Name)
-
-		entries, err := payload.GetEntries(map[string]string{
-			".tekton/pipelinerun-on-tag.yaml": "testdata/pipelinerun-on-tag.yaml",
-		}, targetNs, "refs/tags/*", triggertype.Push.String(), map[string]string{})
-		assert.NilError(t, err)
-
-		cloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, "git", *glprovider.Token)
-		assert.NilError(t, err)
-
-		scmOpts := &scm.Opts{
-			GitURL:        cloneURL,
-			Log:           runcnx.Clients.Log,
-			WebURL:        projectinfo.WebURL,
-			TargetRefName: targetBranch,
-			BaseRefName:   projectinfo.DefaultBranch,
-			CommitTitle:   "Test GitOps Commands on Tag - " + targetNs,
-		}
-		_ = scm.PushFilesToRefGit(t, scmOpts, entries)
-
-		branch, _, err := glprovider.Client().Branches.GetBranch(opts.ProjectID, targetBranch)
-		assert.NilError(t, err)
-
-		sha = branch.Commit.ID
-
-		_, _, err = glprovider.Client().Tags.CreateTag(opts.ProjectID, &gitlab.CreateTagOptions{
-			TagName: gitlab.Ptr(tagName),
-			Ref:     gitlab.Ptr(targetBranch),
-		})
-		assert.NilError(t, err)
-
-		// as we're creating a tag, we need to increment the number of PRs
-		// because the tag creation will also trigger a new PipelineRun
-		numberOfPRs++
-	} else {
-		runcnx.Clients.Log.Infof("Tag %s already created in repository %s", tagName, projectinfo.Name)
-		sha = tag.Commit.ID
+	scmOpts := &scm.Opts{
+		GitURL:        topts.GitCloneURL,
+		Log:           topts.ParamsRun.Clients.Log,
+		WebURL:        topts.GitHTMLURL,
+		TargetRefName: targetBranch,
+		BaseRefName:   topts.DefaultBranch,
+		CommitTitle:   "Test GitOps Commands on Tag - " + topts.TargetNS,
 	}
-	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, "", targetNs, opts.ProjectID)
+	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
 
-	cc, _, err := glprovider.Client().Commits.PostCommitComment(opts.ProjectID, sha, &gitlab.PostCommitCommentOptions{
+	branch, _, err := topts.GLProvider.Client().Branches.GetBranch(topts.ProjectID, targetBranch)
+	assert.NilError(t, err)
+	sha := branch.Commit.ID
+
+	_, _, err = topts.GLProvider.Client().Tags.CreateTag(topts.ProjectID, &gitlab.CreateTagOptions{
+		TagName: gitlab.Ptr(tagName),
+		Ref:     gitlab.Ptr(targetBranch),
+	})
+	assert.NilError(t, err)
+
+	defer tgitlab.CleanTag(topts.GLProvider.Client(), topts.ProjectID, tagName)
+
+	cc, _, err := topts.GLProvider.Client().Commits.PostCommitComment(topts.ProjectID, sha, &gitlab.PostCommitCommentOptions{
 		Note: gitlab.Ptr(comment),
 	})
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
+	topts.ParamsRun.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
 
 	waitOpts := wait.Opts{
-		RepoName:        targetNs,
-		Namespace:       targetNs,
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
 		MinNumberStatus: numberOfPRs,
 		PollTimeout:     wait.DefaultTimeout,
 		TargetSHA:       sha,
 	}
 
-	err = wait.UntilPipelineRunCreated(ctx, runcnx.Clients, waitOpts)
+	err = wait.UntilPipelineRunCreated(ctx, topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 
-	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNs).List(ctx, metav1.ListOptions{})
+	prsNew, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prsNew.Items) == numberOfPRs)
 }

--- a/test/pkg/configfile/config.go
+++ b/test/pkg/configfile/config.go
@@ -43,9 +43,10 @@ type GitHubEnterpriseConfig struct {
 }
 
 type GitLabConfig struct {
-	APIURL    string `env:"TEST_GITLAB_API_URL"    json:"api_url"    yaml:"api_url"`
-	Token     string `env:"TEST_GITLAB_TOKEN"      json:"token"      yaml:"token"`
-	ProjectID string `env:"TEST_GITLAB_PROJECT_ID" json:"project_id" yaml:"project_id"`
+	APIURL  string `env:"TEST_GITLAB_API_URL" json:"api_url"  yaml:"api_url"`
+	Token   string `env:"TEST_GITLAB_TOKEN"   json:"token"    yaml:"token"`
+	Group   string `env:"TEST_GITLAB_GROUP"   json:"group"    yaml:"group"`
+	SmeeURL string `env:"TEST_GITLAB_SMEEURL" json:"smee_url" yaml:"smee_url"`
 }
 
 type GiteaConfig struct {

--- a/test/pkg/configfile/config_test.go
+++ b/test/pkg/configfile/config_test.go
@@ -136,7 +136,8 @@ github_enterprise:
 gitlab:
   api_url: "https://gitlab.com"
   token: "glpat-xyz"
-  project_id: "42"
+  group: "pac-e2e-tests"
+  smee_url: "https://hook.pipelinesascode.com/gitlab-test"
 gitea:
   api_url: "http://localhost:3000"
   internal_url: "http://forgejo:3000"
@@ -169,7 +170,7 @@ bitbucket_server:
 		"TEST_GITHUB_SECOND_API_URL", "TEST_GITHUB_SECOND_TOKEN",
 		"TEST_GITHUB_SECOND_EL_URL", "TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP",
 		"TEST_GITHUB_SECOND_REPO_INSTALLATION_ID",
-		"TEST_GITLAB_API_URL", "TEST_GITLAB_TOKEN", "TEST_GITLAB_PROJECT_ID",
+		"TEST_GITLAB_API_URL", "TEST_GITLAB_TOKEN", "TEST_GITLAB_GROUP", "TEST_GITLAB_SMEEURL",
 		"TEST_GITEA_API_URL", "TEST_GITEA_INTERNAL_URL", "TEST_GITEA_PASSWORD",
 		"TEST_GITEA_USERNAME", "TEST_GITEA_REPO_OWNER", "TEST_GITEA_SMEEURL",
 		"TEST_BITBUCKET_CLOUD_API_URL", "TEST_BITBUCKET_CLOUD_USER",
@@ -203,7 +204,8 @@ bitbucket_server:
 		"TEST_GITHUB_SECOND_REPO_INSTALLATION_ID": "1",
 		"TEST_GITLAB_API_URL":                     "https://gitlab.com",
 		"TEST_GITLAB_TOKEN":                       "glpat-xyz",
-		"TEST_GITLAB_PROJECT_ID":                  "42",
+		"TEST_GITLAB_GROUP":                       "pac-e2e-tests",
+		"TEST_GITLAB_SMEEURL":                     "https://hook.pipelinesascode.com/gitlab-test",
 		"TEST_GITEA_API_URL":                      "http://localhost:3000",
 		"TEST_GITEA_INTERNAL_URL":                 "http://forgejo:3000",
 		"TEST_GITEA_PASSWORD":                     "pac",

--- a/test/pkg/gitlab/crd.go
+++ b/test/pkg/gitlab/crd.go
@@ -5,44 +5,41 @@ import (
 	"os"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	pacrepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
-	gitlab "gitlab.com/gitlab-org/api/client-go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func CreateCRD(ctx context.Context, projectinfo *gitlab.Project, run *params.Run, opts options.E2E, targetNS string, incomings *[]v1alpha1.Incoming) error {
-	if err := pacrepo.CreateNS(ctx, targetNS, run); err != nil {
+func CreateCRD(ctx context.Context, topts *TestOpts) error {
+	if err := pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun); err != nil {
 		return err
 	}
 
 	token, _ := os.LookupEnv("TEST_GITLAB_TOKEN")
 	webhookSecret, _ := os.LookupEnv("TEST_EL_WEBHOOK_SECRET")
 	apiURL, _ := os.LookupEnv("TEST_GITLAB_API_URL")
-	if err := secret.Create(ctx, run, map[string]string{"token": token}, targetNS, "webhook-token"); err != nil {
+	if err := secret.Create(ctx, topts.ParamsRun, map[string]string{"token": token}, topts.TargetNS, "webhook-token"); err != nil {
 		return err
 	}
-	if err := secret.Create(ctx, run, map[string]string{"secret": webhookSecret}, targetNS, "webhook-secret"); err != nil {
+	if err := secret.Create(ctx, topts.ParamsRun, map[string]string{"secret": webhookSecret}, topts.TargetNS, "webhook-secret"); err != nil {
 		return err
 	}
 	repository := &v1alpha1.Repository{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: targetNS,
+			Name: topts.TargetNS,
 		},
 		Spec: v1alpha1.RepositorySpec{
-			Settings: &opts.Settings,
-			URL:      projectinfo.WebURL,
+			Settings: topts.Settings,
+			URL:      topts.GitHTMLURL,
 			GitProvider: &v1alpha1.GitProvider{
 				Type:          "gitlab",
 				URL:           apiURL,
 				Secret:        &v1alpha1.Secret{Name: "webhook-token", Key: "token"},
 				WebhookSecret: &v1alpha1.Secret{Name: "webhook-secret", Key: "secret"},
 			},
-			Incomings: incomings,
+			Incomings: topts.Incomings,
 		},
 	}
 
-	return pacrepo.CreateRepo(ctx, targetNS, run, repository)
+	return pacrepo.CreateRepo(ctx, topts.TargetNS, topts.ParamsRun, repository)
 }

--- a/test/pkg/gitlab/scm.go
+++ b/test/pkg/gitlab/scm.go
@@ -1,0 +1,48 @@
+package gitlab
+
+import (
+	"fmt"
+
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+	"go.uber.org/zap"
+)
+
+// CreateGitLabProject creates a new GitLab project inside a group and adds
+// a webhook pointing to the given hookURL (for example, a smee channel URL
+// used to forward events to the controller). The project is initialised with
+// a README on the "main" branch.
+func CreateGitLabProject(client *gitlab.Client, groupPath, projectName, hookURL, webhookSecret string, logger *zap.SugaredLogger) (*gitlab.Project, error) {
+	logger.Infof("Looking up GitLab group %s", groupPath)
+	group, _, err := client.Groups.GetGroup(groupPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up group %s: %w", groupPath, err)
+	}
+
+	logger.Infof("Creating GitLab project %s in group %s (ID %d)", projectName, groupPath, group.ID)
+	project, _, err := client.Projects.CreateProject(&gitlab.CreateProjectOptions{
+		Name:                 gitlab.Ptr(projectName),
+		NamespaceID:          gitlab.Ptr(group.ID),
+		InitializeWithReadme: gitlab.Ptr(true),
+		DefaultBranch:        gitlab.Ptr("main"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create project %s: %w", projectName, err)
+	}
+	logger.Infof("Created GitLab project %s (ID %d)", project.PathWithNamespace, project.ID)
+
+	logger.Infof("Adding webhook to project %s pointing to %s", project.PathWithNamespace, hookURL)
+	_, _, err = client.Projects.AddProjectHook(project.ID, &gitlab.AddProjectHookOptions{
+		URL:                   gitlab.Ptr(hookURL),
+		Token:                 gitlab.Ptr(webhookSecret),
+		MergeRequestsEvents:   gitlab.Ptr(true),
+		NoteEvents:            gitlab.Ptr(true),
+		PushEvents:            gitlab.Ptr(true),
+		TagPushEvents:         gitlab.Ptr(true),
+		EnableSSLVerification: gitlab.Ptr(false),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add webhook to project %s: %w", project.PathWithNamespace, err)
+	}
+
+	return project, nil
+}

--- a/test/pkg/gitlab/setup.go
+++ b/test/pkg/gitlab/setup.go
@@ -2,9 +2,7 @@ package gitlab
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -14,27 +12,21 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/setup"
 	gitlab2 "gitlab.com/gitlab-org/api/client-go"
-	"gotest.tools/v3/assert"
 )
 
 func Setup(ctx context.Context) (*params.Run, options.E2E, gitlab.Provider, error) {
 	if err := setup.RequireEnvs(
 		"TEST_GITLAB_API_URL",
 		"TEST_GITLAB_TOKEN",
-		"TEST_GITLAB_PROJECT_ID",
+		"TEST_GITLAB_GROUP",
 		"TEST_EL_WEBHOOK_SECRET",
 		"TEST_EL_URL",
+		"TEST_GITLAB_SMEEURL",
 	); err != nil {
 		return nil, options.E2E{}, gitlab.Provider{}, err
 	}
 	gitlabURL := os.Getenv("TEST_GITLAB_API_URL")
 	gitlabToken := os.Getenv("TEST_GITLAB_TOKEN")
-	sgitlabPid := os.Getenv("TEST_GITLAB_PROJECT_ID")
-	gitlabPid, err := strconv.Atoi(sgitlabPid)
-	if err != nil {
-		return nil, options.E2E{}, gitlab.Provider{}, fmt.Errorf("TEST_GITLAB_PROJECT_ID env variable must be an integer, found '%v': %w", gitlabPid, err)
-	}
-
 	controllerURL := os.Getenv("TEST_EL_URL")
 
 	run := params.New()
@@ -43,13 +35,12 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitlab.Provider, erro
 	}
 
 	e2eoptions := options.E2E{
-		ProjectID:     gitlabPid,
 		ControllerURL: controllerURL,
-		UserName:      "git",
+		UserName:      "oauth2",
 		Password:      gitlabToken,
 	}
 	glprovider := gitlab.Provider{}
-	err = glprovider.SetClient(ctx, run, &info.Event{
+	err := glprovider.SetClient(ctx, run, &info.Event{
 		Provider: &info.Provider{
 			Token: gitlabToken,
 			URL:   gitlabURL,
@@ -61,25 +52,29 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitlab.Provider, erro
 	return run, e2eoptions, glprovider, nil
 }
 
-func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, glprovider gitlab.Provider, mrNumber int, ref, targetNS string, projectid int) {
+func TearDown(ctx context.Context, t *testing.T, topts *TestOpts) {
 	if os.Getenv("TEST_NOCLEANUP") == "true" {
-		runcnx.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
+		topts.ParamsRun.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
 		return
 	}
 
-	if mrNumber != -1 {
-		runcnx.Clients.Log.Infof("Closing PR %d", mrNumber)
-		_, _, err := glprovider.Client().MergeRequests.UpdateMergeRequest(projectid, int64(mrNumber),
+	if topts.MRNumber > 0 {
+		topts.ParamsRun.Clients.Log.Infof("Closing MR %d", topts.MRNumber)
+		_, _, err := topts.GLProvider.Client().MergeRequests.UpdateMergeRequest(topts.ProjectID, int64(topts.MRNumber),
 			&gitlab2.UpdateMergeRequestOptions{StateEvent: gitlab2.Ptr("close")})
 		if err != nil {
-			t.Fatal(err)
+			t.Logf("Error closing MR %d: %v", topts.MRNumber, err)
 		}
 	}
-	repository.NSTearDown(ctx, t, runcnx, targetNS)
-	if ref != "" {
-		runcnx.Clients.Log.Infof("Deleting Ref %s", ref)
-		_, err := glprovider.Client().Branches.DeleteBranch(projectid, ref)
-		assert.NilError(t, err)
+
+	repository.NSTearDown(ctx, t, topts.ParamsRun, topts.TargetNS)
+
+	if topts.ProjectID != 0 {
+		topts.ParamsRun.Clients.Log.Infof("Deleting GitLab project %d", topts.ProjectID)
+		_, err := topts.GLProvider.Client().Projects.DeleteProject(topts.ProjectID, nil)
+		if err != nil {
+			t.Logf("Error deleting GitLab project %d: %v", topts.ProjectID, err)
+		}
 	}
 }
 

--- a/test/pkg/gitlab/test.go
+++ b/test/pkg/gitlab/test.go
@@ -1,11 +1,145 @@
 package gitlab
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"regexp"
+	"testing"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	gitlab2 "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
+	"github.com/tektoncd/pipeline/pkg/names"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
+	"gotest.tools/v3/assert"
 )
+
+type TestOpts struct {
+	TargetNS             string
+	TargetRefName        string
+	TargetEvent          string
+	DefaultBranch        string
+	ProjectID            int
+	ProjectInfo          *gitlab.Project
+	MRNumber             int
+	GitCloneURL          string
+	GitHTMLURL           string
+	SHA                  string
+	ParamsRun            *params.Run
+	GLProvider           gitlab2.Provider
+	Opts                 options.E2E
+	YAMLFiles            map[string]string
+	ExtraArgs            map[string]string
+	Regexp               *regexp.Regexp
+	CheckForStatus       string
+	CheckForNumberStatus int
+	Settings             *v1alpha1.Settings
+	Incomings            *[]v1alpha1.Incoming
+	NoMRCreation         bool
+	SkipEventsCheck      bool
+	ExpectEvents         bool
+}
+
+// TestMR is the unified lifecycle function for GitLab E2E tests.
+// It creates a fresh project, sets up the CRD, pushes files,
+// creates a merge request, and returns a cleanup function.
+func TestMR(t *testing.T, topts *TestOpts) (context.Context, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	if topts.ParamsRun == nil {
+		runcnx, opts, glprovider, err := Setup(ctx)
+		assert.NilError(t, err, fmt.Errorf("cannot do gitlab setup: %w", err))
+		topts.GLProvider = glprovider
+		topts.ParamsRun = runcnx
+		topts.Opts = opts
+	}
+	ctx, err := cctx.GetControllerCtxInfo(ctx, topts.ParamsRun)
+	assert.NilError(t, err)
+
+	if topts.TargetRefName == "" {
+		topts.TargetRefName = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+	}
+	if topts.TargetNS == "" {
+		topts.TargetNS = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	}
+	if topts.DefaultBranch == "" {
+		topts.DefaultBranch = options.MainBranch
+	}
+	if topts.ExtraArgs == nil {
+		topts.ExtraArgs = map[string]string{}
+	}
+
+	// Update incoming targets to use the actual TargetNS
+	if topts.Incomings != nil {
+		for i := range *topts.Incomings {
+			(*topts.Incomings)[i].Targets = []string{topts.TargetNS}
+		}
+	}
+
+	// Create a fresh GitLab project
+	groupPath := os.Getenv("TEST_GITLAB_GROUP")
+	hookURL := os.Getenv("TEST_GITLAB_SMEEURL")
+	webhookSecret := os.Getenv("TEST_EL_WEBHOOK_SECRET")
+	project, err := CreateGitLabProject(topts.GLProvider.Client(), groupPath, topts.TargetRefName, hookURL, webhookSecret, topts.ParamsRun.Clients.Log)
+	assert.NilError(t, err)
+	topts.ProjectID = int(project.ID)
+	topts.ProjectInfo = project
+	topts.GitHTMLURL = project.WebURL
+	topts.DefaultBranch = project.DefaultBranch
+
+	// Create CRD (namespace, secrets, Repository CR)
+	err = CreateCRD(ctx, topts)
+	assert.NilError(t, err)
+
+	cleanup := func() {
+		if os.Getenv("TEST_NOCLEANUP") != "true" {
+			TearDown(ctx, t, topts)
+		}
+	}
+
+	// Build git clone URL
+	gitCloneURL, err := scm.MakeGitCloneURL(project.WebURL, topts.Opts.UserName, topts.Opts.Password)
+	assert.NilError(t, err)
+	topts.GitCloneURL = gitCloneURL
+
+	if topts.NoMRCreation {
+		return ctx, cleanup
+	}
+
+	// Process YAML files and push
+	entries, err := payload.GetEntries(topts.YAMLFiles,
+		topts.TargetNS,
+		topts.DefaultBranch,
+		topts.TargetEvent,
+		topts.ExtraArgs)
+	assert.NilError(t, err)
+
+	scmOpts := &scm.Opts{
+		GitURL:        topts.GitCloneURL,
+		Log:           topts.ParamsRun.Clients.Log,
+		WebURL:        topts.GitHTMLURL,
+		TargetRefName: topts.TargetRefName,
+		BaseRefName:   topts.DefaultBranch,
+	}
+	topts.SHA = scm.PushFilesToRefGit(t, scmOpts, entries)
+	topts.ParamsRun.Clients.Log.Infof("Branch %s has been created and pushed with files", topts.TargetRefName)
+
+	// Create MR
+	mrTitle := "TestMergeRequest - " + topts.TargetRefName
+	mrID, err := CreateMR(topts.GLProvider.Client(), topts.ProjectID, topts.TargetRefName, topts.DefaultBranch, mrTitle)
+	assert.NilError(t, err)
+	topts.MRNumber = mrID
+	topts.ParamsRun.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", topts.GitHTMLURL, mrID)
+
+	return ctx, cleanup
+}
 
 func CreateMR(client *gitlab.Client, pid int, sourceBranch, targetBranch, title string) (int, error) {
 	mr, _, err := client.MergeRequests.CreateMergeRequest(pid, &gitlab.CreateMergeRequestOptions{

--- a/test/pkg/options/options.go
+++ b/test/pkg/options/options.go
@@ -5,7 +5,6 @@ import "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascod
 type E2E struct {
 	Repo, Organization string
 	DirectWebhook      bool
-	ProjectID          int
 	ControllerURL      string
 	Concurrency        int
 	UserName           string


### PR DESCRIPTION
GitLab E2E tests previously relied on a static pre-created project (TEST_GITLAB_PROJECT_ID) and direct webhook delivery to the controller URL. This broke in Kind-based CI environments where the controller runs inside the cluster and is not reachable from the external GitLab instance (gitlab.pipelinesascode.com).

This was causing issue when multiple e2e runs were executed in parallel, as they would all share the same project and webhook, leading to conflicts and unreliable test results when testing comments, commit statuses, and merge request events.

Refactor GitLab E2E tests to dynamically create and delete projects per test run, and route webhooks through gosmee/smee — the same pattern already used by Gitea tests. Each test now creates a fresh GitLab project with a webhook pointing to a smee channel, and gosmee forwards payloads to the in-cluster controller.

Key changes:

- CreateGitLabProject() now accepts hookURL and webhookSecret as parameters instead of reading TEST_EL_URL from the environment, mirroring CreateGiteaRepo() in test/pkg/gitea/scm.go.

- TestMR() reads TEST_GITLAB_SMEEURL and passes it as the webhook target when creating projects. TearDown() deletes the project on cleanup.

- CI workflow generates a unique smee channel for the gitlab_bitbucket matrix job and runs a gosmee client to forward webhooks, matching the existing Gitea gosmee setup.

- Add SmeeURL field to GitLabConfig in the YAML-based test configuration, with corresponding test coverage.

- Add hack/cleanup-gitlab-projects.py to garbage-collect stale test projects older than 7 days (dry-run by default, --force to delete).

- Fix title assertions in TestGitlabIssueGitopsComment, TestGitlabConsistentCommitStatusOnMR, and TestGitlabMergeRequestCelPrefix. These tests expected custom titles but the repository status always reflects the commit message set by TestMR ("Committing files from test on ..."). The mismatch was latent in the refactoring and surfaced when running the full suite.

- Document manual GitLab test setup in test/README.md including smee channel generation, required env vars, and project cleanup.

## 📝 Description of the Change

## 👨🏻‍ Linked Jira

<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

<!-- (update the title of the Pull Request accordingly), the lint task checks it -->

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] 🎨 Style (`style:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] ⚡ Performance (`perf:`)
- [x] ✅ Test (`test:`)
- [ ] 🏗️ Build (`build:`)
- [ ] 👷 CI (`ci:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] ⏪ Revert (`revert:`)
- [ ] 📦 Dependency update (`deps:`)

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center