### PR TITLE
test(e2e): migrate GitHub webhook tests to GHE

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -87,6 +87,8 @@ jobs:
       TEST_GITHUB_SECOND_REPO_INSTALLATION_ID: 1
       TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP: pipelines-as-code/e2e
       TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
+      TEST_GITHUB_SECOND_SMEE_URL: ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}
+      TEST_GITHUB_SECOND_WEBHOOK_ORG: pac-e2e-webhook-tests
       TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
       TEST_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
     steps:
@@ -333,10 +335,25 @@ jobs:
         run: |
           nohup gosmee client --saveDir /tmp/gosmee-replay-gitlab "${TEST_GITLAB_SMEEURL}" "https://${CONTROLLER_DOMAIN_URL}" >> /tmp/gosmee-gitlab.log 2>&1 &
 
-      - name: Run gosmee for second controller (GHE)
+
+      - name: Run gosmee for second controller GHE App
         if: startsWith(matrix.provider, 'github_ghe') || matrix.provider == 'concurrency'
         run: |
-          nohup gosmee client --saveDir /tmp/gosmee-replay-ghe ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }} "https://ghe.paac-127-0-0-1.nip.io" > /tmp/gosmee-ghe.log 2>&1 &
+          nohup gosmee client --saveDir /tmp/gosmee-replay-ghe "${TEST_GITHUB_SECOND_SMEE_URL}" "https://ghe.paac-127-0-0-1.nip.io" >> /tmp/gosmee-ghe.log 2>&1 &
+
+      - name: Generate unique gosmee URL for GHE webhook tests
+        if: startsWith(matrix.provider, 'github_ghe') || matrix.provider == 'concurrency'
+        id: gosmee-ghe-webhook-url
+        run: |
+          SMEE_URL=$(curl -s https://hook.pipelinesascode.com -o /dev/null -w '%{redirect_url}')
+          echo "Generated unique GHE webhook smee URL: ${SMEE_URL}"
+          echo "url=${SMEE_URL}" >> "$GITHUB_OUTPUT"
+          echo "TEST_GITHUB_SECOND_WEBHOOK_SMEE_URL=${SMEE_URL}" >> "$GITHUB_ENV"
+
+      - name: Run gosmee for second controller GHE webhook
+        if: startsWith(matrix.provider, 'github_ghe') || matrix.provider == 'concurrency'
+        run: |
+          nohup gosmee client --saveDir /tmp/gosmee-replay-ghe-webhook "${TEST_GITHUB_SECOND_WEBHOOK_SMEE_URL}" "https://ghe.paac-127-0-0-1.nip.io" >> /tmp/gosmee-ghe-webhook.log 2>&1 &
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3
@@ -375,6 +392,7 @@ jobs:
           TEST_GITHUB_SECOND_REPO_INSTALLATION_ID: 1
           TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP: pipelines-as-code/e2e
           TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
+          TEST_GITHUB_SECOND_WEBHOOK_ORG: pac-e2e-webhook-tests
           TEST_GITHUB_SECOND_SMEE_URL: ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}
           TEST_GITHUB_SECOND_WEBHOOK_SECRET: ${{ secrets.TEST_GITHUB_SECOND_WEBHOOK_SECRET }}
           TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
@@ -480,6 +498,7 @@ jobs:
         if: ${{ always() }}
         env:
           TEST_GITHUB_SECOND_SMEE_URL: ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}
+          TEST_GITHUB_SECOND_WEBHOOK_SMEE_URL: ${{ steps.gosmee-ghe-webhook-url.outputs.url }}
           TEST_GITLAB_SMEEURL: ${{ steps.gosmee-gitlab-url.outputs.url }}
         run: |
           ./hack/gh-workflow-ci.sh collect_logs

--- a/test/e2e-config.yaml.example
+++ b/test/e2e-config.yaml.example
@@ -39,6 +39,9 @@ github_enterprise:
   controller_url: ""
   repo_owner_githubapp: ""
   repo_installation_id: ""
+  smee_url: ""  # For GitHub App tests
+  webhook_smee_url: ""  # For webhook-based tests with dynamic repo creation
+  webhook_org: ""  # Optional: Different org for webhook tests (uses repo_owner_githubapp org if not set)
 
 # GitLab
 gitlab:

--- a/test/github_comment_strategy_update_test.go
+++ b/test/github_comment_strategy_update_test.go
@@ -23,15 +23,12 @@ import (
 // 1. A CEL error comment is posted for a PLR
 // 2. After fixing the CEL error with a new commit, the same comment is updated with success status
 // 3. Only one comment exists.
-func TestGithubCommentStrategyUpdateCELErrorReplacement(t *testing.T) {
-	if os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK") == "" {
-		t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
-	}
-
+func TestGithubGHECommentStrategyUpdateCELErrorReplacement(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label:         "Github Comment Strategy CEL Error",
 		YamlFiles:     []string{"testdata/failures/pipelinerun-invalid-cel.yaml"},
+		GHE:           true,
 		Webhook:       true,
 		NoStatusCheck: true,
 	}
@@ -43,8 +40,8 @@ func TestGithubCommentStrategyUpdateCELErrorReplacement(t *testing.T) {
 	}
 	g.Options.Settings = commentStrategy
 
-	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
+	g.RunPullRequest(ctx, t)
 
 	g.Cnx.Clients.Log.Infof("Waiting for CEL error comment to be created")
 	time.Sleep(15 * time.Second)
@@ -145,15 +142,12 @@ func TestGithubCommentStrategyUpdateCELErrorReplacement(t *testing.T) {
 // 1. Multiple PLRs in one PR each create their own comment
 // 2. Each PLR only updates its own comment (no cross-updates)
 // 3. Comments are correctly identified by their unique markers.
-func TestGithubCommentStrategyUpdateMultiplePLRs(t *testing.T) {
-	if os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK") == "" {
-		t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
-	}
-
+func TestGithubGHECommentStrategyUpdateMultiplePLRs(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label:     "Github Comment Strategy Multiple PLRs",
 		YamlFiles: []string{"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml"},
+		GHE:       true,
 		Webhook:   true,
 	}
 
@@ -164,8 +158,8 @@ func TestGithubCommentStrategyUpdateMultiplePLRs(t *testing.T) {
 	}
 	g.Options.Settings = commentStrategy
 
-	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
+	g.RunPullRequest(ctx, t)
 
 	sopt := twait.SuccessOpt{
 		Title:           g.CommitTitle,
@@ -253,11 +247,7 @@ func TestGithubCommentStrategyUpdateMultiplePLRs(t *testing.T) {
 // 1. PLR names containing regex-relevant characters (dots, brackets, etc.) are handled correctly
 // 2. Marker matching remains exact even with special characters
 // 3. No cross-contamination between PLRs with similar names.
-func TestGithubCommentStrategyUpdateMarkerMatchingWithRegexChars(t *testing.T) {
-	if os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK") == "" {
-		t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
-	}
-
+func TestGithubGHECommentStrategyUpdateMarkerMatchingWithRegexChars(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label: "Github Comment Strategy Regex Chars",
@@ -265,6 +255,7 @@ func TestGithubCommentStrategyUpdateMarkerMatchingWithRegexChars(t *testing.T) {
 			"testdata/pipelinerun-regex-chars-dots.yaml",
 			"testdata/pipelinerun-regex-chars-brackets.yaml",
 		},
+		GHE:     true,
 		Webhook: true,
 	}
 
@@ -275,8 +266,8 @@ func TestGithubCommentStrategyUpdateMarkerMatchingWithRegexChars(t *testing.T) {
 	}
 	g.Options.Settings = commentStrategy
 
-	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
+	g.RunPullRequest(ctx, t)
 
 	sopt := twait.SuccessOpt{
 		Title:           g.CommitTitle,

--- a/test/github_incoming_test.go
+++ b/test/github_incoming_test.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-github/v81/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
@@ -41,7 +43,7 @@ func TestGithubGHEAppIncoming(t *testing.T) {
 	}, randomedString, randomedString, triggertype.Incoming.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{randomedString}, false, true, 1)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{randomedString}, false, 1)
 }
 
 func TestGithubGHEIncoming(t *testing.T) {
@@ -52,10 +54,10 @@ func TestGithubGHEIncoming(t *testing.T) {
 	}, randomedString, randomedString, triggertype.Incoming.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{randomedString}, false, true, 1)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{randomedString}, false, 1)
 }
 
-func TestGithubWebhookIncoming(t *testing.T) {
+func TestGithubGHEWebhookIncoming(t *testing.T) {
 	randomedString := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 
 	// Create entries with different event types to test that only incoming PipelineRun gets triggered
@@ -78,7 +80,7 @@ func TestGithubWebhookIncoming(t *testing.T) {
 		entries[k] = v
 	}
 
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{randomedString}, true, false, 1)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{randomedString}, true, 1)
 }
 
 // TestGithubAppIncomingForDifferentEvent tests that a Pipelinerun with the incoming event
@@ -92,7 +94,7 @@ func TestGithubGHEAppIncomingForDifferentEvent(t *testing.T) {
 	}, randomedString, randomedString, triggertype.PullRequest.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming-", entries, []string{randomedString}, false, true, 1)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming-", entries, []string{randomedString}, false, 1)
 }
 
 // TestGithubAppIncomingGlobPattern tests incoming webhook with glob pattern matching.
@@ -106,7 +108,7 @@ func TestGithubGHEAppIncomingGlobPattern(t *testing.T) {
 
 	// Test with glob pattern that matches the branch name
 	// Pattern: pac-e2e-ns* should match branch pac-e2e-ns-xxxxx
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"pac-e2e-ns*"}, false, true, 1)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"pac-e2e-ns*"}, false, 1)
 }
 
 // TestGithubAppIncomingGlobPrefixPattern tests incoming webhook with prefix glob pattern.
@@ -120,7 +122,7 @@ func TestGithubGHEAppIncomingGlobPrefixPattern(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Test with glob pattern that matches feature branches
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"feature-*"}, false, true, 1)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"feature-*"}, false, 1)
 }
 
 // TestGithubAppIncomingGlobFirstMatchWins tests first-match-wins with multiple glob targets.
@@ -134,7 +136,7 @@ func TestGithubGHEAppIncomingGlobFirstMatchWins(t *testing.T) {
 
 	// Multiple patterns - first one that matches should win
 	// Both pac-e2e-ns* and * will match, but first should win
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"pac-e2e-ns*", "*"}, false, true, 1)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"pac-e2e-ns*", "*"}, false, 1)
 }
 
 // TestGithubAppIncomingNoMatch tests that incoming webhook fails when branch doesn't match any target.
@@ -148,7 +150,7 @@ func TestGithubGHEAppIncomingNoMatch(t *testing.T) {
 
 	// Test with glob pattern that will NOT match the branch
 	// Pattern: production-* should NOT match branch pac-e2e-ns-xxxxx
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"production-*"}, false, true, 0)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"production-*"}, false, 0)
 }
 
 // TestGithubAppIncomingMultiplePatternsNoMatch tests that incoming webhook fails when none of the patterns match.
@@ -161,7 +163,7 @@ func TestGithubGHEAppIncomingMultiplePatternsNoMatch(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Multiple patterns that all don't match the branch
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"production-*", "staging-*", "release-*"}, false, true, 0)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"production-*", "staging-*", "release-*"}, false, 0)
 }
 
 // TestGithubAppIncomingNoMatchExactName tests that exact non-matching string doesn't match.
@@ -174,11 +176,12 @@ func TestGithubGHEAppIncomingNoMatchExactName(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Test with exact branch name that doesn't match
-	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"main", "develop", "staging"}, false, true, 0)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, []string{"main", "develop", "staging"}, false, 0)
 }
 
-func verifyIncomingWebhook(t *testing.T, randomedString, pipelinerunName string, entries map[string]string, targets []string, onWebhook, onGHE bool, numberOfPR int) {
+func verifyIncomingWebhook(t *testing.T, randomedString, pipelinerunName string, entries map[string]string, targets []string, onWebhook bool, numberOfPR int) {
 	ctx := context.Background()
+	onGHE := true // All incoming webhook tests use GHE
 	ctx, runcnx, opts, ghprovider, err := tgithub.Setup(ctx, onGHE, onWebhook)
 	assert.NilError(t, err)
 	label := "GithubApp Incoming"
@@ -188,10 +191,29 @@ func verifyIncomingWebhook(t *testing.T, randomedString, pipelinerunName string,
 	logmsg := fmt.Sprintf("Testing %s with Github APPS integration on %s with targets %v", label, randomedString, targets)
 	runcnx.Clients.Log.Info(logmsg)
 
-	repoinfo, resp, err := ghprovider.Client().Repositories.Get(ctx, opts.Organization, opts.Repo)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	var repoinfo *github.Repository
+	var dynamicRepoName string
+
+	// For GHE + webhook, create a dynamic repo with SMEE webhook
+	if onGHE && onWebhook {
+		repoName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+		smeeURL := os.Getenv("TEST_GITHUB_SECOND_WEBHOOK_SMEE_URL")
+		webhookSecret := os.Getenv("TEST_EL_WEBHOOK_SECRET")
+
+		runcnx.Clients.Log.Infof("Creating dynamic GHE repository %s/%s with webhook to %s", opts.Organization, repoName, smeeURL)
+		repoinfo, err = tgithub.CreateGHERepo(ctx, ghprovider.Client(), opts.Organization, repoName, smeeURL, webhookSecret, runcnx.Clients.Log)
+		assert.NilError(t, err)
+
+		opts.Repo = repoName
+		dynamicRepoName = repoName
+	} else {
+		// Use existing pre-configured repo
+		var resp *github.Response
+		repoinfo, resp, err = ghprovider.Client().Repositories.Get(ctx, opts.Organization, opts.Repo)
+		assert.NilError(t, err)
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+		}
 	}
 
 	incoming := &[]v1alpha1.Incoming{
@@ -275,6 +297,7 @@ func verifyIncomingWebhook(t *testing.T, randomedString, pipelinerunName string,
 		Logger:          runcnx.Clients.Log,
 		Webhook:         onWebhook,
 		GHE:             onGHE,
+		DynamicRepoName: dynamicRepoName,
 	}
 	defer g.TearDown(ctx, t)
 

--- a/test/github_pullrequest_privaterepository_test.go
+++ b/test/github_pullrequest_privaterepository_test.go
@@ -4,7 +4,6 @@ package test
 
 import (
 	"context"
-	"os"
 	"regexp"
 	"testing"
 
@@ -43,18 +42,16 @@ func TestGithubGHEPullRequestGitClone(t *testing.T) {
 	defer g.TearDown(ctx, t)
 }
 
-func TestGithubPullRequestPrivateRepositoryOnWebhook(t *testing.T) {
-	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
-		t.Skip("Skipping test since only enabled for nightly")
-	}
+func TestGithubGHEPullRequestPrivateRepositoryOnWebhook(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:     "Github Rerequest",
+		Label:     "Github GHE Rerequest",
 		YamlFiles: []string{"testdata/pipelinerun_git_clone_private.yaml"},
+		GHE:       true,
 		Webhook:   true,
 	}
-	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
+	g.RunPullRequest(ctx, t)
 }
 
 // Local Variables:

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -150,23 +150,17 @@ func TestGithubGHEPullRequestCELMatchOnTitle(t *testing.T) {
 	defer g.TearDown(ctx, t)
 }
 
-func TestGithubPullRequestWebhook(t *testing.T) {
-	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
-		t.Skip("Skipping test since only enabled for nightly")
-	}
-	if os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK") == "" {
-		t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
-		return
-	}
+func TestGithubGHEPullRequestWebhook(t *testing.T) {
 	ctx := context.Background()
 
 	g := &tgithub.PRTest{
-		Label:     "Github PullRequest onWebhook",
+		Label:     "Github GHE PullRequest onWebhook",
 		YamlFiles: []string{"testdata/pipelinerun.yaml"},
+		GHE:       true,
 		Webhook:   true,
 	}
-	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
+	g.RunPullRequest(ctx, t)
 }
 
 func TestGithubGHEInvalidCELExpressionReportingOnPR(t *testing.T) {
@@ -665,16 +659,13 @@ func TestGithubGHEPullandPushMatchTriggerOnlyPull(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func TestGithubDisableCommentsOnPR(t *testing.T) {
-	if os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK") == "" {
-		t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
-		return
-	}
+func TestGithubGHEDisableCommentsOnPR(t *testing.T) {
 	ctx := context.Background()
 
 	g := &tgithub.PRTest{
-		Label:     "Github PullRequest onWebhook",
+		Label:     "Github GHE PullRequest onWebhook",
 		YamlFiles: []string{"testdata/pipelinerun.yaml"},
+		GHE:       true,
 		Webhook:   true,
 	}
 
@@ -685,8 +676,8 @@ func TestGithubDisableCommentsOnPR(t *testing.T) {
 	}
 
 	g.Options.Settings = commentStrategy
-	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
+	g.RunPullRequest(ctx, t)
 
 	comments, _, _ := g.Provider.Client().Issues.ListComments(ctx, g.Options.Organization, g.Options.Repo, g.PRNumber, nil)
 	commentRegexp := regexp.MustCompile(`.*Pipelines as Code CI/*`)

--- a/test/github_push_test.go
+++ b/test/github_push_test.go
@@ -4,35 +4,21 @@ package test
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 )
 
-func TestGithubPush(t *testing.T) {
-	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
-		t.Skip("Skipping test since only enabled for nightly")
-	}
+func TestGithubGHEPushWebhook(t *testing.T) {
 	ctx := context.Background()
-	if os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK") == "" {
-		g := &tgithub.PRTest{
-			Label:     "Github push request on Webhook",
-			YamlFiles: []string{"testdata/pipelinerun-on-push.yaml"},
-			GHE:       false,
-			Webhook:   true,
-		}
-		g.RunPushRequest(ctx, t)
-		defer g.TearDown(ctx, t)
-	} else {
-		t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
-	}
 	g := &tgithub.PRTest{
-		Label:     "Github apps push request",
+		Label:     "Github GHE push request on Webhook",
 		YamlFiles: []string{"testdata/pipelinerun-on-push.yaml"},
+		GHE:       true,
+		Webhook:   true,
 	}
-	g.RunPushRequest(ctx, t)
 	defer g.TearDown(ctx, t)
+	g.RunPushRequest(ctx, t)
 }
 
 func TestGithubGHEPush(t *testing.T) {

--- a/test/pkg/configfile/config.go
+++ b/test/pkg/configfile/config.go
@@ -40,6 +40,9 @@ type GitHubEnterpriseConfig struct {
 	ControllerURL      string `env:"TEST_GITHUB_SECOND_EL_URL"               json:"controller_url"       yaml:"controller_url"`
 	RepoOwnerGithubApp string `env:"TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP" json:"repo_owner_githubapp" yaml:"repo_owner_githubapp"`
 	RepoInstallationID string `env:"TEST_GITHUB_SECOND_REPO_INSTALLATION_ID" json:"repo_installation_id" yaml:"repo_installation_id"`
+	SmeeURL            string `env:"TEST_GITHUB_SECOND_SMEE_URL"             json:"smee_url"             yaml:"smee_url"`
+	WebhookSmeeURL     string `env:"TEST_GITHUB_SECOND_WEBHOOK_SMEE_URL"     json:"webhook_smee_url"     yaml:"webhook_smee_url"`
+	WebhookOrg         string `env:"TEST_GITHUB_SECOND_WEBHOOK_ORG"          json:"webhook_org"          yaml:"webhook_org"`
 }
 
 type GitLabConfig struct {

--- a/test/pkg/github/crd.go
+++ b/test/pkg/github/crd.go
@@ -34,9 +34,18 @@ func CreateCRD(ctx context.Context, t *testing.T, repoinfo *github.Repository, r
 	assert.NilError(t, err)
 
 	if opts.DirectWebhook {
-		token, _ := os.LookupEnv("TEST_GITHUB_TOKEN")
+		// Use opts.Token and opts.APIURL if provided (for GHE dynamic repos),
+		// otherwise fall back to environment variables (for public GitHub)
+		token := opts.Token
+		if token == "" {
+			token, _ = os.LookupEnv("TEST_GITHUB_TOKEN")
+		}
+		apiURL := opts.APIURL
+		if apiURL == "" {
+			apiURL, _ = os.LookupEnv("TEST_GITHUB_API_URL")
+		}
 		webhookSecret, _ := os.LookupEnv("TEST_EL_WEBHOOK_SECRET")
-		apiURL, _ := os.LookupEnv("TEST_GITHUB_API_URL")
+
 		err := secret.Create(ctx, run,
 			map[string]string{
 				"webhook-secret": webhookSecret,
@@ -84,9 +93,18 @@ func CreateCRDIncoming(ctx context.Context, t *testing.T, repoinfo *github.Repos
 	assert.NilError(t, err)
 
 	if opts.DirectWebhook {
-		token, _ := os.LookupEnv("TEST_GITHUB_TOKEN")
+		// Use opts.Token and opts.APIURL if provided (for GHE dynamic repos),
+		// otherwise fall back to environment variables (for public GitHub)
+		token := opts.Token
+		if token == "" {
+			token, _ = os.LookupEnv("TEST_GITHUB_TOKEN")
+		}
+		apiURL := opts.APIURL
+		if apiURL == "" {
+			apiURL, _ = os.LookupEnv("TEST_GITHUB_API_URL")
+		}
 		webhookSecret, _ := os.LookupEnv("TEST_EL_WEBHOOK_SECRET")
-		apiURL, _ := os.LookupEnv("TEST_GITHUB_API_URL")
+
 		err := secret.Create(ctx, run,
 			map[string]string{
 				"webhook-secret": webhookSecret,

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -123,6 +123,7 @@ type PRTest struct {
 	SHA             string
 	Logger          *zap.SugaredLogger
 	CommitTitle     string
+	DynamicRepoName string
 }
 
 func (g *PRTest) RunPullRequest(ctx context.Context, t *testing.T) {
@@ -135,10 +136,28 @@ func (g *PRTest) RunPullRequest(ctx context.Context, t *testing.T) {
 	g.CommitTitle = fmt.Sprintf("Testing %s with Github APPS integration on %s", g.Label, targetNS)
 	g.Logger.Info(g.CommitTitle)
 
-	repoinfo, resp, err := ghcnx.Client().Repositories.Get(ctx, opts.Organization, opts.Repo)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	var repoinfo *github.Repository
+
+	// For GHE + webhook, create a dynamic repo with SMEE webhook
+	if g.GHE && g.Webhook {
+		repoName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+		smeeURL := os.Getenv("TEST_GITHUB_SECOND_WEBHOOK_SMEE_URL")
+		webhookSecret := os.Getenv("TEST_EL_WEBHOOK_SECRET")
+
+		g.Logger.Infof("Creating dynamic GHE repository %s/%s with webhook to %s", opts.Organization, repoName, smeeURL)
+		repoinfo, err = CreateGHERepo(ctx, ghcnx.Client(), opts.Organization, repoName, smeeURL, webhookSecret, g.Logger)
+		assert.NilError(t, err)
+
+		opts.Repo = repoName
+		g.DynamicRepoName = repoName
+	} else {
+		// Use existing pre-configured repo
+		var resp *github.Response
+		repoinfo, resp, err = ghcnx.Client().Repositories.Get(ctx, opts.Organization, opts.Repo)
+		assert.NilError(t, err)
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+		}
 	}
 
 	if g.Options.Settings.Github != nil {
@@ -209,10 +228,19 @@ func (g *PRTest) TearDown(ctx context.Context, t *testing.T) {
 	if g.TargetNamespace != "" {
 		repository.NSTearDown(ctx, t, g.Cnx, g.TargetNamespace)
 	}
-	if g.TargetRefName != "" && g.TargetRefName != options.MainBranch {
+
+	// Skip branch deletion for dynamic repos since we're deleting the entire repo
+	if g.DynamicRepoName == "" && g.TargetRefName != "" && g.TargetRefName != options.MainBranch {
 		branch := fmt.Sprintf("heads/%s", filepath.Base(g.TargetRefName))
 		g.Logger.Infof("Deleting Ref %s", branch)
 		_, err := g.Provider.Client().Git.DeleteRef(ctx, g.Options.Organization, g.Options.Repo, branch)
+		assert.NilError(t, err)
+	}
+
+	// Delete dynamic repo if one was created
+	if g.DynamicRepoName != "" {
+		g.Logger.Infof("Deleting dynamic repository %s/%s", g.Options.Organization, g.DynamicRepoName)
+		err := DeleteGHERepo(ctx, g.Provider.Client(), g.Options.Organization, g.DynamicRepoName, g.Logger)
 		assert.NilError(t, err)
 	}
 }
@@ -237,10 +265,29 @@ func (g *PRTest) RunPushRequest(ctx context.Context, t *testing.T) {
 		logmsg = fmt.Sprintf("Testing %s with Github APPS integration on %s", g.Label, targetNS)
 		g.Logger.Info(logmsg)
 	}
-	repoinfo, resp, err := ghcnx.Client().Repositories.Get(ctx, opts.Organization, opts.Repo)
-	assert.NilError(t, err)
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+
+	var repoinfo *github.Repository
+
+	// For GHE + webhook, create a dynamic repo with SMEE webhook
+	if g.GHE && g.Webhook {
+		repoName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+		smeeURL := os.Getenv("TEST_GITHUB_SECOND_WEBHOOK_SMEE_URL")
+		webhookSecret := os.Getenv("TEST_EL_WEBHOOK_SECRET")
+
+		g.Logger.Infof("Creating dynamic GHE repository %s/%s with webhook to %s", opts.Organization, repoName, smeeURL)
+		repoinfo, err = CreateGHERepo(ctx, ghcnx.Client(), opts.Organization, repoName, smeeURL, webhookSecret, g.Logger)
+		assert.NilError(t, err)
+
+		opts.Repo = repoName
+		g.DynamicRepoName = repoName
+	} else {
+		// Use existing pre-configured repo
+		var resp *github.Response
+		repoinfo, resp, err = ghcnx.Client().Repositories.Get(ctx, opts.Organization, opts.Repo)
+		assert.NilError(t, err)
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+		}
 	}
 	err = CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
 	assert.NilError(t, err)

--- a/test/pkg/github/scm.go
+++ b/test/pkg/github/scm.go
@@ -1,0 +1,56 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v81/github"
+	"go.uber.org/zap"
+)
+
+// CreateGHERepo creates a new GitHub repository inside an organization and adds
+// a webhook pointing to the given hookURL (for example, a smee channel URL
+// used to forward events to the controller). The repository is initialized with
+// a README on the "main" branch.
+func CreateGHERepo(ctx context.Context, client *github.Client, org, name, hookURL, webhookSecret string, logger *zap.SugaredLogger) (*github.Repository, error) {
+	logger.Infof("Creating GitHub repository %s/%s", org, name)
+
+	autoInit := true
+	repo, _, err := client.Repositories.Create(ctx, org, &github.Repository{
+		Name:     github.Ptr(name),
+		AutoInit: &autoInit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create repository %s/%s: %w", org, name, err)
+	}
+	logger.Infof("Created GitHub repository %s", repo.GetFullName())
+
+	logger.Infof("Adding webhook to repository %s pointing to %s", repo.GetFullName(), hookURL)
+
+	active := true
+	_, _, err = client.Repositories.CreateHook(ctx, org, name, &github.Hook{
+		Events: []string{"push", "pull_request", "issue_comment", "check_run", "check_suite"},
+		Config: &github.HookConfig{
+			URL:         github.Ptr(hookURL),
+			ContentType: github.Ptr("json"),
+			Secret:      github.Ptr(webhookSecret),
+			InsecureSSL: github.Ptr("1"),
+		},
+		Active: &active,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add webhook to repository %s: %w", repo.GetFullName(), err)
+	}
+
+	return repo, nil
+}
+
+func DeleteGHERepo(ctx context.Context, client *github.Client, org, name string, logger *zap.SugaredLogger) error {
+	logger.Infof("Deleting GitHub repository %s/%s", org, name)
+	_, err := client.Repositories.Delete(ctx, org, name)
+	if err != nil {
+		return fmt.Errorf("failed to delete repository %s/%s: %w", org, name, err)
+	}
+	logger.Infof("Deleted GitHub repository %s/%s", org, name)
+	return nil
+}

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -29,35 +29,60 @@ func Setup(ctx context.Context, onGHE, viaDirectWebhook bool) (context.Context, 
 	githubToken := ""
 	githubURL := os.Getenv("TEST_GITHUB_API_URL")
 	githubRepoOwnerGithubApp := os.Getenv("TEST_GITHUB_REPO_OWNER_GITHUBAPP")
-	githubRepoOwnerDirectWebhook := os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK")
 	// EL_URL mean CONTROLLER URL, it's called el_url because a long time ago pac was based on trigger
 	controllerURL := os.Getenv("TEST_EL_URL")
 
 	if onGHE {
-		if err := setup.RequireEnvs(
+		requiredEnvs := []string{
 			"TEST_GITHUB_SECOND_API_URL",
 			"TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP",
 			"TEST_GITHUB_SECOND_TOKEN",
 			"TEST_GITHUB_SECOND_EL_URL",
-		); err != nil {
+		}
+		if viaDirectWebhook {
+			requiredEnvs = append(requiredEnvs, "TEST_GITHUB_SECOND_WEBHOOK_SMEE_URL")
+		}
+		if err := setup.RequireEnvs(requiredEnvs...); err != nil {
 			return ctx, nil, options.E2E{}, github.New(), err
 		}
 	}
 
 	var split []string
-	if !viaDirectWebhook {
-		split = strings.Split(githubRepoOwnerGithubApp, "/")
-	}
-	if viaDirectWebhook {
-		githubToken = os.Getenv("TEST_GITHUB_TOKEN")
-		split = strings.Split(githubRepoOwnerDirectWebhook, "/")
-	}
-	if onGHE {
+	var repo string
+
+	// Configure based on provider and authentication method
+	switch {
+	case onGHE && viaDirectWebhook:
+		// GHE + webhook (dynamic repo creation)
+		githubURL = os.Getenv("TEST_GITHUB_SECOND_API_URL")
+		githubToken = os.Getenv("TEST_GITHUB_SECOND_TOKEN")
+		controllerURL = os.Getenv("TEST_GITHUB_SECOND_EL_URL")
+		// Use dedicated webhook org if set, otherwise fall back to GitHub App org
+		webhookOrg := os.Getenv("TEST_GITHUB_SECOND_WEBHOOK_ORG")
+		if webhookOrg != "" {
+			split = []string{webhookOrg}
+		} else {
+			githubRepoOwnerGithubApp = os.Getenv("TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP")
+			split = strings.Split(githubRepoOwnerGithubApp, "/")
+		}
+		repo = "" // Will be filled after dynamic repo creation
+	case onGHE:
+		// GHE + GitHub App
 		githubURL = os.Getenv("TEST_GITHUB_SECOND_API_URL")
 		githubRepoOwnerGithubApp = os.Getenv("TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP")
 		githubToken = os.Getenv("TEST_GITHUB_SECOND_TOKEN")
 		controllerURL = os.Getenv("TEST_GITHUB_SECOND_EL_URL")
 		split = strings.Split(githubRepoOwnerGithubApp, "/")
+		repo = split[1]
+	case viaDirectWebhook:
+		// Public GitHub + webhook (uses same repo as GitHub App)
+		githubToken = os.Getenv("TEST_GITHUB_TOKEN")
+		split = strings.Split(githubRepoOwnerGithubApp, "/")
+		repo = split[1]
+	default:
+		// Public GitHub + GitHub App
+		split = strings.Split(githubRepoOwnerGithubApp, "/")
+		repo = split[1]
 	}
 
 	run := params.New()
@@ -70,7 +95,14 @@ func Setup(ctx context.Context, onGHE, viaDirectWebhook bool) (context.Context, 
 		return ctx, nil, options.E2E{}, github.New(), err
 	}
 	ctx = ctxWithInfo
-	e2eoptions := options.E2E{Organization: split[0], Repo: split[1], DirectWebhook: viaDirectWebhook, ControllerURL: controllerURL}
+	e2eoptions := options.E2E{
+		Organization:  split[0],
+		Repo:          repo,
+		DirectWebhook: viaDirectWebhook,
+		ControllerURL: controllerURL,
+		Token:         githubToken,
+		APIURL:        githubURL,
+	}
 	gprovider := github.New()
 	gprovider.Run = run
 	event := info.NewEvent()

--- a/test/pkg/options/options.go
+++ b/test/pkg/options/options.go
@@ -11,6 +11,8 @@ type E2E struct {
 	Password           string
 	LightweightTag     bool
 	Settings           v1alpha1.Settings
+	Token              string
+	APIURL             string
 }
 
 var (


### PR DESCRIPTION

## 📝 Description of the Change
  ### Summary                                                                                                                                                                                                                                                     
   
  - Add infrastructure for GitHub Enterprise webhook E2E tests with dynamic repository creation                                                                                                                                                                  
  - Migrate all GitHub webhook E2E tests to use GHE instead of public GitHub with fixed repositories
  - Each test now creates a fresh repository with SMEE webhook forwarding, enabling isolated webhook testing

  ### Changes

  - Enhanced test setup with dynamic GHE repository provisioning
  - Updated all webhook E2E tests to use on-demand repo creation
  - Removed dependency on pre-configured repositories and manual webhook setup

  This covers the main goal (migrating GitHub webhook tests to GHE with dynamic repos) and the key benefit (isolated testing without manual setup).

<details>
<summary>Logs when running all tests from local</summary>
```
    go test -v -race -failfast -timeout 45m -count=1 -tags=e2e -run "^(TestGithubGHEPushWebhook|TestGithubGHEPullRequestWebhook|TestGithubGHEDisableCommentsOnPR|TestGithubGHEPullRequestPrivateRepositoryOnWebhook|TestGithubGHECommentStrategyUpdateCELErrorReplacement|TestGithubGHECommentStrategyUpdateMultiplePLRs|TestGithubGHECommentStrategyUpdateMarkerMatchingWithRegexChars)$" ./test

  === RUN   TestGithubGHECommentStrategyUpdateCELErrorReplacement
  {"level":"info","ts":1772702716.739074,"caller":"cctx/ctx.go:19","msg":"Found pipelines-as-code installation in namespace pipelines-as-code"}
  {"level":"info","ts":1772702716.7393014,"caller":"cctx/ctx.go:22","msg":"Pipelines as Code Controller: &{Name:default Configmap:pipelines-as-code Secret:pipelines-as-code-secret GlobalRepository:pipelines-as-code}"}
  {"level":"info","ts":1772702716.7394133,"caller":"github/github.go:319","msg":"github-webhook: initialized OAuth2 client for providerName=github-enterprise providerURL=https://ghe.pipelinesascode.com/api/v3"}
  {"level":"info","ts":1772702716.7394898,"caller":"github/pr.go:137","msg":"Testing Github Comment Strategy CEL Error with Github APPS integration on pac-e2e-ns-bdhdv"}
  {"level":"info","ts":1772702716.739569,"caller":"github/pr.go:147","msg":"Creating dynamic GHE repository akpant-test/pac-e2e-test-v8jvq with webhook to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702716.739618,"caller":"github/scm.go:16","msg":"Creating GitHub repository akpant-test/pac-e2e-test-v8jvq"}
  {"level":"info","ts":1772702718.779499,"caller":"github/scm.go:26","msg":"Created GitHub repository akpant-test/pac-e2e-test-v8jvq"}
  {"level":"info","ts":1772702718.7796192,"caller":"github/scm.go:28","msg":"Adding webhook to repository akpant-test/pac-e2e-test-v8jvq pointing to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702719.3817892,"caller":"repository/create.go:17","msg":"Namespace pac-e2e-ns-bdhdv created"}
  {"level":"info","ts":1772702719.3976588,"caller":"repository/create.go:26","msg":"PipelinesAsCode Repository pac-e2e-ns-bdhdv has been created in namespace pac-e2e-ns-bdhdv"}
  {"level":"info","ts":1772702721.7866106,"caller":"github/pr.go:185","msg":"Commit e8cc6f69488fefaaf2a7fd1b546d36c44d9b90b0 has been created and pushed to https://ghe.pipelinesascode.com/api/v3/repos/akpant-test/pac-e2e-test-v8jvq/git/refs/heads/pac-e2e-test-qpdwn"}
  {"level":"info","ts":1772702722.9946425,"caller":"github/pr.go:106","msg":"Pull request created: https://ghe.pipelinesascode.com/akpant-test/pac-e2e-test-v8jvq/pull/1"}
  {"level":"info","ts":1772702722.9947927,"caller":"test/github_comment_strategy_update_test.go:46","msg":"Waiting for CEL error comment to be created"}
  {"level":"info","ts":1772702738.8818772,"caller":"test/github_comment_strategy_update_test.go:70","msg":"Found CEL error comment ID: 61890"}
  {"level":"info","ts":1772702738.8819878,"caller":"test/github_comment_strategy_update_test.go:78","msg":"Initial comment body (truncated): <!-- pac-status-pipelinerun-invalid-cel-swps -->\n> [!CAUTION]\n> There are some errors in your PipelineRun template.\n\n| PipelineRun | Error |\n|------|-------|\n| pipelinerun-invalid-cel-swps | `CEL expr..."}
  {"level":"info","ts":1772702738.8820667,"caller":"test/github_comment_strategy_update_test.go:84","msg":"Pushing fix to replace CEL error with valid pipelinerun"}
  {"level":"info","ts":1772702740.8794537,"caller":"test/github_comment_strategy_update_test.go:98","msg":"Pushed commit: 9f1b7aa47806f5505a698a134975afd99798c1ff"}
  {"level":"info","ts":1772702740.879552,"caller":"wait/check.go:31","msg":"Waiting for Repository to be updated"}
  {"level":"info","ts":1772702740.895999,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702743.9052424,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702746.907992,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702749.9116428,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702752.9094522,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702755.9095957,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 1/1"}
  {"level":"info","ts":1772702757.910438,"caller":"wait/check.go:46","msg":"Check if we have the repository set as succeeded"}
  {"level":"info","ts":1772702757.9211178,"caller":"wait/check.go:103","msg":"Success, number of status 1 has been matched"}
  {"level":"info","ts":1772702768.6328263,"caller":"test/github_comment_strategy_update_test.go:134","msg":"Updated comment body (truncated): <!-- pac-status-pipelinerun-invalid-cel-swps -->\n✅ **Success: pipelinerun-invalid-cel-swps for 9f1b7aa47806f5505a698a134975afd99798c1ff**\n\nPipelines as Code CI/pipelinerun-invalid-cel-swps has <b>su..."}
  {"level":"info","ts":1772702768.6330216,"caller":"github/instrumentation.go:59","msg":"Attempting to collect GitHub API calls from controller: ghe-controller in namespace: "}
  {"level":"warn","ts":1772702768.633332,"caller":"github/instrumentation.go:68","msg":"Failed to get controller logs: could not get controller logs for controller \"ghe-controller\" in namespace \"\", attempts: app.kubernetes.io/name=ghe-controller/ghe-controller: resource name may not be empty; app.kubernetes.io/component=controller,app.kubernetes.io/part-of=pipelines-as-code/ghe-controller: resource name may not be empty"}
  {"level":"info","ts":1772702768.6334207,"caller":"github/pr.go:219","msg":"Closing PR 1"}
  {"level":"info","ts":1772702769.2675042,"caller":"repository/teardown.go:32","msg":"Deleting NS pac-e2e-ns-bdhdv"}
  {"level":"info","ts":1772702769.2718627,"caller":"github/pr.go:233","msg":"Deleting Ref heads/pac-e2e-test-qpdwn"}
  {"level":"info","ts":1772702769.5977652,"caller":"github/pr.go:240","msg":"Deleting dynamic repository akpant-test/pac-e2e-test-v8jvq"}
  {"level":"info","ts":1772702769.5978847,"caller":"github/scm.go:50","msg":"Deleting GitHub repository akpant-test/pac-e2e-test-v8jvq"}
  {"level":"info","ts":1772702770.0473993,"caller":"github/scm.go:55","msg":"Deleted GitHub repository akpant-test/pac-e2e-test-v8jvq"}
  --- PASS: TestGithubGHECommentStrategyUpdateCELErrorReplacement (53.34s)
  === RUN   TestGithubGHECommentStrategyUpdateMultiplePLRs
  {"level":"info","ts":1772702770.0641797,"caller":"cctx/ctx.go:19","msg":"Found pipelines-as-code installation in namespace pipelines-as-code"}
  {"level":"info","ts":1772702770.0649185,"caller":"cctx/ctx.go:22","msg":"Pipelines as Code Controller: &{Name:default Configmap:pipelines-as-code Secret:pipelines-as-code-secret GlobalRepository:pipelines-as-code}"}
  {"level":"info","ts":1772702770.0656972,"caller":"github/github.go:319","msg":"github-webhook: initialized OAuth2 client for providerName=github-enterprise providerURL=https://ghe.pipelinesascode.com/api/v3"}
  {"level":"info","ts":1772702770.0657787,"caller":"github/pr.go:137","msg":"Testing Github Comment Strategy Multiple PLRs with Github APPS integration on pac-e2e-ns-4msmp"}
  {"level":"info","ts":1772702770.065859,"caller":"github/pr.go:147","msg":"Creating dynamic GHE repository akpant-test/pac-e2e-test-smcc6 with webhook to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702770.0658998,"caller":"github/scm.go:16","msg":"Creating GitHub repository akpant-test/pac-e2e-test-smcc6"}
  {"level":"info","ts":1772702771.0888803,"caller":"github/scm.go:26","msg":"Created GitHub repository akpant-test/pac-e2e-test-smcc6"}
  {"level":"info","ts":1772702771.089004,"caller":"github/scm.go:28","msg":"Adding webhook to repository akpant-test/pac-e2e-test-smcc6 pointing to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702771.4299493,"caller":"repository/create.go:17","msg":"Namespace pac-e2e-ns-4msmp created"}
  {"level":"info","ts":1772702771.4441707,"caller":"repository/create.go:26","msg":"PipelinesAsCode Repository pac-e2e-ns-4msmp has been created in namespace pac-e2e-ns-4msmp"}
  {"level":"info","ts":1772702774.3665974,"caller":"github/pr.go:185","msg":"Commit e0d00cd38eec544e2b2aecaebb5eacdb39ad839f has been created and pushed to https://ghe.pipelinesascode.com/api/v3/repos/akpant-test/pac-e2e-test-smcc6/git/refs/heads/pac-e2e-test-96wrl"}
  {"level":"info","ts":1772702775.5431478,"caller":"github/pr.go:106","msg":"Pull request created: https://ghe.pipelinesascode.com/akpant-test/pac-e2e-test-smcc6/pull/1"}
  {"level":"info","ts":1772702775.5432682,"caller":"wait/check.go:31","msg":"Waiting for Repository to be updated"}
  {"level":"info","ts":1772702775.5493262,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/2"}
  {"level":"info","ts":1772702778.5592523,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/2"}
  {"level":"info","ts":1772702781.5639997,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/2"}
  {"level":"info","ts":1772702784.5633755,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/2"}
  {"level":"info","ts":1772702787.5655885,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/2"}
  {"level":"info","ts":1772702789.566643,"caller":"wait/check.go:46","msg":"Check if we have the repository set as succeeded"}
  {"level":"info","ts":1772702789.5795283,"caller":"wait/check.go:103","msg":"Success, number of status 2 has been matched"}
  {"level":"info","ts":1772702789.579626,"caller":"wait/check.go:31","msg":"Waiting for Repository to be updated"}
  {"level":"info","ts":1772702789.5908558,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/2"}
  {"level":"info","ts":1772702791.5922987,"caller":"wait/check.go:46","msg":"Check if we have the repository set as succeeded"}
  {"level":"info","ts":1772702791.6055276,"caller":"wait/check.go:103","msg":"Success, number of status 2 has been matched"}
  {"level":"info","ts":1772702797.5116303,"caller":"test/github_comment_strategy_update_test.go:190","msg":"Found comment for PLR: pipelinerun-qhjp (ID: 61891)"}
  {"level":"info","ts":1772702797.5117464,"caller":"test/github_comment_strategy_update_test.go:190","msg":"Found comment for PLR: pipelinerun-clone-ttpo (ID: 61892)"}
  {"level":"info","ts":1772702797.5117953,"caller":"test/github_comment_strategy_update_test.go:202","msg":"Pushing empty commit to trigger pipelines again"}
  {"level":"info","ts":1772702799.3730822,"caller":"test/github_comment_strategy_update_test.go:210","msg":"Pushed trigger commit: 32f12aca49fe764c90bfba61f6b7c34970a5176c"}
  {"level":"info","ts":1772702799.3732035,"caller":"wait/check.go:31","msg":"Waiting for Repository to be updated"}
  {"level":"info","ts":1772702799.3818338,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/4"}
  {"level":"info","ts":1772702802.390728,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/4"}
  {"level":"info","ts":1772702805.3960238,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/4"}
  {"level":"info","ts":1772702808.3986602,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/4"}
  {"level":"info","ts":1772702811.397592,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/4"}
  {"level":"info","ts":1772702814.397425,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 4/4"}
  {"level":"info","ts":1772702816.3983705,"caller":"wait/check.go:46","msg":"Check if we have the repository set as succeeded"}
  {"level":"info","ts":1772702816.4126754,"caller":"wait/check.go:103","msg":"Success, number of status 4 has been matched"}
  {"level":"info","ts":1772702822.2906635,"caller":"test/github_comment_strategy_update_test.go:242","msg":"Verified PLR pipelinerun-qhjp comment was updated (ID: 61891)"}
  {"level":"info","ts":1772702822.2907782,"caller":"test/github_comment_strategy_update_test.go:242","msg":"Verified PLR pipelinerun-clone-ttpo comment was updated (ID: 61892)"}
  {"level":"info","ts":1772702822.2908359,"caller":"github/instrumentation.go:59","msg":"Attempting to collect GitHub API calls from controller: ghe-controller in namespace: "}
  {"level":"warn","ts":1772702822.2910936,"caller":"github/instrumentation.go:68","msg":"Failed to get controller logs: could not get controller logs for controller \"ghe-controller\" in namespace \"\", attempts: app.kubernetes.io/name=ghe-controller/ghe-controller: resource name may not be empty; app.kubernetes.io/component=controller,app.kubernetes.io/part-of=pipelines-as-code/ghe-controller: resource name may not be empty"}
  {"level":"info","ts":1772702822.2911665,"caller":"github/pr.go:219","msg":"Closing PR 1"}
  {"level":"info","ts":1772702823.0459957,"caller":"repository/teardown.go:32","msg":"Deleting NS pac-e2e-ns-4msmp"}
  {"level":"info","ts":1772702823.0508757,"caller":"github/pr.go:233","msg":"Deleting Ref heads/pac-e2e-test-96wrl"}
  {"level":"info","ts":1772702823.453939,"caller":"github/pr.go:240","msg":"Deleting dynamic repository akpant-test/pac-e2e-test-smcc6"}
  {"level":"info","ts":1772702823.45402,"caller":"github/scm.go:50","msg":"Deleting GitHub repository akpant-test/pac-e2e-test-smcc6"}
  {"level":"info","ts":1772702824.0290167,"caller":"github/scm.go:55","msg":"Deleted GitHub repository akpant-test/pac-e2e-test-smcc6"}
  --- PASS: TestGithubGHECommentStrategyUpdateMultiplePLRs (53.98s)
  === RUN   TestGithubGHECommentStrategyUpdateMarkerMatchingWithRegexChars
  {"level":"info","ts":1772702824.0461464,"caller":"cctx/ctx.go:19","msg":"Found pipelines-as-code installation in namespace pipelines-as-code"}
  {"level":"info","ts":1772702824.0463176,"caller":"cctx/ctx.go:22","msg":"Pipelines as Code Controller: &{Name:default Configmap:pipelines-as-code Secret:pipelines-as-code-secret GlobalRepository:pipelines-as-code}"}
  {"level":"info","ts":1772702824.046411,"caller":"github/github.go:319","msg":"github-webhook: initialized OAuth2 client for providerName=github-enterprise providerURL=https://ghe.pipelinesascode.com/api/v3"}
  {"level":"info","ts":1772702824.04648,"caller":"github/pr.go:137","msg":"Testing Github Comment Strategy Regex Chars with Github APPS integration on pac-e2e-ns-dt4d4"}
  {"level":"info","ts":1772702824.0465565,"caller":"github/pr.go:147","msg":"Creating dynamic GHE repository akpant-test/pac-e2e-test-7mjdm with webhook to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702824.0466115,"caller":"github/scm.go:16","msg":"Creating GitHub repository akpant-test/pac-e2e-test-7mjdm"}
  {"level":"info","ts":1772702825.159263,"caller":"github/scm.go:26","msg":"Created GitHub repository akpant-test/pac-e2e-test-7mjdm"}
  {"level":"info","ts":1772702825.159376,"caller":"github/scm.go:28","msg":"Adding webhook to repository akpant-test/pac-e2e-test-7mjdm pointing to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702825.4904046,"caller":"repository/create.go:17","msg":"Namespace pac-e2e-ns-dt4d4 created"}
  {"level":"info","ts":1772702825.501855,"caller":"repository/create.go:26","msg":"PipelinesAsCode Repository pac-e2e-ns-dt4d4 has been created in namespace pac-e2e-ns-dt4d4"}
  {"level":"info","ts":1772702828.1259968,"caller":"github/pr.go:185","msg":"Commit 3a7a08508d0f5940719cb1854a15f8d7116bc66f has been created and pushed to https://ghe.pipelinesascode.com/api/v3/repos/akpant-test/pac-e2e-test-7mjdm/git/refs/heads/pac-e2e-test-zvjcf"}
  {"level":"info","ts":1772702829.0200372,"caller":"github/pr.go:106","msg":"Pull request created: https://ghe.pipelinesascode.com/akpant-test/pac-e2e-test-7mjdm/pull/1"}
  {"level":"info","ts":1772702829.0201511,"caller":"wait/check.go:31","msg":"Waiting for Repository to be updated"}
  {"level":"info","ts":1772702829.0279398,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/2"}
  {"level":"info","ts":1772702832.0417314,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/2"}
  {"level":"info","ts":1772702835.042721,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/2"}
  {"level":"info","ts":1772702838.0437496,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 1/2"}
  {"level":"info","ts":1772702841.0432885,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/2"}
  {"level":"info","ts":1772702843.0434878,"caller":"wait/check.go:46","msg":"Check if we have the repository set as succeeded"}
  {"level":"info","ts":1772702843.058152,"caller":"wait/check.go:103","msg":"Success, number of status 2 has been matched"}
  {"level":"info","ts":1772702843.0582829,"caller":"wait/check.go:31","msg":"Waiting for Repository to be updated"}
  {"level":"info","ts":1772702843.0781186,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/2"}
  {"level":"info","ts":1772702845.0793223,"caller":"wait/check.go:46","msg":"Check if we have the repository set as succeeded"}
  {"level":"info","ts":1772702845.0927486,"caller":"wait/check.go:103","msg":"Success, number of status 2 has been matched"}
  {"level":"info","ts":1772702850.9650493,"caller":"test/github_comment_strategy_update_test.go:298","msg":"Found comment for PLR with special chars: test-pipeline[0] (ID: 61893)"}
  {"level":"info","ts":1772702850.965192,"caller":"test/github_comment_strategy_update_test.go:298","msg":"Found comment for PLR with special chars: test.pipeline.v1.0 (ID: 61894)"}
  {"level":"info","ts":1772702850.965256,"caller":"test/github_comment_strategy_update_test.go:332","msg":"Pushing dummy update to trigger comment refresh"}
  {"level":"info","ts":1772702852.8600008,"caller":"test/github_comment_strategy_update_test.go:340","msg":"Pushed dummy commit: b1586f8009c48b2b35be8749336a231a109d9665"}
  {"level":"info","ts":1772702852.8601236,"caller":"wait/check.go:31","msg":"Waiting for Repository to be updated"}
  {"level":"info","ts":1772702852.8696215,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/4"}
  {"level":"info","ts":1772702855.8803568,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/4"}
  {"level":"info","ts":1772702858.8821,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/4"}
  {"level":"info","ts":1772702861.8864963,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 2/4"}
  {"level":"info","ts":1772702864.8842947,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 3/4"}
  {"level":"info","ts":1772702867.8850675,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 4/4"}
  {"level":"info","ts":1772702869.885427,"caller":"wait/check.go:46","msg":"Check if we have the repository set as succeeded"}
  {"level":"info","ts":1772702869.8985357,"caller":"wait/check.go:103","msg":"Success, number of status 4 has been matched"}
  {"level":"info","ts":1772702870.7285545,"caller":"github/instrumentation.go:59","msg":"Attempting to collect GitHub API calls from controller: ghe-controller in namespace: "}
  {"level":"warn","ts":1772702870.7289157,"caller":"github/instrumentation.go:68","msg":"Failed to get controller logs: could not get controller logs for controller \"ghe-controller\" in namespace \"\", attempts: app.kubernetes.io/name=ghe-controller/ghe-controller: resource name may not be empty; app.kubernetes.io/component=controller,app.kubernetes.io/part-of=pipelines-as-code/ghe-controller: resource name may not be empty"}
  {"level":"info","ts":1772702870.728971,"caller":"github/pr.go:219","msg":"Closing PR 1"}
  {"level":"info","ts":1772702871.3666396,"caller":"repository/teardown.go:32","msg":"Deleting NS pac-e2e-ns-dt4d4"}
  {"level":"info","ts":1772702871.3704057,"caller":"github/pr.go:233","msg":"Deleting Ref heads/pac-e2e-test-zvjcf"}
  {"level":"info","ts":1772702871.7242777,"caller":"github/pr.go:240","msg":"Deleting dynamic repository akpant-test/pac-e2e-test-7mjdm"}
  {"level":"info","ts":1772702871.7243986,"caller":"github/scm.go:50","msg":"Deleting GitHub repository akpant-test/pac-e2e-test-7mjdm"}
  {"level":"info","ts":1772702872.157093,"caller":"github/scm.go:55","msg":"Deleted GitHub repository akpant-test/pac-e2e-test-7mjdm"}
  --- PASS: TestGithubGHECommentStrategyUpdateMarkerMatchingWithRegexChars (48.13s)
  === RUN   TestGithubGHEPullRequestPrivateRepositoryOnWebhook
  {"level":"info","ts":1772702872.1754303,"caller":"cctx/ctx.go:19","msg":"Found pipelines-as-code installation in namespace pipelines-as-code"}
  {"level":"info","ts":1772702872.1755712,"caller":"cctx/ctx.go:22","msg":"Pipelines as Code Controller: &{Name:default Configmap:pipelines-as-code Secret:pipelines-as-code-secret GlobalRepository:pipelines-as-code}"}
  {"level":"info","ts":1772702872.1756592,"caller":"github/github.go:319","msg":"github-webhook: initialized OAuth2 client for providerName=github-enterprise providerURL=https://ghe.pipelinesascode.com/api/v3"}
  {"level":"info","ts":1772702872.1757207,"caller":"github/pr.go:137","msg":"Testing Github GHE Rerequest with Github APPS integration on pac-e2e-ns-prmvs"}
  {"level":"info","ts":1772702872.1757782,"caller":"github/pr.go:147","msg":"Creating dynamic GHE repository akpant-test/pac-e2e-test-qpmn4 with webhook to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702872.1758182,"caller":"github/scm.go:16","msg":"Creating GitHub repository akpant-test/pac-e2e-test-qpmn4"}
  {"level":"info","ts":1772702872.8931704,"caller":"github/scm.go:26","msg":"Created GitHub repository akpant-test/pac-e2e-test-qpmn4"}
  {"level":"info","ts":1772702872.893285,"caller":"github/scm.go:28","msg":"Adding webhook to repository akpant-test/pac-e2e-test-qpmn4 pointing to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702873.5001333,"caller":"repository/create.go:17","msg":"Namespace pac-e2e-ns-prmvs created"}
  {"level":"info","ts":1772702873.5144844,"caller":"repository/create.go:26","msg":"PipelinesAsCode Repository pac-e2e-ns-prmvs has been created in namespace pac-e2e-ns-prmvs"}
  {"level":"info","ts":1772702875.9671779,"caller":"github/pr.go:185","msg":"Commit 0ffb9826773b95d5b6a5ece187487b4b0fbf65ad has been created and pushed to https://ghe.pipelinesascode.com/api/v3/repos/akpant-test/pac-e2e-test-qpmn4/git/refs/heads/pac-e2e-test-9w2p8"}
  {"level":"info","ts":1772702876.869521,"caller":"github/pr.go:106","msg":"Pull request created: https://ghe.pipelinesascode.com/akpant-test/pac-e2e-test-qpmn4/pull/1"}
  {"level":"info","ts":1772702876.8696299,"caller":"wait/check.go:31","msg":"Waiting for Repository to be updated"}
  {"level":"info","ts":1772702876.8752713,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702879.8847184,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702882.8931813,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702885.8961732,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702888.8940485,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702891.8942525,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702894.89177,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702897.8942313,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702900.894141,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702903.8943331,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702906.8942602,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702909.896131,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702912.8949933,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702915.893107,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702918.8934212,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702921.8927472,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702924.8945692,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702927.8935988,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702930.8936777,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702933.8948708,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702936.8941479,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702939.8919847,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702942.8946583,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702945.891988,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702948.8944707,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 1/1"}
  {"level":"info","ts":1772702950.8955748,"caller":"wait/check.go:46","msg":"Check if we have the repository set as succeeded"}
  {"level":"info","ts":1772702950.9136066,"caller":"wait/check.go:103","msg":"Success, number of status 1 has been matched"}
  {"level":"info","ts":1772702950.9137037,"caller":"github/instrumentation.go:59","msg":"Attempting to collect GitHub API calls from controller: ghe-controller in namespace: "}
  {"level":"warn","ts":1772702950.9139054,"caller":"github/instrumentation.go:68","msg":"Failed to get controller logs: could not get controller logs for controller \"ghe-controller\" in namespace \"\", attempts: app.kubernetes.io/name=ghe-controller/ghe-controller: resource name may not be empty; app.kubernetes.io/component=controller,app.kubernetes.io/part-of=pipelines-as-code/ghe-controller: resource name may not be empty"}
  {"level":"info","ts":1772702950.9139683,"caller":"github/pr.go:219","msg":"Closing PR 1"}
  {"level":"info","ts":1772702952.0372076,"caller":"repository/teardown.go:32","msg":"Deleting NS pac-e2e-ns-prmvs"}
  {"level":"info","ts":1772702952.0430155,"caller":"github/pr.go:233","msg":"Deleting Ref heads/pac-e2e-test-9w2p8"}
  {"level":"info","ts":1772702952.386728,"caller":"github/pr.go:240","msg":"Deleting dynamic repository akpant-test/pac-e2e-test-qpmn4"}
  {"level":"info","ts":1772702952.3868392,"caller":"github/scm.go:50","msg":"Deleting GitHub repository akpant-test/pac-e2e-test-qpmn4"}
  {"level":"info","ts":1772702952.9550269,"caller":"github/scm.go:55","msg":"Deleted GitHub repository akpant-test/pac-e2e-test-qpmn4"}
  --- PASS: TestGithubGHEPullRequestPrivateRepositoryOnWebhook (80.80s)
  === RUN   TestGithubGHEPullRequestWebhook
  {"level":"info","ts":1772702952.9713104,"caller":"cctx/ctx.go:19","msg":"Found pipelines-as-code installation in namespace pipelines-as-code"}
  {"level":"info","ts":1772702952.9714751,"caller":"cctx/ctx.go:22","msg":"Pipelines as Code Controller: &{Name:default Configmap:pipelines-as-code Secret:pipelines-as-code-secret GlobalRepository:pipelines-as-code}"}
  {"level":"info","ts":1772702952.9715712,"caller":"github/github.go:319","msg":"github-webhook: initialized OAuth2 client for providerName=github-enterprise providerURL=https://ghe.pipelinesascode.com/api/v3"}
  {"level":"info","ts":1772702952.9716418,"caller":"github/pr.go:137","msg":"Testing Github GHE PullRequest onWebhook with Github APPS integration on pac-e2e-ns-vk95p"}
  {"level":"info","ts":1772702952.9717047,"caller":"github/pr.go:147","msg":"Creating dynamic GHE repository akpant-test/pac-e2e-test-6ch7h with webhook to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702952.9717624,"caller":"github/scm.go:16","msg":"Creating GitHub repository akpant-test/pac-e2e-test-6ch7h"}
  {"level":"info","ts":1772702953.8054476,"caller":"github/scm.go:26","msg":"Created GitHub repository akpant-test/pac-e2e-test-6ch7h"}
  {"level":"info","ts":1772702953.8055534,"caller":"github/scm.go:28","msg":"Adding webhook to repository akpant-test/pac-e2e-test-6ch7h pointing to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702954.3951936,"caller":"repository/create.go:17","msg":"Namespace pac-e2e-ns-vk95p created"}
  {"level":"info","ts":1772702954.406622,"caller":"repository/create.go:26","msg":"PipelinesAsCode Repository pac-e2e-ns-vk95p has been created in namespace pac-e2e-ns-vk95p"}
  {"level":"info","ts":1772702956.5378945,"caller":"github/pr.go:185","msg":"Commit 7b33efa343754c938388020aec244412b3029639 has been created and pushed to https://ghe.pipelinesascode.com/api/v3/repos/akpant-test/pac-e2e-test-6ch7h/git/refs/heads/pac-e2e-test-9pmrh"}
  {"level":"info","ts":1772702958.0193996,"caller":"github/pr.go:106","msg":"Pull request created: https://ghe.pipelinesascode.com/akpant-test/pac-e2e-test-6ch7h/pull/1"}
  {"level":"info","ts":1772702958.019528,"caller":"wait/check.go:31","msg":"Waiting for Repository to be updated"}
  {"level":"info","ts":1772702958.027541,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702961.0365784,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702964.0414882,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702967.0394602,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702970.0414567,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 1/1"}
  {"level":"info","ts":1772702972.042589,"caller":"wait/check.go:46","msg":"Check if we have the repository set as succeeded"}
  {"level":"info","ts":1772702972.0563273,"caller":"wait/check.go:103","msg":"Success, number of status 1 has been matched"}
  {"level":"info","ts":1772702972.0564775,"caller":"github/instrumentation.go:59","msg":"Attempting to collect GitHub API calls from controller: ghe-controller in namespace: "}
  {"level":"warn","ts":1772702972.0567844,"caller":"github/instrumentation.go:68","msg":"Failed to get controller logs: could not get controller logs for controller \"ghe-controller\" in namespace \"\", attempts: app.kubernetes.io/name=ghe-controller/ghe-controller: resource name may not be empty; app.kubernetes.io/component=controller,app.kubernetes.io/part-of=pipelines-as-code/ghe-controller: resource name may not be empty"}
  {"level":"info","ts":1772702972.0568726,"caller":"github/pr.go:219","msg":"Closing PR 1"}
  {"level":"info","ts":1772702973.1483722,"caller":"repository/teardown.go:32","msg":"Deleting NS pac-e2e-ns-vk95p"}
  {"level":"info","ts":1772702973.1539197,"caller":"github/pr.go:233","msg":"Deleting Ref heads/pac-e2e-test-9pmrh"}
  {"level":"info","ts":1772702973.548409,"caller":"github/pr.go:240","msg":"Deleting dynamic repository akpant-test/pac-e2e-test-6ch7h"}
  {"level":"info","ts":1772702973.5485,"caller":"github/scm.go:50","msg":"Deleting GitHub repository akpant-test/pac-e2e-test-6ch7h"}
  {"level":"info","ts":1772702973.9452126,"caller":"github/scm.go:55","msg":"Deleted GitHub repository akpant-test/pac-e2e-test-6ch7h"}
  --- PASS: TestGithubGHEPullRequestWebhook (20.99s)
  === RUN   TestGithubGHEDisableCommentsOnPR
  {"level":"info","ts":1772702973.9650009,"caller":"cctx/ctx.go:19","msg":"Found pipelines-as-code installation in namespace pipelines-as-code"}
  {"level":"info","ts":1772702973.9651883,"caller":"cctx/ctx.go:22","msg":"Pipelines as Code Controller: &{Name:default Configmap:pipelines-as-code Secret:pipelines-as-code-secret GlobalRepository:pipelines-as-code}"}
  {"level":"info","ts":1772702973.9653099,"caller":"github/github.go:319","msg":"github-webhook: initialized OAuth2 client for providerName=github-enterprise providerURL=https://ghe.pipelinesascode.com/api/v3"}
  {"level":"info","ts":1772702973.965382,"caller":"github/pr.go:137","msg":"Testing Github GHE PullRequest onWebhook with Github APPS integration on pac-e2e-ns-qsbs8"}
  {"level":"info","ts":1772702973.965473,"caller":"github/pr.go:147","msg":"Creating dynamic GHE repository akpant-test/pac-e2e-test-mzwrf with webhook to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702973.965515,"caller":"github/scm.go:16","msg":"Creating GitHub repository akpant-test/pac-e2e-test-mzwrf"}
  {"level":"info","ts":1772702974.9058697,"caller":"github/scm.go:26","msg":"Created GitHub repository akpant-test/pac-e2e-test-mzwrf"}
  {"level":"info","ts":1772702974.9059727,"caller":"github/scm.go:28","msg":"Adding webhook to repository akpant-test/pac-e2e-test-mzwrf pointing to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702975.4154305,"caller":"repository/create.go:17","msg":"Namespace pac-e2e-ns-qsbs8 created"}
  {"level":"info","ts":1772702975.4273183,"caller":"repository/create.go:26","msg":"PipelinesAsCode Repository pac-e2e-ns-qsbs8 has been created in namespace pac-e2e-ns-qsbs8"}
  {"level":"info","ts":1772702977.8830462,"caller":"github/pr.go:185","msg":"Commit 72194692ba9be868ae93a3566c38fbd03f03a8e4 has been created and pushed to https://ghe.pipelinesascode.com/api/v3/repos/akpant-test/pac-e2e-test-mzwrf/git/refs/heads/pac-e2e-test-h5mtz"}
  {"level":"info","ts":1772702978.7692523,"caller":"github/pr.go:106","msg":"Pull request created: https://ghe.pipelinesascode.com/akpant-test/pac-e2e-test-mzwrf/pull/1"}
  {"level":"info","ts":1772702978.769365,"caller":"wait/check.go:31","msg":"Waiting for Repository to be updated"}
  {"level":"info","ts":1772702978.7797432,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702981.790678,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702984.7927501,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772702987.7936647,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 1/1"}
  {"level":"info","ts":1772702989.7944403,"caller":"wait/check.go:46","msg":"Check if we have the repository set as succeeded"}
  {"level":"info","ts":1772702989.8053215,"caller":"wait/check.go:103","msg":"Success, number of status 1 has been matched"}
  {"level":"info","ts":1772702990.5919747,"caller":"github/instrumentation.go:59","msg":"Attempting to collect GitHub API calls from controller: ghe-controller in namespace: "}
  {"level":"warn","ts":1772702990.592286,"caller":"github/instrumentation.go:68","msg":"Failed to get controller logs: could not get controller logs for controller \"ghe-controller\" in namespace \"\", attempts: app.kubernetes.io/name=ghe-controller/ghe-controller: resource name may not be empty; app.kubernetes.io/component=controller,app.kubernetes.io/part-of=pipelines-as-code/ghe-controller: resource name may not be empty"}
  {"level":"info","ts":1772702990.592367,"caller":"github/pr.go:219","msg":"Closing PR 1"}
  {"level":"info","ts":1772702991.2684174,"caller":"repository/teardown.go:32","msg":"Deleting NS pac-e2e-ns-qsbs8"}
  {"level":"info","ts":1772702991.2726738,"caller":"github/pr.go:233","msg":"Deleting Ref heads/pac-e2e-test-h5mtz"}
  {"level":"info","ts":1772702991.6590219,"caller":"github/pr.go:240","msg":"Deleting dynamic repository akpant-test/pac-e2e-test-mzwrf"}
  {"level":"info","ts":1772702991.6591182,"caller":"github/scm.go:50","msg":"Deleting GitHub repository akpant-test/pac-e2e-test-mzwrf"}
  {"level":"info","ts":1772702992.171605,"caller":"github/scm.go:55","msg":"Deleted GitHub repository akpant-test/pac-e2e-test-mzwrf"}
  --- PASS: TestGithubGHEDisableCommentsOnPR (18.23s)
  === RUN   TestGithubGHEPushWebhook
  {"level":"info","ts":1772702992.1904793,"caller":"cctx/ctx.go:19","msg":"Found pipelines-as-code installation in namespace pipelines-as-code"}
  {"level":"info","ts":1772702992.190601,"caller":"cctx/ctx.go:22","msg":"Pipelines as Code Controller: &{Name:default Configmap:pipelines-as-code Secret:pipelines-as-code-secret GlobalRepository:pipelines-as-code}"}
  {"level":"info","ts":1772702992.190687,"caller":"github/github.go:319","msg":"github-webhook: initialized OAuth2 client for providerName=github-enterprise providerURL=https://ghe.pipelinesascode.com/api/v3"}
  {"level":"info","ts":1772702992.1907492,"caller":"github/pr.go:261","msg":"Testing Github GHE push request on Webhook with Direct Webhook integration on pac-e2e-push-fqs2h"}
  {"level":"info","ts":1772702992.1908085,"caller":"github/pr.go:275","msg":"Creating dynamic GHE repository akpant-test/pac-e2e-test-f8jd2 with webhook to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702992.1908476,"caller":"github/scm.go:16","msg":"Creating GitHub repository akpant-test/pac-e2e-test-f8jd2"}
  {"level":"info","ts":1772702993.0950906,"caller":"github/scm.go:26","msg":"Created GitHub repository akpant-test/pac-e2e-test-f8jd2"}
  {"level":"info","ts":1772702993.095204,"caller":"github/scm.go:28","msg":"Adding webhook to repository akpant-test/pac-e2e-test-f8jd2 pointing to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772702993.6129823,"caller":"repository/create.go:17","msg":"Namespace pac-e2e-push-fqs2h created"}
  {"level":"info","ts":1772702993.625044,"caller":"repository/create.go:26","msg":"PipelinesAsCode Repository pac-e2e-push-fqs2h has been created in namespace pac-e2e-push-fqs2h"}
  {"level":"info","ts":1772702998.5196006,"caller":"scm/scm.go:48","msg":"Pushed files to repo https://ghe.pipelinesascode.com/akpant-test/pac-e2e-test-f8jd2 branch pac-e2e-push-fqs2h"}
  {"level":"info","ts":1772703004.5730386,"caller":"github/pr.go:317","msg":"Commit 6a70ece49fd1fb73d0311d1a4869080c116a12a0 has been created and pushed to https://ghe.pipelinesascode.com/akpant-test/pac-e2e-test-f8jd2/commit/6a70ece49fd1fb73d0311d1a4869080c116a12a0 in branch pac-e2e-push-fqs2h"}
  {"level":"info","ts":1772703004.573152,"caller":"wait/check.go:31","msg":"Waiting for Repository to be updated"}
  {"level":"info","ts":1772703004.5839045,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703007.595186,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703010.5967386,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703013.5952053,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703016.595162,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703019.5943427,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703022.5973194,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703025.5989618,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703028.595725,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703031.5941243,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703034.5959496,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703037.5962746,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703040.5970755,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 1/1"}
  {"level":"info","ts":1772703042.5974793,"caller":"wait/check.go:46","msg":"Check if we have the repository set as succeeded"}
  {"level":"info","ts":1772703042.6103828,"caller":"wait/check.go:103","msg":"Success, number of status 1 has been matched"}
  {"level":"info","ts":1772703042.6105294,"caller":"github/instrumentation.go:59","msg":"Attempting to collect GitHub API calls from controller: ghe-controller in namespace: "}
  {"level":"warn","ts":1772703042.6107903,"caller":"github/instrumentation.go:68","msg":"Failed to get controller logs: could not get controller logs for controller \"ghe-controller\" in namespace \"\", attempts: app.kubernetes.io/name=ghe-controller/ghe-controller: resource name may not be empty; app.kubernetes.io/component=controller,app.kubernetes.io/part-of=pipelines-as-code/ghe-controller: resource name may not be empty"}
  {"level":"info","ts":1772703042.634642,"caller":"repository/teardown.go:32","msg":"Deleting NS pac-e2e-push-fqs2h"}
  {"level":"info","ts":1772703042.6400642,"caller":"github/pr.go:233","msg":"Deleting Ref heads/pac-e2e-push-fqs2h"}
  {"level":"info","ts":1772703043.4273546,"caller":"github/pr.go:240","msg":"Deleting dynamic repository akpant-test/pac-e2e-test-f8jd2"}
  {"level":"info","ts":1772703043.427426,"caller":"github/scm.go:50","msg":"Deleting GitHub repository akpant-test/pac-e2e-test-f8jd2"}
  {"level":"info","ts":1772703043.7958043,"caller":"github/scm.go:55","msg":"Deleted GitHub repository akpant-test/pac-e2e-test-f8jd2"}
  --- PASS: TestGithubGHEPushWebhook (51.62s)
  PASS
  ok      github.com/openshift-pipelines/pipelines-as-code/test   328.180s

  go test -v -race -failfast -timeout 45m -count=1 -tags=e2e -run "^(TestGithubGHEWebhookIncoming)$" ./test
  === RUN   TestGithubGHEWebhookIncoming
  {"level":"info","ts":1772703468.8584476,"caller":"cctx/ctx.go:19","msg":"Found pipelines-as-code installation in namespace pipelines-as-code"}
  {"level":"info","ts":1772703468.8586395,"caller":"cctx/ctx.go:22","msg":"Pipelines as Code Controller: &{Name:default Configmap:pipelines-as-code Secret:pipelines-as-code-secret GlobalRepository:pipelines-as-code}"}
  {"level":"info","ts":1772703468.8587692,"caller":"github/github.go:319","msg":"github-webhook: initialized OAuth2 client for providerName=github-enterprise providerURL=https://ghe.pipelinesascode.com/api/v3"}
  {"level":"info","ts":1772703468.8588736,"caller":"test/github_incoming_test.go:192","msg":"Testing GithubApp Incoming with Github APPS integration on pac-e2e-ns-2svjg with targets [pac-e2e-ns-2svjg]"}
  {"level":"info","ts":1772703468.8589706,"caller":"test/github_incoming_test.go:203","msg":"Creating dynamic GHE repository akpant-test/pac-e2e-test-nhlxh with webhook to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772703468.8590207,"caller":"github/scm.go:12","msg":"Creating GitHub repository akpant-test/pac-e2e-test-nhlxh"}
  {"level":"info","ts":1772703470.9034228,"caller":"github/scm.go:22","msg":"Created GitHub repository akpant-test/pac-e2e-test-nhlxh"}
  {"level":"info","ts":1772703470.9035878,"caller":"github/scm.go:24","msg":"Adding webhook to repository akpant-test/pac-e2e-test-nhlxh pointing to https://hook.pipelinesascode.com/kVKGWWgBkHTo"}
  {"level":"info","ts":1772703471.2443357,"caller":"repository/create.go:17","msg":"Namespace pac-e2e-ns-2svjg created"}
  {"level":"info","ts":1772703471.2614696,"caller":"repository/create.go:26","msg":"PipelinesAsCode Repository pac-e2e-ns-2svjg has been created in namespace pac-e2e-ns-2svjg"}
  {"level":"info","ts":1772703473.76445,"caller":"test/github_incoming_test.go:249","msg":"Commit 9c114879582be581efaa8f02325398af4fac395f has been created and pushed to branch https://ghe.pipelinesascode.com/api/v3/repos/akpant-test/pac-e2e-test-nhlxh/git/refs/heads/pac-e2e-ns-2svjg"}
  {"level":"info","ts":1772703473.7800856,"caller":"test/github_incoming_test.go:305","msg":"Kicked off on incoming URL: http://controller.paac-127-0-0-1.nip.io/incoming?repository=pac-e2e-ns-2svjg&branch=pac-e2e-ns-2svjg&pipelinerun=pipelinerun-incoming&secret=shhhh-secrete with branch: pac-e2e-ns-2svjg, targets: [pac-e2e-ns-2svjg]"}
  {"level":"info","ts":1772703473.7802353,"caller":"wait/check.go:31","msg":"Waiting for Repository to be updated"}
  {"level":"info","ts":1772703473.7968285,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703476.8080883,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703479.8073847,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703482.8081982,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 0/1"}
  {"level":"info","ts":1772703485.8074791,"caller":"wait/wait.go:75","msg":"Still waiting for repository status to be updated: 1/1"}
  {"level":"info","ts":1772703487.808613,"caller":"wait/check.go:46","msg":"Check if we have the repository set as succeeded"}
  {"level":"info","ts":1772703487.820913,"caller":"wait/check.go:103","msg":"Success, number of status 1 has been matched"}
  {"level":"info","ts":1772703487.82662,"caller":"wait/logs.go:54","msg":"looking for regexp .*It's a Bird... It's a Plane... It's Superman in namespace: pac-e2e-ns-2svjg for label pipelinesascode.tekton.dev/event-type=incoming and container step-task"}
  {"level":"info","ts":1772703487.8459792,"caller":"wait/logs.go:70","msg":"matched regexp .*It's a Bird... It's a Plane... It's Superman in labelSelector/container pipelinesascode.tekton.dev/event-type=incoming:step-task"}
  {"level":"info","ts":1772703487.8461132,"caller":"github/instrumentation.go:59","msg":"Attempting to collect GitHub API calls from controller: ghe-controller in namespace: pipelines-as-code"}
  {"level":"warn","ts":1772703487.855968,"caller":"github/instrumentation.go:68","msg":"Failed to get controller logs: could not get controller logs for controller \"ghe-controller\" in namespace \"pipelines-as-code\", attempts: app.kubernetes.io/name=ghe-controller/ghe-controller: could not match any pod to label selector: app.kubernetes.io/name=ghe-controller; app.kubernetes.io/component=controller,app.kubernetes.io/part-of=pipelines-as-code/ghe-controller: could not find logs for label selector \"app.kubernetes.io/component=controller,app.kubernetes.io/part-of=pipelines-as-code\": container \"ghe-controller\" is not present in any pod: pipelines-as-code-controller-7579467d78-7g8cn[pac-controller]"}
  {"level":"info","ts":1772703487.8742447,"caller":"repository/teardown.go:32","msg":"Deleting NS pac-e2e-ns-2svjg"}
  {"level":"info","ts":1772703487.8786962,"caller":"github/pr.go:242","msg":"Deleting dynamic repository akpant-test/pac-e2e-test-nhlxh"}
  {"level":"info","ts":1772703487.8787632,"caller":"github/scm.go:46","msg":"Deleting GitHub repository akpant-test/pac-e2e-test-nhlxh"}
  {"level":"info","ts":1772703488.6748273,"caller":"github/scm.go:51","msg":"Deleted GitHub repository akpant-test/pac-e2e-test-nhlxh"}
  --- PASS: TestGithubGHEWebhookIncoming (19.85s)
  PASS
  ok      github.com/openshift-pipelines/pipelines-as-code/test   20.929s
  
</details>

## 👨🏻‍ Linked Jira
N/A
<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [x] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
