### PR TITLE
ci: correct cache-fetch step reference in pipelines

### DIFF
--- a/.tekton/generate-coverage-release.yaml
+++ b/.tekton/generate-coverage-release.yaml
@@ -134,7 +134,7 @@ spec:
                 - name: target
                   value: oci://image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/cache-go:{{hash}}
                 - name: fetched
-                  value: $(tasks.cached-fetch.results.fetched)
+                  value: $(steps.cache-fetch.results.fetched)
                 - name: cachePath
                   value: $(workspaces.source.path)/go-build-cache
                 - name: workingdir

--- a/.tekton/go.yaml
+++ b/.tekton/go.yaml
@@ -122,7 +122,7 @@ spec:
                 - name: target
                   value: oci://image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/cache-go:{{hash}}
                 - name: fetched
-                  value: $(tasks.cached-fetch.results.fetched)
+                  value: $(steps.cache-fetch.results.fetched)
                 - name: cachePath
                   value: $(workspaces.source.path)/go-build-cache
                 - name: workingdir


### PR DESCRIPTION
## 📝 Description of the Change
Fix Go module cache mechanism in Tekton CI pipelines by correcting the step result reference in cache-upload steps.                                                                         
                                                                                            
### Problem                                                                                      

The Go module cache configured in `.tekton/go.yaml` and `.tekton/generate-coverage-release.yaml` was not working effectively - modules were being re-downloaded on every pipeline run despite successful cache fetches.
Root cause: The cache-upload step was using incorrect syntax to reference the fetched result from the cache-fetch step, causing the variable to remain unexpanded as a literal string.

### Changes

Fixed in both pipeline files:

Before:
```yaml
- name: fetched
  value: $(tasks.cached-fetch.results.fetched)
```

After:
```yaml
- name: fetched
  value: $(steps.cache-fetch.results.fetched)
```

### Two bugs corrected:

- Wrong reference type: tasks → steps
  - Both `cache-fetch` and `cache-upload` are steps within the same task
- Typo in step name: `cached-fetch` → `cache-fetch`

### How It Works

Result Flow:

1. cache-fetch emits result (writes to own result):
    ```bash
    if [ $? -eq 0 ]; then
      echo -n true > $(step.results.fetched.path)   # Cache hit
    else
      echo -n false > $(step.results.fetched.path)  # Cache miss
    fi
    ```
2. cache-upload consumes result (reads from previous step):
    ```yaml
    - name: fetched
      value: $(steps.cache-fetch.results.fetched)  # Expands to "true" or "false"
    ```
3. Upload logic evaluates correctly:
    ```yaml
    if [[ ${PARAM_FORCE_CACHE_UPLOAD} == "false" && ${RESULT_CACHE_FETCHED} == "true" ]]; then
      echo "no need to upload cache"
      exit 0
    fi
    ```

### Before This Fix

Pipeline logs showed the variable was not being substituted:
```bash
+ [[ $(tasks.cached-fetch.results.fetched) == \t\r\u\e ]]
```
Tekton couldn't resolve tasks.cached-fetch (doesn't exist), so it left the literal string unexpanded. This never equals "true", causing cache upload to run unnecessarily on every pipeline execution.

### After This Fix

The variable gets properly substituted:
```bash
+ [[ true == \t\r\u\e ]]  # When cache was successfully fetched
```

Now when cache is hit, the upload step correctly skips with "no need to upload cache", avoiding redundant uploads and enabling proper cache reuse.
## 👨🏻‍ Linked Jira
N/A
<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue
Fixes #2533

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
