### PR TITLE
refactor(test): restructure GitHub GHE test setup

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,42 +55,56 @@ jobs:
           ]
 
     env:
+      # Common/Infra
       CONTROLLER_DOMAIN_URL: paac.paac-127-0-0-1.nip.io
       KOCACHE: /tmp/ko-cache
       KO_DOCKER_REPO: registry.paac-127-0-0-1.nip.io
       KUBECONFIG: /home/runner/.kube/config.local
       TARGET_TEAM_SLUGS: "pipeline-as-code,pipeline-as-code-contributors"
-      TEST_BITBUCKET_CLOUD_API_URL: https://api.bitbucket.org/2.0
-      TEST_BITBUCKET_CLOUD_E2E_REPOSITORY: cboudjna/pac-e2e-tests
-      TEST_BITBUCKET_CLOUD_TOKEN: ${{ secrets.BITBUCKET_CLOUD_TOKEN }}
-      TEST_BITBUCKET_CLOUD_USER: cboudjna
-      TEST_BITBUCKET_SERVER_API_URL: ${{ secrets.BITBUCKET_SERVER_API_URL }}
-      TEST_BITBUCKET_SERVER_E2E_REPOSITORY: PAC/pac-e2e-tests
-      TEST_BITBUCKET_SERVER_TOKEN: ${{ secrets.BITBUCKET_SERVER_TOKEN }}
-      TEST_BITBUCKET_SERVER_USER: pipelines
-      TEST_BITBUCKET_SERVER_WEBHOOK_SECRET: ${{ secrets.BITBUCKET_SERVER_WEBHOOK_SECRET }}
       TEST_EL_URL: https://paac.paac-127-0-0-1.nip.io
       TEST_EL_WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
-      TEST_GITEA_API_URL: http://localhost:3000
-      TEST_GITEA_INTERNAL_URL: http://forgejo-http.forgejo.svc.cluster.local:3000
-      TEST_GITEA_PASSWORD: pac
-      TEST_GITEA_REPO_OWNER: pac/pac
-      TEST_GITEA_USERNAME: pac
+
+      # GitHub (Public)
       TEST_GITHUB_API_URL: api.github.com
       TEST_GITHUB_PRIVATE_TASK_NAME: task-remote
       TEST_GITHUB_PRIVATE_TASK_URL: https://github.com/openshift-pipelines/pipelines-as-code-e2e-tests-private/blob/main/remote_task.yaml
       TEST_GITHUB_REPO_INSTALLATION_ID: ${{ vars.INSTALLATION_ID }}
       TEST_GITHUB_REPO_OWNER_GITHUBAPP: openshift-pipelines/pipelines-as-code-e2e-tests
       TEST_GITHUB_REPO_OWNER_WEBHOOK: openshift-pipelines/pipelines-as-code-e2e-tests-webhook
+      TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
+
+      # GitHub Enterprise (Second)
       TEST_GITHUB_SECOND_API_URL: ghe.pipelinesascode.com
       TEST_GITHUB_SECOND_EL_URL: https://ghe.paac-127-0-0-1.nip.io
       TEST_GITHUB_SECOND_REPO_INSTALLATION_ID: 1
       TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP: pipelines-as-code/e2e
-      TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
       TEST_GITHUB_SECOND_SMEE_URL: ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}
+      TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
       TEST_GITHUB_SECOND_WEBHOOK_ORG: pac-e2e-webhook-tests
-      TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
+      TEST_GITHUB_SECOND_WEBHOOK_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_WEBHOOK_TOKEN }}
+
+      # GitLab
       TEST_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+
+      # Gitea
+      TEST_GITEA_API_URL: http://localhost:3000
+      TEST_GITEA_INTERNAL_URL: http://forgejo-http.forgejo.svc.cluster.local:3000
+      TEST_GITEA_PASSWORD: pac
+      TEST_GITEA_REPO_OWNER: pac/pac
+      TEST_GITEA_USERNAME: pac
+
+      # Bitbucket Cloud
+      TEST_BITBUCKET_CLOUD_API_URL: https://api.bitbucket.org/2.0
+      TEST_BITBUCKET_CLOUD_E2E_REPOSITORY: cboudjna/pac-e2e-tests
+      TEST_BITBUCKET_CLOUD_TOKEN: ${{ secrets.BITBUCKET_CLOUD_TOKEN }}
+      TEST_BITBUCKET_CLOUD_USER: cboudjna
+
+      # Bitbucket Server
+      TEST_BITBUCKET_SERVER_API_URL: ${{ secrets.BITBUCKET_SERVER_API_URL }}
+      TEST_BITBUCKET_SERVER_E2E_REPOSITORY: PAC/pac-e2e-tests
+      TEST_BITBUCKET_SERVER_TOKEN: ${{ secrets.BITBUCKET_SERVER_TOKEN }}
+      TEST_BITBUCKET_SERVER_USER: pipelines
+      TEST_BITBUCKET_SERVER_WEBHOOK_SECRET: ${{ secrets.BITBUCKET_SERVER_WEBHOOK_SECRET }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -359,48 +373,62 @@ jobs:
         uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3
         # add all environment so we can debug easily
         env:
+          # Common/Infra
           CONTROLLER_DOMAIN_URL: paac.paac-127-0-0-1.nip.io
           KOCACHE: /tmp/ko-cache
           KO_DOCKER_REPO: registry.paac-127-0-0-1.nip.io
           KUBECONFIG: /home/runner/.kube/config.local
           TARGET_TEAM_SLUGS: "pipeline-as-code,pipeline-as-code-contributors"
-          TEST_BITBUCKET_CLOUD_API_URL: https://api.bitbucket.org/2.0
-          TEST_BITBUCKET_CLOUD_E2E_REPOSITORY: cboudjna/pac-e2e-tests
-          TEST_BITBUCKET_CLOUD_TOKEN: ${{ secrets.BITBUCKET_CLOUD_TOKEN }}
-          TEST_BITBUCKET_CLOUD_USER: cboudjna
-          TEST_BITBUCKET_SERVER_API_URL: ${{ secrets.BITBUCKET_SERVER_API_URL }}
-          TEST_BITBUCKET_SERVER_E2E_REPOSITORY: PAC/pac-e2e-tests
-          TEST_BITBUCKET_SERVER_TOKEN: ${{ secrets.BITBUCKET_SERVER_TOKEN }}
-          TEST_BITBUCKET_SERVER_USER: pipelines
-          TEST_BITBUCKET_SERVER_WEBHOOK_SECRET: ${{ secrets.BITBUCKET_SERVER_WEBHOOK_SECRET }}
           TEST_EL_URL: https://paac.paac-127-0-0-1.nip.io
           TEST_EL_WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
-          TEST_GITEA_API_URL: http://localhost:3000
-          TEST_GITEA_INTERNAL_URL: http://forgejo-http.forgejo.svc.cluster.local:3000
-          TEST_GITEA_PASSWORD: pac
-          TEST_GITEA_REPO_OWNER: pac/pac
-          TEST_GITEA_USERNAME: pac
+          TEST_PROVIDER: ${{ matrix.provider }}
+
+          # GitHub (Public)
           TEST_GITHUB_API_URL: api.github.com
           TEST_GITHUB_PRIVATE_TASK_NAME: task-remote
           TEST_GITHUB_PRIVATE_TASK_URL: https://github.com/openshift-pipelines/pipelines-as-code-e2e-tests-private/blob/main/remote_task.yaml
           TEST_GITHUB_REPO_INSTALLATION_ID: ${{ vars.INSTALLATION_ID }}
           TEST_GITHUB_REPO_OWNER_GITHUBAPP: openshift-pipelines/pipelines-as-code-e2e-tests
           TEST_GITHUB_REPO_OWNER_WEBHOOK: openshift-pipelines/pipelines-as-code-e2e-tests-webhook
+          TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
+
+          # GitHub Enterprise (Second)
           TEST_GITHUB_SECOND_API_URL: ghe.pipelinesascode.com
           TEST_GITHUB_SECOND_APPLICATION_ID: ${{ vars.TEST_GITHUB_SECOND_APPLICATION_ID }}
           TEST_GITHUB_SECOND_EL_URL: https://ghe.paac-127-0-0-1.nip.io
           TEST_GITHUB_SECOND_REPO_INSTALLATION_ID: 1
           TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP: pipelines-as-code/e2e
+          TEST_GITHUB_SECOND_SMEE_URL: ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}
           TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
           TEST_GITHUB_SECOND_WEBHOOK_ORG: pac-e2e-webhook-tests
-          TEST_GITHUB_SECOND_SMEE_URL: ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}
           TEST_GITHUB_SECOND_WEBHOOK_SECRET: ${{ secrets.TEST_GITHUB_SECOND_WEBHOOK_SECRET }}
-          TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
+          TEST_GITHUB_SECOND_WEBHOOK_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_WEBHOOK_TOKEN }}
+
+          # GitLab
           TEST_GITLAB_API_URL: https://gitlab.com
           TEST_GITLAB_GROUP: pac-e2e-tests
           TEST_GITLAB_SMEEURL: ${{ env.TEST_GITLAB_SMEEURL }}
           TEST_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-          TEST_PROVIDER: ${{ matrix.provider }}
+
+          # Gitea
+          TEST_GITEA_API_URL: http://localhost:3000
+          TEST_GITEA_INTERNAL_URL: http://forgejo-http.forgejo.svc.cluster.local:3000
+          TEST_GITEA_PASSWORD: pac
+          TEST_GITEA_REPO_OWNER: pac/pac
+          TEST_GITEA_USERNAME: pac
+
+          # Bitbucket Cloud
+          TEST_BITBUCKET_CLOUD_API_URL: https://api.bitbucket.org/2.0
+          TEST_BITBUCKET_CLOUD_E2E_REPOSITORY: cboudjna/pac-e2e-tests
+          TEST_BITBUCKET_CLOUD_TOKEN: ${{ secrets.BITBUCKET_CLOUD_TOKEN }}
+          TEST_BITBUCKET_CLOUD_USER: cboudjna
+
+          # Bitbucket Server
+          TEST_BITBUCKET_SERVER_API_URL: ${{ secrets.BITBUCKET_SERVER_API_URL }}
+          TEST_BITBUCKET_SERVER_E2E_REPOSITORY: PAC/pac-e2e-tests
+          TEST_BITBUCKET_SERVER_TOKEN: ${{ secrets.BITBUCKET_SERVER_TOKEN }}
+          TEST_BITBUCKET_SERVER_USER: pipelines
+          TEST_BITBUCKET_SERVER_WEBHOOK_SECRET: ${{ secrets.BITBUCKET_SERVER_WEBHOOK_SECRET }}
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
         with:
           detached: true
@@ -468,6 +496,7 @@ jobs:
           TEST_GITHUB_REPO_INSTALLATION_ID: ${{ vars.INSTALLATION_ID }}
           TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
           TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
+          TEST_GITHUB_SECOND_WEBHOOK_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_WEBHOOK_TOKEN }}
           TEST_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
           TEST_BITBUCKET_SERVER_TOKEN: ${{ secrets.BITBUCKET_SERVER_TOKEN }}
           TEST_BITBUCKET_SERVER_API_URL: ${{ secrets.BITBUCKET_SERVER_API_URL }}
@@ -486,6 +515,7 @@ jobs:
           TEST_GITHUB_REPO_INSTALLATION_ID: ${{ vars.INSTALLATION_ID }}
           TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
           TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
+          TEST_GITHUB_SECOND_WEBHOOK_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_WEBHOOK_TOKEN }}
           TEST_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
           TEST_BITBUCKET_SERVER_TOKEN: ${{ secrets.BITBUCKET_SERVER_TOKEN }}
           TEST_BITBUCKET_SERVER_API_URL: ${{ secrets.BITBUCKET_SERVER_API_URL }}

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -39,7 +39,7 @@ const (
 
 // ErrNoFailedPipelineToRetest is returned when /retest or /ok-to-test is used
 // but all matching pipelines have already succeeded for this commit.
-var ErrNoFailedPipelineToRetest = errors.New("All PipelineRuns for this commit have already succeeded. Use `/retest <pipeline-name>` to re-run a specific pipeline or `/test` to re-run all pipelines.")
+var ErrNoFailedPipelineToRetest = errors.New("All PipelineRuns for this commit have already succeeded. Use `/retest <pipeline-name>` to re-run a specific pipeline or `/test` to re-run all pipelines.") // nolint:revive,staticcheck
 
 // prunBranch is value from annotations and baseBranch is event.Base value from event.
 func branchMatch(prunBranch, baseBranch string) bool {

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -1822,14 +1822,14 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 		runevent info.Event
 	}
 	tests := []struct {
-		name                          string
-		args                          args
-		wantErr                       bool
-		wantPrName                    string
-		wantLog                       []string
-		logLevel                      int
-		repo                          *v1alpha1.Repository
-		seedData                      *testclient.Data
+		name                            string
+		args                            args
+		wantErr                         bool
+		wantPrName                      string
+		wantLog                         []string
+		logLevel                        int
+		repo                            *v1alpha1.Repository
+		seedData                        *testclient.Data
 		wantErrNoFailedPipelineToRetest bool
 	}{
 		{
@@ -2277,7 +2277,7 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 					URL:           "https://github.com/org/repo",
 				},
 			},
-			wantErr:                       true,
+			wantErr:                         true,
 			wantErrNoFailedPipelineToRetest: true,
 			repo: &v1alpha1.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "test-ns"},

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -306,16 +306,16 @@ func TestGetPipelineRunsFromRepo(t *testing.T) {
 		TriggerTarget: "pull_request",
 	}
 	retestAllEvent := &info.Event{
-		SHA:                "principale",
-		Organization:       "organizationes",
-		Repository:         "lagaffe",
-		URL:                "https://service/documentation",
-		HeadBranch:         "main",
-		BaseBranch:         "main",
-		Sender:             "fantasio",
-		EventType:          opscomments.RetestAllCommentEventType.String(),
-		TriggerTarget:      "pull_request",
-		PullRequestNumber:  10,
+		SHA:               "principale",
+		Organization:      "organizationes",
+		Repository:        "lagaffe",
+		URL:               "https://service/documentation",
+		HeadBranch:        "main",
+		BaseBranch:        "main",
+		Sender:            "fantasio",
+		EventType:         opscomments.RetestAllCommentEventType.String(),
+		TriggerTarget:     "pull_request",
+		PullRequestNumber: 10,
 	}
 	testExplicitNoMatchPREvent := &info.Event{
 		SHA:           "principale",

--- a/test/github_incoming_test.go
+++ b/test/github_incoming_test.go
@@ -230,7 +230,7 @@ func verifyIncomingWebhook(t *testing.T, randomedString, pipelinerunName string,
 		},
 	}
 
-	err = tgithub.CreateCRDIncoming(ctx, t, repoinfo, runcnx, incoming, opts, randomedString)
+	err = tgithub.CreateCRDIncoming(ctx, t, repoinfo, runcnx, incoming, opts, ghprovider, randomedString)
 	assert.NilError(t, err)
 
 	err = secret.Create(ctx, runcnx, map[string]string{"incoming": incomingSecreteValue}, randomedString, incomingSecretName)

--- a/test/github_pullrequest_concurrency_multiplepr_test.go
+++ b/test/github_pullrequest_concurrency_multiplepr_test.go
@@ -53,7 +53,7 @@ func TestGithubGHEPullRequestConcurrencyMultiplePR(t *testing.T) {
 	}
 	// set concurrency
 	opts.Concurrency = maxNumberOfConcurrentPipelineRuns
-	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
+	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, ghcnx, targetNS)
 	assert.NilError(t, err)
 
 	allPullRequests := []tgithub.PRTest{}

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -167,7 +167,7 @@ func setupGithubConcurrency(ctx context.Context, t *testing.T, maxNumberOfConcur
 		opts.Concurrency = maxNumberOfConcurrentPipelineRuns
 	}
 
-	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
+	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, ghcnx, targetNS)
 	assert.NilError(t, err)
 
 	for i := 1; i <= numberOfPipelineRuns; i++ {

--- a/test/github_push_retest_test.go
+++ b/test/github_push_retest_test.go
@@ -246,7 +246,7 @@ func TestGithubGHEPullRequestRetestPullRequestNumberSubstitution(t *testing.T) {
 	if g.Options.Settings.Github != nil {
 		opts.Settings = g.Options.Settings
 	}
-	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
+	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, ghcnx, targetNS)
 	assert.NilError(t, err)
 
 	tempBaseBranch := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("temp-base-branch")

--- a/test/github_tag_gitops_test.go
+++ b/test/github_tag_gitops_test.go
@@ -27,7 +27,7 @@ func TestGithubGHEGitOpsCommentOnTag(t *testing.T) {
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		t.Errorf("Repository %s not found in %s", opts.Repo, opts.Organization)
 	}
-	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
+	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, ghcnx, targetNS)
 	assert.NilError(t, err)
 	runcnx.Clients.Log.Infof("Repository %s has been created successfully", targetNS)
 

--- a/test/pkg/github/crd.go
+++ b/test/pkg/github/crd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-github/v81/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	ghprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
@@ -15,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func CreateCRD(ctx context.Context, t *testing.T, repoinfo *github.Repository, run *params.Run, opts options.E2E, targetNS string) error {
+func CreateCRD(ctx context.Context, t *testing.T, repoinfo *github.Repository, run *params.Run, opts options.E2E, provider *ghprovider.Provider, targetNS string) error {
 	repo := &v1alpha1.Repository{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: targetNS,
@@ -34,16 +35,7 @@ func CreateCRD(ctx context.Context, t *testing.T, repoinfo *github.Repository, r
 	assert.NilError(t, err)
 
 	if opts.DirectWebhook {
-		// Use opts.Token and opts.APIURL if provided (for GHE dynamic repos),
-		// otherwise fall back to environment variables (for public GitHub)
-		token := opts.Token
-		if token == "" {
-			token, _ = os.LookupEnv("TEST_GITHUB_TOKEN")
-		}
-		apiURL := opts.APIURL
-		if apiURL == "" {
-			apiURL, _ = os.LookupEnv("TEST_GITHUB_API_URL")
-		}
+		token, apiURL := getTokenAndURL(provider)
 		webhookSecret, _ := os.LookupEnv("TEST_EL_WEBHOOK_SECRET")
 
 		err := secret.Create(ctx, run,
@@ -74,7 +66,7 @@ func CreateCRD(ctx context.Context, t *testing.T, repoinfo *github.Repository, r
 
 var intPtr = func(val int) *int { return &val }
 
-func CreateCRDIncoming(ctx context.Context, t *testing.T, repoinfo *github.Repository, run *params.Run, incomings *[]v1alpha1.Incoming, opts options.E2E, targetNS string) error {
+func CreateCRDIncoming(ctx context.Context, t *testing.T, repoinfo *github.Repository, run *params.Run, incomings *[]v1alpha1.Incoming, opts options.E2E, provider *ghprovider.Provider, targetNS string) error {
 	repo := &v1alpha1.Repository{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: targetNS,
@@ -93,16 +85,7 @@ func CreateCRDIncoming(ctx context.Context, t *testing.T, repoinfo *github.Repos
 	assert.NilError(t, err)
 
 	if opts.DirectWebhook {
-		// Use opts.Token and opts.APIURL if provided (for GHE dynamic repos),
-		// otherwise fall back to environment variables (for public GitHub)
-		token := opts.Token
-		if token == "" {
-			token, _ = os.LookupEnv("TEST_GITHUB_TOKEN")
-		}
-		apiURL := opts.APIURL
-		if apiURL == "" {
-			apiURL, _ = os.LookupEnv("TEST_GITHUB_API_URL")
-		}
+		token, apiURL := getTokenAndURL(provider)
 		webhookSecret, _ := os.LookupEnv("TEST_EL_WEBHOOK_SECRET")
 
 		err := secret.Create(ctx, run,
@@ -135,4 +118,24 @@ func CreateCRDIncoming(ctx context.Context, t *testing.T, repoinfo *github.Repos
 	err = repository.CreateRepo(ctx, targetNS, run, repo)
 	assert.NilError(t, err)
 	return err
+}
+
+func getTokenAndURL(provider *ghprovider.Provider) (string, string) {
+	token := ""
+	if provider.Token != nil {
+		token = *provider.Token
+	}
+	if token == "" {
+		token, _ = os.LookupEnv("TEST_GITHUB_TOKEN")
+	}
+
+	apiURL := ""
+	if provider.APIURL != nil {
+		apiURL = *provider.APIURL
+	}
+	if apiURL == "" {
+		apiURL, _ = os.LookupEnv("TEST_GITHUB_API_URL")
+	}
+
+	return token, apiURL
 }

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -163,7 +163,7 @@ func (g *PRTest) RunPullRequest(ctx context.Context, t *testing.T) {
 	if g.Options.Settings.Github != nil {
 		opts.Settings = g.Options.Settings
 	}
-	err = CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
+	err = CreateCRD(ctx, t, repoinfo, runcnx, opts, ghcnx, targetNS)
 	assert.NilError(t, err)
 
 	yamlEntries := map[string]string{}
@@ -289,7 +289,7 @@ func (g *PRTest) RunPushRequest(ctx context.Context, t *testing.T) {
 			t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 		}
 	}
-	err = CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
+	err = CreateCRD(ctx, t, repoinfo, runcnx, opts, ghcnx, targetNS)
 	assert.NilError(t, err)
 
 	yamlEntries := map[string]string{}

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -16,72 +16,15 @@ import (
 )
 
 func Setup(ctx context.Context, onGHE, viaDirectWebhook bool) (context.Context, *params.Run, options.E2E, *github.Provider, error) {
-	if err := setup.RequireEnvs(
-		"TEST_EL_URL",
-		"TEST_GITHUB_API_URL",
-		"TEST_GITHUB_TOKEN",
-		"TEST_GITHUB_REPO_OWNER_GITHUBAPP",
-		"TEST_EL_WEBHOOK_SECRET",
-	); err != nil {
+	config, err := setupEnvVars(onGHE, viaDirectWebhook)
+	if err != nil {
 		return ctx, nil, options.E2E{}, github.New(), err
 	}
 
-	githubToken := ""
-	githubURL := os.Getenv("TEST_GITHUB_API_URL")
-	githubRepoOwnerGithubApp := os.Getenv("TEST_GITHUB_REPO_OWNER_GITHUBAPP")
-	// EL_URL mean CONTROLLER URL, it's called el_url because a long time ago pac was based on trigger
-	controllerURL := os.Getenv("TEST_EL_URL")
+	split := strings.Split(config.repoOwner, "/")
+	repo := ""
 
-	if onGHE {
-		requiredEnvs := []string{
-			"TEST_GITHUB_SECOND_API_URL",
-			"TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP",
-			"TEST_GITHUB_SECOND_TOKEN",
-			"TEST_GITHUB_SECOND_EL_URL",
-		}
-		if viaDirectWebhook {
-			requiredEnvs = append(requiredEnvs, "TEST_GITHUB_SECOND_WEBHOOK_SMEE_URL")
-		}
-		if err := setup.RequireEnvs(requiredEnvs...); err != nil {
-			return ctx, nil, options.E2E{}, github.New(), err
-		}
-	}
-
-	var split []string
-	var repo string
-
-	// Configure based on provider and authentication method
-	switch {
-	case onGHE && viaDirectWebhook:
-		// GHE + webhook (dynamic repo creation)
-		githubURL = os.Getenv("TEST_GITHUB_SECOND_API_URL")
-		githubToken = os.Getenv("TEST_GITHUB_SECOND_TOKEN")
-		controllerURL = os.Getenv("TEST_GITHUB_SECOND_EL_URL")
-		// Use dedicated webhook org if set, otherwise fall back to GitHub App org
-		webhookOrg := os.Getenv("TEST_GITHUB_SECOND_WEBHOOK_ORG")
-		if webhookOrg != "" {
-			split = []string{webhookOrg}
-		} else {
-			githubRepoOwnerGithubApp = os.Getenv("TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP")
-			split = strings.Split(githubRepoOwnerGithubApp, "/")
-		}
-		repo = "" // Will be filled after dynamic repo creation
-	case onGHE:
-		// GHE + GitHub App
-		githubURL = os.Getenv("TEST_GITHUB_SECOND_API_URL")
-		githubRepoOwnerGithubApp = os.Getenv("TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP")
-		githubToken = os.Getenv("TEST_GITHUB_SECOND_TOKEN")
-		controllerURL = os.Getenv("TEST_GITHUB_SECOND_EL_URL")
-		split = strings.Split(githubRepoOwnerGithubApp, "/")
-		repo = split[1]
-	case viaDirectWebhook:
-		// Public GitHub + webhook (uses same repo as GitHub App)
-		githubToken = os.Getenv("TEST_GITHUB_TOKEN")
-		split = strings.Split(githubRepoOwnerGithubApp, "/")
-		repo = split[1]
-	default:
-		// Public GitHub + GitHub App
-		split = strings.Split(githubRepoOwnerGithubApp, "/")
+	if len(split) > 1 {
 		repo = split[1]
 	}
 
@@ -99,42 +42,129 @@ func Setup(ctx context.Context, onGHE, viaDirectWebhook bool) (context.Context, 
 		Organization:  split[0],
 		Repo:          repo,
 		DirectWebhook: viaDirectWebhook,
-		ControllerURL: controllerURL,
-		Token:         githubToken,
-		APIURL:        githubURL,
+		ControllerURL: config.controllerURL,
 	}
 	gprovider := github.New()
 	gprovider.Run = run
 	event := info.NewEvent()
 
-	if githubToken == "" && !viaDirectWebhook {
-		var err error
-
-		envGithubRepoInstallationID, err := setup.GetRequiredEnv("TEST_GITHUB_REPO_INSTALLATION_ID")
-		if err != nil {
-			return ctx, nil, options.E2E{}, github.New(), err
-		}
-		// convert to int64 githubRepoInstallationID
-		githubRepoInstallationID, err := strconv.ParseInt(envGithubRepoInstallationID, 10, 64)
-		if err != nil {
-			return ctx, nil, options.E2E{}, github.New(), fmt.Errorf("TEST_GITHUB_REPO_INSTALLATION_ID env variable must be an integer but got '%s'", envGithubRepoInstallationID)
-		}
-		ns := info.GetNS(ctx)
-		githubToken, err = gprovider.GetAppToken(ctx, run.Clients.Kube, githubURL, githubRepoInstallationID, ns)
-		if err != nil {
-			return ctx, nil, options.E2E{}, github.New(), err
-		}
+	if err := setupGithubAppToken(ctx, config, viaDirectWebhook, run, gprovider); err != nil {
+		return ctx, nil, options.E2E{}, github.New(), err
 	}
 
 	event.Provider = &info.Provider{
-		Token: githubToken,
-		URL:   githubURL,
+		Token: config.token,
+		URL:   config.url,
 	}
-	gprovider.Token = &githubToken
+	gprovider.Token = &config.token
 	// TODO: before PR
 	if err := gprovider.SetClient(ctx, run, event, nil, nil); err != nil {
 		return ctx, nil, options.E2E{}, github.New(), err
 	}
 
 	return ctx, run, e2eoptions, gprovider, nil
+}
+
+type envConfig struct {
+	token         string
+	url           string
+	repoOwner     string
+	controllerURL string
+}
+
+// setupEnvVars validates and retrieves environment variables based on the test scenario.
+// Combination: (Public/GHE) x (App/Webhook).
+func setupEnvVars(onGHE, viaDirectWebhook bool) (*envConfig, error) {
+	var requiredEnvs []string
+	config := &envConfig{}
+
+	switch {
+	case onGHE && viaDirectWebhook:
+		requiredEnvs = append(requiredEnvs,
+			"TEST_EL_WEBHOOK_SECRET",
+			"TEST_GITHUB_SECOND_API_URL",
+			"TEST_GITHUB_SECOND_EL_URL",
+			"TEST_GITHUB_SECOND_WEBHOOK_TOKEN",
+		)
+		if err := setup.RequireEnvs(requiredEnvs...); err != nil {
+			return nil, err
+		}
+		config.url = os.Getenv("TEST_GITHUB_SECOND_API_URL")
+		config.controllerURL = os.Getenv("TEST_GITHUB_SECOND_EL_URL")
+		config.token = os.Getenv("TEST_GITHUB_SECOND_WEBHOOK_TOKEN")
+		webhookOrg := os.Getenv("TEST_GITHUB_SECOND_WEBHOOK_ORG")
+		if webhookOrg == "" {
+			webhookOrg = os.Getenv("TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP")
+		}
+		config.repoOwner = webhookOrg
+	case onGHE && !viaDirectWebhook:
+		requiredEnvs = append(requiredEnvs,
+			"TEST_GITHUB_SECOND_API_URL",
+			"TEST_GITHUB_SECOND_EL_URL",
+			"TEST_GITHUB_SECOND_TOKEN",
+			"TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP",
+			"TEST_GITHUB_SECOND_REPO_INSTALLATION_ID",
+		)
+		if err := setup.RequireEnvs(requiredEnvs...); err != nil {
+			return nil, err
+		}
+		config.url = os.Getenv("TEST_GITHUB_SECOND_API_URL")
+		config.controllerURL = os.Getenv("TEST_GITHUB_SECOND_EL_URL")
+		config.token = os.Getenv("TEST_GITHUB_SECOND_TOKEN")
+		config.repoOwner = os.Getenv("TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP")
+
+	case !onGHE && viaDirectWebhook:
+		requiredEnvs = append(requiredEnvs,
+			"TEST_EL_URL",
+			"TEST_EL_WEBHOOK_SECRET",
+			"TEST_GITHUB_API_URL",
+			"TEST_GITHUB_TOKEN",
+			"TEST_GITHUB_REPO_OWNER_WEBHOOK",
+		)
+		if err := setup.RequireEnvs(requiredEnvs...); err != nil {
+			return nil, err
+		}
+		config.url = os.Getenv("TEST_GITHUB_API_URL")
+		config.controllerURL = os.Getenv("TEST_EL_URL")
+		config.token = os.Getenv("TEST_GITHUB_TOKEN")
+		config.repoOwner = os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK")
+
+	case !onGHE && !viaDirectWebhook:
+		requiredEnvs = append(requiredEnvs,
+			"TEST_EL_URL",
+			"TEST_GITHUB_API_URL",
+			"TEST_GITHUB_REPO_OWNER_GITHUBAPP",
+		)
+		if err := setup.RequireEnvs(requiredEnvs...); err != nil {
+			return nil, err
+		}
+		config.url = os.Getenv("TEST_GITHUB_API_URL")
+		config.controllerURL = os.Getenv("TEST_EL_URL")
+		config.repoOwner = os.Getenv("TEST_GITHUB_REPO_OWNER_GITHUBAPP")
+		// token left empty - will be obtained from GitHub App
+	}
+
+	return config, nil
+}
+
+func setupGithubAppToken(ctx context.Context, config *envConfig, viaDirectWebhook bool, run *params.Run, gprovider *github.Provider) error {
+	if config.token == "" && !viaDirectWebhook {
+		var err error
+
+		envGithubRepoInstallationID, err := setup.GetRequiredEnv("TEST_GITHUB_REPO_INSTALLATION_ID")
+		if err != nil {
+			return err
+		}
+		// convert to int64 githubRepoInstallationID
+		githubRepoInstallationID, err := strconv.ParseInt(envGithubRepoInstallationID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("TEST_GITHUB_REPO_INSTALLATION_ID env variable must be an integer but got '%s'", envGithubRepoInstallationID)
+		}
+		ns := info.GetNS(ctx)
+		config.token, err = gprovider.GetAppToken(ctx, run.Clients.Kube, config.url, githubRepoInstallationID, ns)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/test/pkg/options/options.go
+++ b/test/pkg/options/options.go
@@ -11,8 +11,6 @@ type E2E struct {
 	Password           string
 	LightweightTag     bool
 	Settings           v1alpha1.Settings
-	Token              string
-	APIURL             string
 }
 
 var (


### PR DESCRIPTION
## 📝 Description of the Change
This PR refactors the GitHub and GitHub Enterprise (GHE) test infrastructure to improve code organization, readability, and maintainability.

### Changes

#### Test Infrastructure (`test/pkg/github/setup.go`)

- Extract environment setup logic: Moved environment variable validation and configuration into a dedicated `setupEnvVars()` helper function
- Simplify provider initialization: Replaced complex switch statement with cleaner helper functions
- Extract GitHub App token logic: Created `setupGithubAppToken()` function for better separation of concerns
- Pass provider objects explicitly: Provider objects are now passed as function parameters rather than being embedded in the options struct

#### CI Workflow (`.github/workflows/e2e.yaml`)

- Reorganize environment variables: Grouped and commented env vars by provider for better clarity:
  - Common/Infra
  - GitHub (Public)
  - GitHub Enterprise (Second)
  - GitLab
  - Gitea
  - Bitbucket Cloud
  - Bitbucket Server
- **Add variables: Added `TEST_GITHUB_SECOND_WEBHOOK_TOKEN` for webhook-based GHE tests**

#### Test Files
- Updated test imports/calls to work with refactored setup functions

The changes in `pkg` are golangci-lint fixes.
## 👨🏻‍ Linked Jira
N/A
<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [x] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
