### PR TITLE
test: improve GHE webhook test reliability and naming

### DIFF
--- a/test/github_comment_strategy_update_test.go
+++ b/test/github_comment_strategy_update_test.go
@@ -23,7 +23,7 @@ import (
 // 1. A CEL error comment is posted for a PLR
 // 2. After fixing the CEL error with a new commit, the same comment is updated with success status
 // 3. Only one comment exists.
-func TestGithubGHECommentStrategyUpdateCELErrorReplacement(t *testing.T) {
+func TestGithubGHEWebhookCommentStrategyUpdateCELErrorReplacement(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label:         "Github Comment Strategy CEL Error",
@@ -142,7 +142,7 @@ func TestGithubGHECommentStrategyUpdateCELErrorReplacement(t *testing.T) {
 // 1. Multiple PLRs in one PR each create their own comment
 // 2. Each PLR only updates its own comment (no cross-updates)
 // 3. Comments are correctly identified by their unique markers.
-func TestGithubGHECommentStrategyUpdateMultiplePLRs(t *testing.T) {
+func TestGithubGHEWebhookCommentStrategyUpdateMultiplePLRs(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label:     "Github Comment Strategy Multiple PLRs",
@@ -247,7 +247,7 @@ func TestGithubGHECommentStrategyUpdateMultiplePLRs(t *testing.T) {
 // 1. PLR names containing regex-relevant characters (dots, brackets, etc.) are handled correctly
 // 2. Marker matching remains exact even with special characters
 // 3. No cross-contamination between PLRs with similar names.
-func TestGithubGHECommentStrategyUpdateMarkerMatchingWithRegexChars(t *testing.T) {
+func TestGithubGHEWebhookCommentStrategyUpdateMarkerMatchingWithRegexChars(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label: "Github Comment Strategy Regex Chars",

--- a/test/github_pullrequest_privaterepository_test.go
+++ b/test/github_pullrequest_privaterepository_test.go
@@ -42,7 +42,7 @@ func TestGithubGHEPullRequestGitClone(t *testing.T) {
 	defer g.TearDown(ctx, t)
 }
 
-func TestGithubGHEPullRequestPrivateRepositoryOnWebhook(t *testing.T) {
+func TestGithubGHEWebhookPullRequestPrivateRepository(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label:     "Github GHE Rerequest",

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -150,7 +150,7 @@ func TestGithubGHEPullRequestCELMatchOnTitle(t *testing.T) {
 	defer g.TearDown(ctx, t)
 }
 
-func TestGithubGHEPullRequestWebhook(t *testing.T) {
+func TestGithubGHEWebhookPullRequest(t *testing.T) {
 	ctx := context.Background()
 
 	g := &tgithub.PRTest{
@@ -659,7 +659,7 @@ func TestGithubGHEPullandPushMatchTriggerOnlyPull(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func TestGithubGHEDisableCommentsOnPR(t *testing.T) {
+func TestGithubGHEWebhookDisableCommentsOnPR(t *testing.T) {
 	ctx := context.Background()
 
 	g := &tgithub.PRTest{

--- a/test/github_push_test.go
+++ b/test/github_push_test.go
@@ -9,7 +9,7 @@ import (
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 )
 
-func TestGithubGHEPushWebhook(t *testing.T) {
+func TestGithubGHEWebhookPush(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
 		Label:     "Github GHE push request on Webhook",

--- a/test/pkg/github/instrumentation.go
+++ b/test/pkg/github/instrumentation.go
@@ -49,12 +49,19 @@ type TestResult struct {
 // TODO(chmouel): Add support for Bitbucket.
 // TODO(chmouel): Add support for Gitea.
 func (g *PRTest) collectGitHubAPICalls(ctx context.Context, _ *testing.T) {
+	if g.Cnx == nil || g.Cnx.Clients.Kube == nil || g.Logger == nil {
+		return
+	}
+
 	numLines := int64(100)
 	controllerName := "controller"
 	if g.GHE {
 		controllerName = "ghe-controller"
 	}
-	ns := info.GetNS(ctx)
+	ns := g.TargetNamespace
+	if ns == "" {
+		ns = info.GetNS(ctx)
+	}
 
 	g.Logger.Infof(
 		"Attempting to collect GitHub API calls from controller: %s in namespace: %s",

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -132,7 +132,14 @@ func (g *PRTest) RunPullRequest(ctx context.Context, t *testing.T) {
 	ctx, runcnx, opts, ghcnx, err := Setup(ctx, g.GHE, g.Webhook)
 	assert.NilError(t, err)
 	g.Logger = runcnx.Clients.Log
-
+	g.Cnx = runcnx
+	preSettings := g.Options.Settings
+	g.Options = opts
+	if preSettings.Github != nil {
+		g.Options.Settings = preSettings
+	}
+	g.Provider = ghcnx
+	g.TargetNamespace = targetNS
 	g.CommitTitle = fmt.Sprintf("Testing %s with Github APPS integration on %s", g.Label, targetNS)
 	g.Logger.Info(g.CommitTitle)
 
@@ -149,6 +156,7 @@ func (g *PRTest) RunPullRequest(ctx context.Context, t *testing.T) {
 		assert.NilError(t, err)
 
 		opts.Repo = repoName
+		g.Options.Repo = repoName
 		g.DynamicRepoName = repoName
 	} else {
 		// Use existing pre-configured repo
@@ -177,15 +185,18 @@ func (g *PRTest) RunPullRequest(ctx context.Context, t *testing.T) {
 
 	targetRefName := fmt.Sprintf("refs/heads/%s",
 		names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"))
+	g.TargetRefName = targetRefName
 
 	sha, vref, err := PushFilesToRef(ctx, ghcnx.Client(), g.CommitTitle, repoinfo.GetDefaultBranch(), targetRefName,
 		opts.Organization, opts.Repo, entries)
 	assert.NilError(t, err)
+	g.SHA = sha
 
 	g.Logger.Infof("Commit %s has been created and pushed to %s", sha, vref.GetURL())
 	number, err := PRCreate(ctx, runcnx, ghcnx, opts.Organization,
 		opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), g.CommitTitle)
 	assert.NilError(t, err)
+	g.PRNumber = number
 
 	if !g.NoStatusCheck {
 		sopt := wait.SuccessOpt{
@@ -197,25 +208,20 @@ func (g *PRTest) RunPullRequest(ctx context.Context, t *testing.T) {
 		}
 		wait.Succeeded(ctx, t, runcnx, opts, sopt)
 	}
-	g.Cnx = runcnx
-	g.Options = opts
-	g.Provider = ghcnx
-	g.TargetNamespace = targetNS
-	g.TargetRefName = targetRefName
-	g.PRNumber = number
-	g.SHA = sha
 }
 
 func (g *PRTest) TearDown(ctx context.Context, t *testing.T) {
 	if os.Getenv("TEST_NOCLEANUP") == "true" {
-		g.Logger.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
+		if g.Logger != nil {
+			g.Logger.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
+		}
 		return
 	}
 
 	// Collect GitHub API call information from controller logs
 	g.collectGitHubAPICalls(ctx, t)
 
-	if g.PRNumber != -1 {
+	if g.PRNumber != -1 && g.Provider != nil && g.Logger != nil {
 		g.Logger.Infof("Closing PR %d", g.PRNumber)
 		state := "closed"
 		_, _, err := g.Provider.Client().PullRequests.Edit(ctx,
@@ -225,12 +231,12 @@ func (g *PRTest) TearDown(ctx context.Context, t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if g.TargetNamespace != "" {
+	if g.TargetNamespace != "" && g.Cnx != nil {
 		repository.NSTearDown(ctx, t, g.Cnx, g.TargetNamespace)
 	}
 
 	// Skip branch deletion for dynamic repos since we're deleting the entire repo
-	if g.DynamicRepoName == "" && g.TargetRefName != "" && g.TargetRefName != options.MainBranch {
+	if g.DynamicRepoName == "" && g.TargetRefName != "" && g.TargetRefName != options.MainBranch && g.Provider != nil && g.Logger != nil {
 		branch := fmt.Sprintf("heads/%s", filepath.Base(g.TargetRefName))
 		g.Logger.Infof("Deleting Ref %s", branch)
 		_, err := g.Provider.Client().Git.DeleteRef(ctx, g.Options.Organization, g.Options.Repo, branch)
@@ -238,7 +244,7 @@ func (g *PRTest) TearDown(ctx context.Context, t *testing.T) {
 	}
 
 	// Delete dynamic repo if one was created
-	if g.DynamicRepoName != "" {
+	if g.DynamicRepoName != "" && g.Provider != nil && g.Logger != nil {
 		g.Logger.Infof("Deleting dynamic repository %s/%s", g.Options.Organization, g.DynamicRepoName)
 		err := DeleteGHERepo(ctx, g.Provider.Client(), g.Options.Organization, g.DynamicRepoName, g.Logger)
 		assert.NilError(t, err)
@@ -256,6 +262,15 @@ func (g *PRTest) RunPushRequest(ctx context.Context, t *testing.T) {
 	ctx, runcnx, opts, ghcnx, err := Setup(ctx, g.GHE, g.Webhook)
 	assert.NilError(t, err)
 	g.Logger = runcnx.Clients.Log
+	g.Cnx = runcnx
+	preSettings := g.Options.Settings
+	g.Options = opts
+	if preSettings.Github != nil {
+		g.Options.Settings = preSettings
+	}
+	g.Provider = ghcnx
+	g.TargetNamespace = targetNS
+	g.PRNumber = -1
 
 	var logmsg string
 	if g.Webhook {
@@ -279,6 +294,7 @@ func (g *PRTest) RunPushRequest(ctx context.Context, t *testing.T) {
 		assert.NilError(t, err)
 
 		opts.Repo = repoName
+		g.Options.Repo = repoName
 		g.DynamicRepoName = repoName
 	} else {
 		// Use existing pre-configured repo
@@ -288,6 +304,10 @@ func (g *PRTest) RunPushRequest(ctx context.Context, t *testing.T) {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 		}
+	}
+
+	if g.Options.Settings.Github != nil {
+		opts.Settings = g.Options.Settings
 	}
 	err = CreateCRD(ctx, t, repoinfo, runcnx, opts, ghcnx, targetNS)
 	assert.NilError(t, err)
@@ -302,6 +322,7 @@ func (g *PRTest) RunPushRequest(ctx context.Context, t *testing.T) {
 	assert.NilError(t, err)
 
 	targetRefName := targetBranch
+	g.TargetRefName = targetRefName
 	cloneURL, err := scm.MakeGitCloneURL(repoinfo.GetCloneURL(), "git", *ghcnx.Token)
 	assert.NilError(t, err)
 	scmOpts := scm.Opts{
@@ -316,6 +337,7 @@ func (g *PRTest) RunPushRequest(ctx context.Context, t *testing.T) {
 	branch, _, err := ghcnx.Client().Repositories.GetBranch(ctx, opts.Organization, opts.Repo, targetBranch, 1)
 	assert.NilError(t, err)
 	sha := branch.GetCommit().GetSHA()
+	g.SHA = sha
 	g.Logger.Infof("Commit %s has been created and pushed to %s in branch %s", sha, branch.GetCommit().GetHTMLURL(), branch.GetName())
 	assert.NilError(t, err)
 
@@ -329,14 +351,6 @@ func (g *PRTest) RunPushRequest(ctx context.Context, t *testing.T) {
 		}
 		wait.Succeeded(ctx, t, runcnx, opts, sopt)
 	}
-
-	g.Cnx = runcnx
-	g.Options = opts
-	g.Provider = ghcnx
-	g.TargetNamespace = targetNS
-	g.TargetRefName = targetRefName
-	g.PRNumber = -1
-	g.SHA = sha
 }
 
 func UpdateFilesInRef(ctx context.Context, client *github.Client, owner, repo, branch, commitMessage string, files map[string]string) (string, error) {


### PR DESCRIPTION
## 📝 Description of the Change
- Add nil checks in collectGitHubAPICalls and TearDown to handle test failures before full initialization. Set PRTest fields immediately upon creation rather than at end of RunPullRequest/RunPushRequest to ensure proper cleanup even when tests fail early.
  - Reason for panic: during GHE webhook tests "refactoring", the test `TearDown` is called before `Run(Pull|Push)Request` causing the panic as some of the variables haven't been set.
    ```
    defer g.TearDown(ctx, t)
    g.RunPullRequest(ctx, t)
    ```
  - This was done to prioritize cleanup of "dead" repos on ghe in case of failures.
- Standardize test naming by moving "Webhook" earlier in function names, changing pattern from TestGithubGHE*Webhook to `TestGithubGHEWebhook*` for better clarity and consistency.

## 👨🏻‍ Linked Jira
N/A

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
