### PR TITLE
feat: cache changed files in Gitea provider

### DIFF
--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -61,12 +61,13 @@ type Provider struct {
 	Token            *string
 	giteaInstanceURL string
 	// only exposed for e2e tests
-	Password     string
-	repo         *v1alpha1.Repository
-	eventEmitter *events.EventEmitter
-	run          *params.Run
-	triggerEvent string
-	pacUserID    int64 // user login used by PAC
+	Password           string
+	repo               *v1alpha1.Repository
+	eventEmitter       *events.EventEmitter
+	run                *params.Run
+	triggerEvent       string
+	pacUserID          int64 // user login used by PAC
+	cachedChangedFiles *changedfiles.ChangedFiles
 }
 
 func (v *Provider) Client() *forgejo.Client {
@@ -535,7 +536,19 @@ type PushPayload struct {
 	Commits []forgejo.PayloadCommit `json:"commits,omitempty"`
 }
 
-func (v *Provider) GetFiles(_ context.Context, runevent *info.Event) (changedfiles.ChangedFiles, error) {
+// GetFiles gets and caches the list of files changed by a given event.
+func (v *Provider) GetFiles(ctx context.Context, runevent *info.Event) (changedfiles.ChangedFiles, error) {
+	if v.cachedChangedFiles == nil {
+		changes, err := v.fetchChangedFiles(ctx, runevent)
+		if err != nil {
+			return changedfiles.ChangedFiles{}, err
+		}
+		v.cachedChangedFiles = &changes
+	}
+	return *v.cachedChangedFiles, nil
+}
+
+func (v *Provider) fetchChangedFiles(_ context.Context, runevent *info.Event) (changedfiles.ChangedFiles, error) {
 	changedFiles := changedfiles.ChangedFiles{}
 
 	//nolint:exhaustive // we don't need to handle all cases

--- a/pkg/provider/gitea/gitea_test.go
+++ b/pkg/provider/gitea/gitea_test.go
@@ -25,10 +25,13 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea/test"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
+	metricsutils "github.com/openshift-pipelines/pipelines-as-code/pkg/test/metricstest"
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
+	"knative.dev/pkg/metrics/metricstest"
+	_ "knative.dev/pkg/metrics/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
@@ -277,16 +280,17 @@ func TestProvider_Validate(t *testing.T) {
 	}
 }
 
-func TestProvider_GetFiles(t *testing.T) {
+func TestProviderGetFiles(t *testing.T) {
 	type args struct {
 		runevent *info.Event
 	}
 	tests := []struct {
-		name         string
-		args         args
-		changedFiles string
-		want         changedfiles.ChangedFiles
-		wantErr      bool
+		name                string
+		args                args
+		changedFiles        string
+		want                changedfiles.ChangedFiles
+		wantErr             bool
+		wantAPIRequestCount int64
 	}{
 		{
 			name: "pull_request",
@@ -312,7 +316,8 @@ func TestProvider_GetFiles(t *testing.T) {
 				Modified: []string{"modified.txt"},
 				Renamed:  []string{"renamed.txt"},
 			},
-			changedFiles: `[{"filename":"added.txt","status":"added"},{"filename":"deleted.txt","status":"deleted"},{"filename":"modified.txt","status":"changed"},{"filename":"renamed.txt","status":"renamed"}]`,
+			changedFiles:        `[{"filename":"added.txt","status":"added"},{"filename":"deleted.txt","status":"deleted"},{"filename":"modified.txt","status":"changed"},{"filename":"renamed.txt","status":"renamed"}]`,
+			wantAPIRequestCount: 1,
 		},
 		{
 			name: "push",
@@ -342,12 +347,12 @@ func TestProvider_GetFiles(t *testing.T) {
 				},
 				Deleted:  []string{"deleted.txt"},
 				Modified: []string{"modified.txt"},
-				// Renamed:  []string{"renamed.txt"},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			metricsutils.ResetMetrics()
 			fakeclient, mux, teardown := tgitea.Setup(t)
 			defer teardown()
 
@@ -360,11 +365,17 @@ func TestProvider_GetFiles(t *testing.T) {
 			repo := &v1alpha1.Repository{Spec: v1alpha1.RepositorySpec{
 				Settings: &v1alpha1.Settings{},
 			}}
+			giteaInstanceURL := "https://gitea.example.com"
 			gprovider := Provider{
-				giteaClient: fakeclient,
-				repo:        repo,
-				Logger:      logger,
+				giteaClient:      fakeclient,
+				repo:             repo,
+				Logger:           logger,
+				giteaInstanceURL: giteaInstanceURL,
+				triggerEvent:     string(tt.args.runevent.TriggerTarget),
 			}
+
+			metricsTags := map[string]string{"provider": giteaInstanceURL, "event-type": string(tt.args.runevent.TriggerTarget)}
+			metricstest.CheckStatsNotReported(t, "pipelines_as_code_git_provider_api_request_count")
 
 			got, err := gprovider.GetFiles(ctx, tt.args.runevent)
 
@@ -400,6 +411,24 @@ func TestProvider_GetFiles(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got.Renamed, tt.want.Renamed) {
 				t.Errorf("Provider.GetFiles() Renamed = %v, want %v", got.Renamed, tt.want.Renamed)
+			}
+
+			// Verify metrics from first call
+			if tt.wantAPIRequestCount > 0 {
+				metricstest.CheckCountData(t, "pipelines_as_code_git_provider_api_request_count", metricsTags, tt.wantAPIRequestCount)
+			} else {
+				metricstest.CheckStatsNotReported(t, "pipelines_as_code_git_provider_api_request_count")
+			}
+
+			// Verify caching: second call should return cached result without additional API calls
+			got2, err2 := gprovider.GetFiles(ctx, tt.args.runevent)
+			assert.NilError(t, err2)
+			assert.DeepEqual(t, got, got2)
+
+			if tt.wantAPIRequestCount > 0 {
+				metricstest.CheckCountData(t, "pipelines_as_code_git_provider_api_request_count", metricsTags, tt.wantAPIRequestCount)
+			} else {
+				metricstest.CheckStatsNotReported(t, "pipelines_as_code_git_provider_api_request_count")
 			}
 		})
 	}


### PR DESCRIPTION
## 📝 Description of the Change

Implemented a caching mechanism for changed files in the Gitea provider to prevent redundant API requests during the reconciliation process. The implementation mirrors the existing pattern from PR #2317 for other providers.

### Changes Made:
- Added `cachedChangedFiles` field to the Provider struct to cache the result of the first GetFiles() call
- Implemented `GetFiles()` method that returns cached results on subsequent calls
- Implemented `fetchChangedFiles()` helper that handles both pull request and push event scenarios with proper file status categorization
- Added comprehensive test coverage including verification that subsequent calls use cached data without making additional API requests

### Benefits:
- Reduces API calls to the Gitea instance during pipeline reconciliation
- Improves performance by avoiding redundant file change lookups
- Maintains consistency with caching patterns used in other provider implementations

## 👨🏻‍ Linked Jira

Jira: https://issues.redhat.com/browse/SRVKP-10944

## 🔗 Linked GitHub Issue

Fixes #

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

### Test Coverage:
- **TestProvider_GetFiles**: Tests both pull request and push event scenarios
- **Cache verification**: Confirms that the second call to GetFiles() returns cached results without making additional API requests
- **File categorization**: Validates correct categorization of files as Added, Deleted, Modified, or Renamed

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [x] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [x] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center