### PR TITLE
fix(resolve): restore relative task path resolution for repository paths

### DIFF
--- a/pkg/resolve/remote.go
+++ b/pkg/resolve/remote.go
@@ -33,11 +33,14 @@ func assembleTaskFQDNs(pipelineURL string, tasks []string) ([]string, error) {
 		return tasks, nil // no pipeline URL, return tasks as is
 	}
 
-	// Only HTTP(S) URLs can serve as base for relative task resolution.
+	// Only HTTP(S) URLs and repository file paths can serve as base for relative task resolution.
 	// Hub catalog references (e.g., "catalog://resource:version") use a
 	// different scheme where relative paths are meaningless.
 	lowered := strings.ToLower(pipelineURL)
-	if !strings.HasPrefix(lowered, "http://") && !strings.HasPrefix(lowered, "https://") {
+	isHTTP := strings.HasPrefix(lowered, "http://") || strings.HasPrefix(lowered, "https://")
+	isRepoPath := strings.Contains(lowered, "/") && !strings.Contains(lowered, "://")
+
+	if !isHTTP && !isRepoPath {
 		return tasks, nil
 	}
 

--- a/pkg/resolve/remote_test.go
+++ b/pkg/resolve/remote_test.go
@@ -562,10 +562,10 @@ func TestAssembleTaskFQDNs(t *testing.T) {
 			expected:    []string{"https://example.com/repo/task.yaml"},
 		},
 		{
-			name:        "repository file path URL returns tasks unchanged",
+			name:        "repository file path URL resolves relative tasks",
 			pipelineURL: "share/pipelines/build.yaml",
 			tasks:       []string{"../tasks/t.yaml", "tasks/other-task.yaml"},
-			expected:    []string{"../tasks/t.yaml", "tasks/other-task.yaml"},
+			expected:    []string{"share/tasks/t.yaml", "share/pipelines/tasks/other-task.yaml"},
 		},
 	}
 	for _, tt := range tests {

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -103,6 +103,25 @@ func TestGiteaPullRequestPipelineAnnotations(t *testing.T) {
 	defer f()
 }
 
+// TestGiteaPullRequestRemotePipelineRelativeTask verifies that relative task paths
+// in a Pipeline's annotations are resolved correctly when the pipeline is
+// fetched from a repository path.
+func TestGiteaPullRequestRemotePipelineRelativeTask(t *testing.T) {
+	topts := &tgitea.TestOpts{
+		Regexp:      successRegexp,
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/pr.yaml":                        "testdata/pipelinerun_remote_pipeline_repo_path.yaml",
+			".pipelines/pipeline.yaml":               "testdata/pipeline_relative_task.yaml",
+			".tasks/task-referenced-internally.yaml": "testdata/task_referenced_internally.yaml",
+		},
+		ExpectEvents:   false,
+		CheckForStatus: "success",
+	}
+	_, f := tgitea.TestPR(t, topts)
+	defer f()
+}
+
 func TestGiteaPullRequestResolvePipelineOnlyAssociatedWithPipelineRunFilterted(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      successRegexp,

--- a/test/testdata/pipeline_relative_task.yaml
+++ b/test/testdata/pipeline_relative_task.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-relative-task
+  annotations:
+    pipelinesascode.tekton.dev/task: "[../.tasks/task-referenced-internally.yaml]"
+spec:
+  tasks:
+    - name: task-referenced-internally
+      taskRef:
+        name: task-referenced-internally

--- a/test/testdata/pipelinerun_remote_pipeline_repo_path.yaml
+++ b/test/testdata/pipelinerun_remote_pipeline_repo_path.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "pipelinerun-remote-pipeline-relative-task"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+    pipelinesascode.tekton.dev/pipeline: "[../.pipelines/pipeline.yaml]"
+spec:
+  pipelineRef:
+    name: pipeline-relative-task


### PR DESCRIPTION
## 📝 Description of the Change
Commit 6e366209 broke relative task path resolution for repository file paths by only allowing HTTP(S) URLs. This caused paths containing '..' to be passed unresolved to the GitHub API, which rejects them with "path must not contain '..' due to auth vulnerability issue".

This fix restores the original behavior by allowing both HTTP(S) URLs and repository file paths (e.g., .tekton/pipelines/build.yaml) to have their relative paths resolved, while still excluding catalog/hub references (catalog://, hub://).

Also added relative local path resolution in e2e test `TestGiteaPullRequestTaskAnnotations`.

## 👨🏻‍ Linked Jira
https://redhat.atlassian.net/browse/SRVKP-11021

## 🔗 Linked GitHub Issue
Fixes #2549

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [x] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [x] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
