### PR TITLE
test(ghe): correct PLR count in regex marker test

### DIFF
--- a/test/github_comment_strategy_update_test.go
+++ b/test/github_comment_strategy_update_test.go
@@ -244,7 +244,7 @@ func TestGithubGHEWebhookCommentStrategyUpdateMultiplePLRs(t *testing.T) {
 }
 
 // TestGithubCommentStrategyUpdateMarkerMatchingWithRegexChars tests:
-// 1. PLR names containing regex-relevant characters (dots, brackets, etc.) are handled correctly
+// 1. PLR names containing regex-relevant characters are handled correctly
 // 2. Marker matching remains exact even with special characters
 // 3. No cross-contamination between PLRs with similar names.
 func TestGithubGHEWebhookCommentStrategyUpdateMarkerMatchingWithRegexChars(t *testing.T) {
@@ -252,8 +252,8 @@ func TestGithubGHEWebhookCommentStrategyUpdateMarkerMatchingWithRegexChars(t *te
 	g := &tgithub.PRTest{
 		Label: "Github Comment Strategy Regex Chars",
 		YamlFiles: []string{
-			"testdata/pipelinerun-regex-chars-dots.yaml",
-			"testdata/pipelinerun-regex-chars-brackets.yaml",
+			"testdata/pipelinerun-regex-name.yaml",
+			"testdata/pipelinerun2-regex-name.yaml",
 		},
 		GHE:     true,
 		Webhook: true,
@@ -339,7 +339,7 @@ func TestGithubGHEWebhookCommentStrategyUpdateMarkerMatchingWithRegexChars(t *te
 	assert.NilError(t, err)
 	g.Cnx.Clients.Log.Infof("Pushed dummy commit: %s", sha)
 
-	sopt.NumberofPRMatch = 4
+	sopt.NumberofPRMatch = 2
 	sopt.SHA = sha
 	sopt.Title = "test: trigger comment update"
 	twait.Succeeded(ctx, t, g.Cnx, g.Options, sopt)

--- a/test/testdata/pipelinerun-regex-name.yaml
+++ b/test/testdata/pipelinerun-regex-name.yaml
@@ -2,18 +2,18 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: test-pipeline[0]
+  name: test.pipeline.v1.0
   annotations:
     pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
-    pipelinesascode.tekton.dev/on-cel-expression: "true"
+    pipelinesascode.tekton.dev/on-cel-expression: event_type == "pull_request"
 spec:
   pipelineSpec:
     tasks:
-      - name: task-with-brackets
+      - name: task-with-dots
         taskSpec:
           steps:
             - name: echo
               image: registry.access.redhat.com/ubi10/ubi-micro
               script: |
-                echo "Testing PLR name with brackets: test-pipeline[0]"
-                echo "This tests that brackets in PLR names don't break marker matching"
+                echo "Testing PLR name with dots: test.pipeline.v1.0"
+                echo "This tests that dots in PLR names don't break marker matching"

--- a/test/testdata/pipelinerun2-regex-name.yaml
+++ b/test/testdata/pipelinerun2-regex-name.yaml
@@ -2,18 +2,18 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: test.pipeline.v1.0
+  name: test.pipeline.v120
   annotations:
     pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
-    pipelinesascode.tekton.dev/on-cel-expression: "true"
+    pipelinesascode.tekton.dev/on-cel-expression: event_type == "pull_request"
 spec:
   pipelineSpec:
     tasks:
-      - name: task-with-dots
+      - name: task-with-brackets
         taskSpec:
           steps:
             - name: echo
               image: registry.access.redhat.com/ubi10/ubi-micro
               script: |
-                echo "Testing PLR name with dots: test.pipeline.v1.0"
-                echo "This tests that dots in PLR names don't break marker matching"
+                echo "Testing PLR name with brackets: test-pipeline[0]"
+                echo "This tests that brackets in PLR names don't break marker matching"


### PR DESCRIPTION
## 📝 Description of the Change
The test used "true" as the fixed CEL expression, which matches all event types. This could cause the test to be unreliable if multiple event types are triggered during the test run.

Fix by using a proper github-specific CEL expression `event_type == "pull_request"` that matches only merge request events, consistent with the test's purpose.

The issue is similar to one resolved by https://github.com/openshift-pipelines/pipelines-as-code/pull/2547

Also renamed the pipelinerun names such that both of them contain regex characters and one of them would be a regex match of the other. (`test.pipeline.v1.0`, `test.pipeline.v120`). This helps clear up the purpose of the test by actually checking that 2 regex-ically similar pipelineruns are not contaminating each others' status comment.


## 👨🏻‍ Linked Jira
N/A
<!-- <https://issues.redhat.com/browse/SRVKP-> -->

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

If you have used AI assistance, please provide the following details:

**Which LLM was used?**

- [ ] GitHub Copilot
- [ ] ChatGPT (OpenAI)
- [ ] Claude (Anthropic)
- [ ] Cursor
- [ ] Gemini (Google)
- [ ] Other: ____________

**Extent of AI Assistance:**

- [ ] Documentation and research only
- [ ] Unit tests or E2E tests only
- [ ] Code generation (parts of the code)
- [ ] Full code generation (most of the PR)
- [ ] PR description and comments
- [ ] Commit message(s)

> [!IMPORTANT]
> If the majority of the code in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Gemini <gemini@google.com>
> Co-authored-by: ChatGPT <noreply@chatgpt.com>
> Co-authored-by: Claude <noreply@anthropic.com>
> Co-authored-by: Cursor <noreply@cursor.com>
> Co-authored-by: Copilot <Copilot@users.noreply.github.com>
>
> **💡You can use the script `./hack/add-llm-coauthor.sh` to automatically add
> these co-author trailers to your commits.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
