### PR TITLE
DNM: test ghcr publish permissions for tektoncd org

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,3 +1,4 @@
+# test: verify ghcr publish permissions for tektoncd org
 name: Create and publish a Docker image to ghcr on main and nightly with ko
 
 on:


### PR DESCRIPTION
Testing whether the default GITHUB_TOKEN can publish images to ghcr.io/tektoncd/pipelines-as-code.

This is a minimal test to debug the publish failure in #2570 — no workflow changes, just triggering the existing container.yaml as-is.

Do not merge.