### PR TITLE
fix: implement commit status fallback for retest

### DIFF
--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -20,13 +20,13 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
 
 	"github.com/gobwas/glob"
 	"github.com/google/cel-go/common/types"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 )
 
 const (
@@ -424,7 +424,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 		if event.EventType == opscomments.RetestAllCommentEventType.String() ||
 			event.EventType == opscomments.OkToTestCommentEventType.String() {
 			logger.Debugf("MatchPipelinerunByAnnotation: filtering successful templates for event_type=%s", event.EventType)
-			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, matchedPRs)
+			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, vcx, matchedPRs)
 			if len(filtered) == 0 {
 				return nil, ErrNoFailedPipelineToRetest
 			}
@@ -438,7 +438,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 
 // filterSuccessfulTemplates filters out templates that already have successful PipelineRuns
 // when executing /ok-to-test or /retest gitops commands, implementing per-template checking.
-func filterSuccessfulTemplates(ctx context.Context, logger *zap.SugaredLogger, cs *params.Run, event *info.Event, repo *apipac.Repository, matchedPRs []Match) []Match {
+func filterSuccessfulTemplates(ctx context.Context, logger *zap.SugaredLogger, cs *params.Run, event *info.Event, repo *apipac.Repository, vcx provider.Interface, matchedPRs []Match) []Match {
 	if event.SHA == "" {
 		return matchedPRs
 	}
@@ -470,11 +470,25 @@ func filterSuccessfulTemplates(ctx context.Context, logger *zap.SugaredLogger, c
 		}
 
 		// Check if this PipelineRun succeeded
-		if pr.Status.GetCondition(apis.ConditionSucceeded).IsTrue() {
+		if formatting.PipelineRunStatus(pr) == status.ConclusionSuccess {
 			// Keep the most recent successful run for each template
 			if existing, exists := successfulTemplates[originalPRName]; !exists ||
 				pr.CreationTimestamp.After(existing.CreationTimestamp.Time) {
 				successfulTemplates[originalPRName] = pr
+			}
+		}
+	}
+
+	// Also check provider commit statuses (covers pruned PipelineRuns)
+	commitStatuses, err := vcx.GetCommitStatuses(ctx, event)
+	if err != nil {
+		logger.Warnf("failed to get commit statuses from provider for SHA %s: %v", event.SHA, err)
+	} else if len(commitStatuses) > 0 {
+		appName := cs.Info.GetPacOpts().ApplicationName
+		for _, cs := range commitStatuses {
+			originalName := parseOriginalPRName(cs.Name, appName)
+			if originalName != "" && isSuccessStatus(cs.Status) {
+				successfulTemplates[originalName] = &tektonv1.PipelineRun{} // placeholder
 			}
 		}
 	}
@@ -495,6 +509,26 @@ func filterSuccessfulTemplates(ctx context.Context, logger *zap.SugaredLogger, c
 
 	// Return the filtered list (which may be empty if all templates were skipped)
 	return filteredPRs
+}
+
+// parseOriginalPRName extracts the original PipelineRun name from a commit status name.
+// The commit status name format is "ApplicationName / OriginalPRName".
+func parseOriginalPRName(checkName, appName string) string {
+	prefix := appName + " / "
+	if strings.HasPrefix(checkName, prefix) {
+		return strings.TrimPrefix(checkName, prefix)
+	}
+	return ""
+}
+
+// isSuccessStatus returns true if the status string represents a successful state
+// across different git providers.
+func isSuccessStatus(status string) bool {
+	switch strings.ToLower(status) {
+	case "success", "successful", "completed":
+		return true
+	}
+	return false
 }
 
 func buildAvailableMatchingAnnotationErr(event *info.Event, pruns []*tektonv1.PipelineRun) string {

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -25,6 +25,7 @@ import (
 	ghprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
+	testprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/test/provider"
 	testnewrepo "github.com/openshift-pipelines/pipelines-as-code/pkg/test/repository"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.uber.org/zap"
@@ -3250,7 +3251,7 @@ func TestFilterSuccessfulTemplates(t *testing.T) {
 				return
 			}
 
-			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, tt.matchedPRs)
+			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, &ghprovider.Provider{}, tt.matchedPRs)
 
 			// Check that the correct number of templates remain
 			assert.Equal(t, len(tt.expectedNames), len(filtered),
@@ -3284,6 +3285,133 @@ func TestFilterSuccessfulTemplates(t *testing.T) {
 					}
 				}
 				assert.Assert(t, found, "Unexpected template %s found in %v", actualName, actualNames)
+			}
+		})
+	}
+}
+
+func TestFilterSuccessfulTemplatesFallbackToCommitStatuses(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.DebugLevel)
+	logger := zap.New(observer).Sugar()
+
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo",
+			Namespace: "test-ns",
+		},
+	}
+
+	// No PipelineRuns in the cluster (pruned)
+	tdata := testclient.Data{
+		Repositories: []*v1alpha1.Repository{repo},
+	}
+	stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+
+	cs := &params.Run{
+		Clients: clients.Clients{
+			Log:    logger,
+			Tekton: stdata.Pipeline,
+			Kube:   stdata.Kube,
+		},
+	}
+	pac := info.NewPacOpts()
+	pac.ApplicationName = "Pipelines as Code CI"
+	cs.Info.Pac = pac
+
+	createMatchedPR := func(name string) Match {
+		return Match{
+			PipelineRun: &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		commitStatuses []provider.CommitStatusInfo
+		matchedPRs     []Match
+		expectedNames  []string
+	}{
+		{
+			name: "Fallback filters successful templates from commit statuses",
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / template-a", Status: "success"},
+				{Name: "Pipelines as Code CI / template-b", Status: "failed"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("template-a"),
+				createMatchedPR("template-b"),
+				createMatchedPR("template-c"),
+			},
+			expectedNames: []string{"template-b", "template-c"},
+		},
+		{
+			name: "Fallback with all successful statuses filters all",
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / template-a", Status: "success"},
+				{Name: "Pipelines as Code CI / template-b", Status: "successful"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("template-a"),
+				createMatchedPR("template-b"),
+			},
+			expectedNames: []string{},
+		},
+		{
+			name: "Fallback ignores statuses with different app name prefix",
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "Other App / template-a", Status: "success"},
+				{Name: "Pipelines as Code CI / template-b", Status: "success"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("template-a"),
+				createMatchedPR("template-b"),
+			},
+			expectedNames: []string{"template-a"},
+		},
+		{
+			name:           "No commit statuses re-runs all",
+			commitStatuses: nil,
+			matchedPRs: []Match{
+				createMatchedPR("template-a"),
+				createMatchedPR("template-b"),
+			},
+			expectedNames: []string{"template-a", "template-b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &info.Event{
+				EventType: "retest",
+				SHA:       "test-sha-pruned",
+			}
+			vcx := &testprovider.TestProviderImp{
+				CommitStatuses: tt.commitStatuses,
+			}
+
+			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, vcx, tt.matchedPRs)
+
+			assert.Equal(t, len(tt.expectedNames), len(filtered),
+				"Expected %d templates but got %d", len(tt.expectedNames), len(filtered))
+
+			var actualNames []string
+			for _, match := range filtered {
+				actualNames = append(actualNames, getName(match.PipelineRun))
+			}
+
+			for _, expectedName := range tt.expectedNames {
+				found := false
+				for _, actualName := range actualNames {
+					if actualName == expectedName {
+						found = true
+						break
+					}
+				}
+				assert.Assert(t, found, "Expected template %s not found in %v", expectedName, actualNames)
 			}
 		})
 	}

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -159,6 +159,10 @@ func (v *Provider) CreateStatus(_ context.Context, event *info.Event, statusopts
 	return nil
 }
 
+func (v *Provider) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
+	return nil, nil
+}
+
 func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, provenance string) (string, error) {
 	v.provenance = provenance
 	repositoryFiles, err := v.getDir(event, path)

--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
@@ -170,6 +170,10 @@ func (v *Provider) CreateStatus(ctx context.Context, event *info.Event, statusOp
 	return nil
 }
 
+func (v *Provider) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
+	return nil, nil
+}
+
 func (v *Provider) concatAllYamlFiles(ctx context.Context, objects []string, sha string, runevent *info.Event) (string, error) {
 	var allTemplates string
 	for _, value := range objects {

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -360,6 +360,10 @@ func (v *Provider) createStatusCommit(ctx context.Context, event *info.Event, pa
 	return nil
 }
 
+func (v *Provider) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
+	return nil, nil
+}
+
 func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, provenance string) (string, error) {
 	// default set provenance from the SHA
 	revision := event.SHA

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -330,6 +330,10 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 	return nil
 }
 
+func (v *Provider) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
+	return nil, nil
+}
+
 // GetTektonDir retrieves all YAML files from the .tekton directory and returns them as a single concatenated multi-document YAML file.
 func (v *Provider) GetTektonDir(ctx context.Context, runevent *info.Event, path, provenance string) (string, error) {
 	tektonDirSha := ""

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -438,6 +438,24 @@ func (v *Provider) CreateStatus(ctx context.Context, event *info.Event, statusOp
 	return nil
 }
 
+func (v *Provider) GetCommitStatuses(_ context.Context, event *info.Event) ([]provider.CommitStatusInfo, error) {
+	if v.gitlabClient == nil {
+		return nil, fmt.Errorf("%s", noClientErrStr)
+	}
+	statuses, _, err := v.Client().Commits.GetCommitStatuses(event.SourceProjectID, event.SHA, nil)
+	if err != nil {
+		return nil, err
+	}
+	var result []provider.CommitStatusInfo
+	for _, s := range statuses {
+		result = append(result, provider.CommitStatusInfo{
+			Name:   s.Name,
+			Status: s.Status,
+		})
+	}
+	return result, nil
+}
+
 func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, provenance string) (string, error) {
 	if v.gitlabClient == nil {
 		return "", fmt.Errorf("no gitlab client has been initialized, " +

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -33,6 +33,13 @@ type Interface interface {
 	CheckPolicyAllowing(context.Context, *info.Event, []string) (bool, string)
 	GetTemplate(CommentType) string
 	CreateComment(ctx context.Context, event *info.Event, comment, updateMarker string) error
+	GetCommitStatuses(ctx context.Context, event *info.Event) ([]CommitStatusInfo, error)
+}
+
+// CommitStatusInfo represents a commit status from a git provider.
+type CommitStatusInfo struct {
+	Name   string // e.g. "Pipelines as Code CI / always-good-pipelinerun"
+	Status string // provider-specific status string (e.g. "success", "failed")
 }
 
 const DefaultProviderAPIUser = "git"

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -34,6 +34,7 @@ type TestProviderImp struct {
 	FailGetCommitInfo      bool
 	CommitInfoErrorMsg     string
 	pacInfo                *info.PacOpts
+	CommitStatuses         []provider.CommitStatusInfo
 }
 
 func (v *TestProviderImp) SetPacInfo(pacInfo *info.PacOpts) {
@@ -141,4 +142,8 @@ func (v *TestProviderImp) CreateToken(_ context.Context, _ []string, _ *info.Eve
 
 func (v *TestProviderImp) GetTemplate(commentType provider.CommentType) string {
 	return provider.GetHTMLTemplate(commentType)
+}
+
+func (v *TestProviderImp) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
+	return v.CommitStatuses, nil
 }

--- a/test/gitlab_merge_request_retest_pruned_test.go
+++ b/test/gitlab_merge_request_retest_pruned_test.go
@@ -1,0 +1,170 @@
+//go:build e2e
+
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	clientGitlab "gitlab.com/gitlab-org/api/client-go"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestGitlabRetestAfterPipelineRunPruning reproduces the bug where /retest
+// re-runs all pipelines instead of only the failed ones when PipelineRun
+// objects have been pruned from the cluster.
+//
+// See: https://github.com/openshift-pipelines/pipelines-as-code/issues/2580
+//
+// Flow:
+// 1. Create MR with 2 pipelines: one that succeeds, one that fails
+// 2. Wait for both to complete
+// 3. Delete all PipelineRun objects (simulating pruning)
+// 4. Issue /retest
+// 5. Assert that only the failed pipeline is re-run (not both).
+func TestGitlabRetestAfterPipelineRunPruning(t *testing.T) {
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/always-good-pipelinerun.yaml": "testdata/always-good-pipelinerun.yaml",
+			".tekton/pipelinerun-exit-1.yaml":      "testdata/failures/pipelinerun-exit-1.yaml",
+		},
+	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
+
+	// Get MR to obtain the SHA
+	mr, _, err := topts.GLProvider.Client().MergeRequests.GetMergeRequest(topts.ProjectID, int64(topts.MRNumber), nil)
+	assert.NilError(t, err)
+
+	labelSelector := fmt.Sprintf("%s=%s", keys.SHA, formatting.CleanValueKubernetes(mr.SHA))
+
+	// Wait for both PipelineRuns to appear
+	topts.ParamsRun.Clients.Log.Infof("Waiting for 2 PipelineRuns to appear")
+	err = twait.UntilMinPRAppeared(ctx, topts.ParamsRun.Clients, twait.Opts{
+		RepoName:    topts.TargetNS,
+		Namespace:   topts.TargetNS,
+		PollTimeout: twait.DefaultTimeout,
+		TargetSHA:   formatting.CleanValueKubernetes(mr.SHA),
+	}, 2)
+	assert.NilError(t, err)
+
+	// Wait for repository to have at least 2 status entries (both pipelines reported)
+	topts.ParamsRun.Clients.Log.Infof("Waiting for Repository status to have 2 entries")
+	_, err = twait.UntilRepositoryUpdated(ctx, topts.ParamsRun.Clients, twait.Opts{
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
+		MinNumberStatus: 2,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       mr.SHA,
+	})
+	assert.NilError(t, err)
+
+	// Verify we have exactly 2 PipelineRuns
+	pruns, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pruns.Items), 2, "expected 2 initial PipelineRuns")
+
+	// Record initial PipelineRun names so we can distinguish old from new after /retest
+	initialPRNames := map[string]bool{}
+	for _, pr := range pruns.Items {
+		initialPRNames[pr.Name] = true
+	}
+
+	// Verify GitLab commit statuses: 1 success + 1 failure
+	commitStatuses, _, err := topts.GLProvider.Client().Commits.GetCommitStatuses(topts.ProjectID, mr.SHA, &clientGitlab.GetCommitStatusesOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, len(commitStatuses) >= 2, "expected at least 2 commit statuses, got %d", len(commitStatuses))
+
+	successCount := 0
+	failureCount := 0
+	for _, cs := range commitStatuses {
+		switch cs.Status {
+		case "success":
+			successCount++
+		case "failed":
+			failureCount++
+		}
+	}
+	assert.Assert(t, successCount >= 1, "expected at least 1 successful commit status")
+	assert.Assert(t, failureCount >= 1, "expected at least 1 failed commit status")
+
+	// Simulate pruning: delete all PipelineRun objects
+	topts.ParamsRun.Clients.Log.Infof("Deleting all PipelineRuns to simulate pruning")
+	err = topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).DeleteCollection(ctx,
+		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: labelSelector})
+	assert.NilError(t, err)
+
+	// Wait for pruning to complete (DeleteCollection is async)
+	// This is best-effort — the real assertion is on new PipelineRuns after /retest
+	topts.ParamsRun.Clients.Log.Infof("Waiting for PipelineRuns to be deleted")
+	pollErr := kubeinteraction.PollImmediateWithContext(ctx, twait.DefaultTimeout, func() (bool, error) {
+		pruns, err = topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			return false, err
+		}
+		topts.ParamsRun.Clients.Log.Infof("Waiting for PipelineRuns to be deleted: %d remaining", len(pruns.Items))
+		return len(pruns.Items) == 0, nil
+	})
+	if pollErr != nil {
+		topts.ParamsRun.Clients.Log.Infof("Warning: PipelineRuns not fully deleted after polling: %v (proceeding anyway)", pollErr)
+	}
+
+	// Issue /retest comment on the MR
+	topts.ParamsRun.Clients.Log.Infof("Posting /retest comment on MR %d", topts.MRNumber)
+	_, _, err = topts.GLProvider.Client().Notes.CreateMergeRequestNote(topts.ProjectID, int64(topts.MRNumber),
+		&clientGitlab.CreateMergeRequestNoteOptions{Body: clientGitlab.Ptr("/retest")})
+	assert.NilError(t, err)
+
+	// Wait for retest pipeline(s) to be created
+	// After /retest, we expect only 1 new PipelineRun (the failed one re-runs)
+	topts.ParamsRun.Clients.Log.Infof("Waiting for retest PipelineRun(s) to appear")
+	err = twait.UntilMinPRAppeared(ctx, topts.ParamsRun.Clients, twait.Opts{
+		RepoName:    topts.TargetNS,
+		Namespace:   topts.TargetNS,
+		PollTimeout: twait.DefaultTimeout,
+		TargetSHA:   formatting.CleanValueKubernetes(mr.SHA),
+	}, 1)
+	assert.NilError(t, err)
+
+	// Wait for repository status to be updated with the retest result
+	// We expect the re-run pipeline to fail (it's pipelinerun-exit-1), so disable
+	// the default FailOnRepoCondition=False check by setting it to a no-match value.
+	_, err = twait.UntilRepositoryUpdated(ctx, topts.ParamsRun.Clients, twait.Opts{
+		RepoName:            topts.TargetNS,
+		Namespace:           topts.TargetNS,
+		MinNumberStatus:     3,
+		PollTimeout:         twait.DefaultTimeout,
+		TargetSHA:           mr.SHA,
+		FailOnRepoCondition: "no-match",
+	})
+	assert.NilError(t, err)
+
+	// Assert: only the failed pipeline should have been re-run
+	prunsAfterRetest, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+
+	// Count only NEW PipelineRuns (filter out any old ones that may still be lingering)
+	newCount := 0
+	for _, pr := range prunsAfterRetest.Items {
+		if !initialPRNames[pr.Name] {
+			newCount++
+		}
+	}
+	assert.Equal(t, newCount, 1,
+		"expected only 1 new PipelineRun after /retest (only the failed pipeline should re-run), but got %d",
+		newCount)
+}


### PR DESCRIPTION
Added a fallback mechanism to retrieve commit statuses from the git
provider when the corresponding PipelineRuns are missing from the
cluster due to pruning. This ensures that the retest logic correctly
identifies previously successful templates and avoids re-running them
unnecessarily.

Issues Related (partial): #2580
Jira: https://issues.redhat.com/browse/SRVKP-11112
Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
