### PR TITLE
gitlab: implement commit status fallback for retest

### DIFF
--- a/docs/content/docs/guides/gitops-commands/_index.md
+++ b/docs/content/docs/guides/gitops-commands/_index.md
@@ -25,7 +25,7 @@ failure is not with your PR but seems to be an infrastructure issue.
 - Previously **failed** PipelineRuns exist for the same commit, OR
 - No PipelineRun has run for the same commit yet
 
-If a successful PipelineRun already exists for the same commit, `/retest` **skips** it to avoid unnecessary duplication.
+If a successful PipelineRun already exists for the same commit, `/retest` **skips** it to avoid unnecessary duplication. When PipelineRuns have been pruned from the cluster (for example, by a retention policy), Pipelines-as-Code falls back to querying the Git provider's commit status API to determine which pipelines previously succeeded, ensuring only failed pipelines are re-run even when the original PipelineRun objects no longer exist.
 
 **When to use it:** To force a rerun regardless of previous status, use:
 

--- a/docs/content/docs/guides/repository-crd/comment-settings.md
+++ b/docs/content/docs/guides/repository-crd/comment-settings.md
@@ -41,6 +41,15 @@ in the target repository, because GitLab only creates pipeline entries for commi
 that actually trigger CI in that specific project. If either status update
 succeeds, Pipelines-as-Code does not post a comment on the Merge Request.
 
+Successful commit status reporting is also important for the `/retest` command.
+When PipelineRuns are pruned from the cluster, Pipelines-as-Code queries
+GitLab's commit status API to identify which pipelines previously succeeded,
+ensuring only failed pipelines are re-run. If commit statuses were never
+reported (for example, because both status updates failed and only a comment was
+posted), Pipelines-as-Code cannot determine prior results and will fail to
+re-run any pipelines when `/retest` unless you retest individual pipelineruns
+with `/test <pipeline-name>`.
+
 When a status update succeeds, you can see the status in the GitLab UI in the `Pipelines` tab, as
 shown in the following example:
 

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -424,7 +424,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 		if event.EventType == opscomments.RetestAllCommentEventType.String() ||
 			event.EventType == opscomments.OkToTestCommentEventType.String() {
 			logger.Debugf("MatchPipelinerunByAnnotation: filtering successful templates for event_type=%s", event.EventType)
-			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, matchedPRs)
+			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, vcx, matchedPRs)
 			if len(filtered) == 0 {
 				return nil, ErrNoFailedPipelineToRetest
 			}
@@ -438,7 +438,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 
 // filterSuccessfulTemplates filters out templates that already have successful PipelineRuns
 // when executing /ok-to-test or /retest gitops commands, implementing per-template checking.
-func filterSuccessfulTemplates(ctx context.Context, logger *zap.SugaredLogger, cs *params.Run, event *info.Event, repo *apipac.Repository, matchedPRs []Match) []Match {
+func filterSuccessfulTemplates(ctx context.Context, logger *zap.SugaredLogger, cs *params.Run, event *info.Event, repo *apipac.Repository, vcx provider.Interface, matchedPRs []Match) []Match {
 	if event.SHA == "" {
 		return matchedPRs
 	}
@@ -469,12 +469,26 @@ func filterSuccessfulTemplates(ctx context.Context, logger *zap.SugaredLogger, c
 			continue // Skip PipelineRuns without template identification
 		}
 
-		// Check if this PipelineRun succeeded
+		// Only completed successful PipelineRuns should suppress a /retest.
 		if pr.Status.GetCondition(apis.ConditionSucceeded).IsTrue() {
 			// Keep the most recent successful run for each template
 			if existing, exists := successfulTemplates[originalPRName]; !exists ||
 				pr.CreationTimestamp.After(existing.CreationTimestamp.Time) {
 				successfulTemplates[originalPRName] = pr
+			}
+		}
+	}
+
+	// Also check provider commit statuses (covers pruned PipelineRuns)
+	commitStatuses, err := vcx.GetCommitStatuses(ctx, event)
+	if err != nil {
+		logger.Warnf("failed to get commit statuses from provider for SHA %s: %v", event.SHA, err)
+	} else if len(commitStatuses) > 0 {
+		appName := cs.Info.GetPacOpts().ApplicationName
+		for _, cs := range commitStatuses {
+			originalName := parseOriginalPRName(cs.Name, appName)
+			if originalName != "" && isSuccessStatus(cs.Status) {
+				successfulTemplates[originalName] = &tektonv1.PipelineRun{} // placeholder
 			}
 		}
 	}
@@ -495,6 +509,26 @@ func filterSuccessfulTemplates(ctx context.Context, logger *zap.SugaredLogger, c
 
 	// Return the filtered list (which may be empty if all templates were skipped)
 	return filteredPRs
+}
+
+// parseOriginalPRName extracts the original PipelineRun name from a commit status name.
+// The commit status name format is "ApplicationName / OriginalPRName".
+func parseOriginalPRName(checkName, appName string) string {
+	prefix := appName + " / "
+	if strings.HasPrefix(checkName, prefix) {
+		return strings.TrimPrefix(checkName, prefix)
+	}
+	return ""
+}
+
+// isSuccessStatus returns true if the status string represents a successful state
+// across different git providers.
+func isSuccessStatus(status string) bool {
+	switch strings.ToLower(status) {
+	case "success", "successful", "completed":
+		return true
+	}
+	return false
 }
 
 func buildAvailableMatchingAnnotationErr(event *info.Event, pruns []*tektonv1.PipelineRun) string {

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -25,6 +25,7 @@ import (
 	ghprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
+	testprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/test/provider"
 	testnewrepo "github.com/openshift-pipelines/pipelines-as-code/pkg/test/repository"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.uber.org/zap"
@@ -3078,6 +3079,33 @@ func TestFilterSuccessfulTemplates(t *testing.T) {
 		},
 	}
 
+	// Template E: has a running run - should be kept for /retest
+	runningPRE := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "template-e-running",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				keys.SHA:            "test-sha",
+				keys.OriginalPRName: "template-e",
+			},
+			Annotations: map[string]string{
+				keys.OriginalPRName: "template-e",
+			},
+			CreationTimestamp: now,
+		},
+		Status: tektonv1.PipelineRunStatus{
+			Status: knativeduckv1.Status{
+				Conditions: knativeduckv1.Conditions{
+					apis.Condition{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionUnknown,
+						Reason: "Running",
+					},
+				},
+			},
+		},
+	}
+
 	// PipelineRun with different SHA - should not interfere
 	differentSHAPR := &tektonv1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3128,7 +3156,7 @@ func TestFilterSuccessfulTemplates(t *testing.T) {
 	// Setup test clients
 	tdata := testclient.Data{
 		PipelineRuns: []*tektonv1.PipelineRun{
-			successfulPRA, failedPRB, olderSuccessfulPRD, newerSuccessfulPRD, differentSHAPR, noOriginalNamePR,
+			successfulPRA, failedPRB, olderSuccessfulPRD, newerSuccessfulPRD, runningPRE, differentSHAPR, noOriginalNamePR,
 		},
 		Repositories: []*v1alpha1.Repository{repo},
 	}
@@ -3169,8 +3197,9 @@ func TestFilterSuccessfulTemplates(t *testing.T) {
 				createMatchedPR("template-b"), // has failed run - should be kept
 				createMatchedPR("template-c"), // no previous runs - should be kept
 				createMatchedPR("template-d"), // has multiple successful runs - should be filtered
+				createMatchedPR("template-e"), // has a running run - should be kept
 			},
-			expectedNames: []string{"template-b", "template-c"},
+			expectedNames: []string{"template-b", "template-c", "template-e"},
 		},
 		{
 			name:      "Ok-to-test command filters templates with successful runs",
@@ -3250,7 +3279,7 @@ func TestFilterSuccessfulTemplates(t *testing.T) {
 				return
 			}
 
-			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, tt.matchedPRs)
+			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, &ghprovider.Provider{}, tt.matchedPRs)
 
 			// Check that the correct number of templates remain
 			assert.Equal(t, len(tt.expectedNames), len(filtered),
@@ -3284,6 +3313,133 @@ func TestFilterSuccessfulTemplates(t *testing.T) {
 					}
 				}
 				assert.Assert(t, found, "Unexpected template %s found in %v", actualName, actualNames)
+			}
+		})
+	}
+}
+
+func TestFilterSuccessfulTemplatesFallbackToCommitStatuses(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.DebugLevel)
+	logger := zap.New(observer).Sugar()
+
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo",
+			Namespace: "test-ns",
+		},
+	}
+
+	// No PipelineRuns in the cluster (pruned)
+	tdata := testclient.Data{
+		Repositories: []*v1alpha1.Repository{repo},
+	}
+	stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+
+	cs := &params.Run{
+		Clients: clients.Clients{
+			Log:    logger,
+			Tekton: stdata.Pipeline,
+			Kube:   stdata.Kube,
+		},
+	}
+	pac := info.NewPacOpts()
+	pac.ApplicationName = "Pipelines as Code CI"
+	cs.Info.Pac = pac
+
+	createMatchedPR := func(name string) Match {
+		return Match{
+			PipelineRun: &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		commitStatuses []provider.CommitStatusInfo
+		matchedPRs     []Match
+		expectedNames  []string
+	}{
+		{
+			name: "Fallback filters successful templates from commit statuses",
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / template-a", Status: "success"},
+				{Name: "Pipelines as Code CI / template-b", Status: "failed"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("template-a"),
+				createMatchedPR("template-b"),
+				createMatchedPR("template-c"),
+			},
+			expectedNames: []string{"template-b", "template-c"},
+		},
+		{
+			name: "Fallback with all successful statuses filters all",
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / template-a", Status: "success"},
+				{Name: "Pipelines as Code CI / template-b", Status: "successful"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("template-a"),
+				createMatchedPR("template-b"),
+			},
+			expectedNames: []string{},
+		},
+		{
+			name: "Fallback ignores statuses with different app name prefix",
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "Other App / template-a", Status: "success"},
+				{Name: "Pipelines as Code CI / template-b", Status: "success"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("template-a"),
+				createMatchedPR("template-b"),
+			},
+			expectedNames: []string{"template-a"},
+		},
+		{
+			name:           "No commit statuses re-runs all",
+			commitStatuses: nil,
+			matchedPRs: []Match{
+				createMatchedPR("template-a"),
+				createMatchedPR("template-b"),
+			},
+			expectedNames: []string{"template-a", "template-b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &info.Event{
+				EventType: "retest",
+				SHA:       "test-sha-pruned",
+			}
+			vcx := &testprovider.TestProviderImp{
+				CommitStatuses: tt.commitStatuses,
+			}
+
+			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, vcx, tt.matchedPRs)
+
+			assert.Equal(t, len(tt.expectedNames), len(filtered),
+				"Expected %d templates but got %d", len(tt.expectedNames), len(filtered))
+
+			var actualNames []string
+			for _, match := range filtered {
+				actualNames = append(actualNames, getName(match.PipelineRun))
+			}
+
+			for _, expectedName := range tt.expectedNames {
+				found := false
+				for _, actualName := range actualNames {
+					if actualName == expectedName {
+						found = true
+						break
+					}
+				}
+				assert.Assert(t, found, "Expected template %s not found in %v", expectedName, actualNames)
 			}
 		})
 	}

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -159,6 +159,10 @@ func (v *Provider) CreateStatus(_ context.Context, event *info.Event, statusopts
 	return nil
 }
 
+func (v *Provider) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
+	return nil, nil
+}
+
 func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, provenance string) (string, error) {
 	v.provenance = provenance
 	repositoryFiles, err := v.getDir(event, path)

--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
@@ -170,6 +170,10 @@ func (v *Provider) CreateStatus(ctx context.Context, event *info.Event, statusOp
 	return nil
 }
 
+func (v *Provider) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
+	return nil, nil
+}
+
 func (v *Provider) concatAllYamlFiles(ctx context.Context, objects []string, sha string, runevent *info.Event) (string, error) {
 	var allTemplates string
 	for _, value := range objects {

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -360,6 +360,10 @@ func (v *Provider) createStatusCommit(ctx context.Context, event *info.Event, pa
 	return nil
 }
 
+func (v *Provider) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
+	return nil, nil
+}
+
 func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, provenance string) (string, error) {
 	// default set provenance from the SHA
 	revision := event.SHA

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -330,6 +330,10 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 	return nil
 }
 
+func (v *Provider) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
+	return nil, nil
+}
+
 // GetTektonDir retrieves all YAML files from the .tekton directory and returns them as a single concatenated multi-document YAML file.
 func (v *Provider) GetTektonDir(ctx context.Context, runevent *info.Event, path, provenance string) (string, error) {
 	tektonDirSha := ""

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -438,6 +438,67 @@ func (v *Provider) CreateStatus(ctx context.Context, event *info.Event, statusOp
 	return nil
 }
 
+func (v *Provider) GetCommitStatuses(_ context.Context, event *info.Event) ([]provider.CommitStatusInfo, error) {
+	if v.gitlabClient == nil {
+		return nil, fmt.Errorf("%s", noClientErrStr)
+	}
+
+	sourceProjectID := event.SourceProjectID
+	if sourceProjectID == 0 {
+		sourceProjectID = v.sourceProjectID
+	}
+
+	targetProjectID := event.TargetProjectID
+	if targetProjectID == 0 {
+		targetProjectID = v.targetProjectID
+	}
+
+	projectIDs := []int64{}
+	if sourceProjectID != 0 {
+		projectIDs = append(projectIDs, sourceProjectID)
+	}
+	if targetProjectID != 0 && targetProjectID != sourceProjectID {
+		projectIDs = append(projectIDs, targetProjectID)
+	}
+
+	var (
+		firstErr error
+		result   []provider.CommitStatusInfo
+		seen     = map[string]struct{}{}
+	)
+
+	for _, projectID := range projectIDs {
+		statuses, _, err := v.Client().Commits.GetCommitStatuses(projectID, event.SHA, &gitlab.GetCommitStatusesOptions{})
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			if v.Logger != nil {
+				v.Logger.Debugf("failed to get commit statuses from gitlab project ID %d for SHA %s: %v", projectID, event.SHA, err)
+			}
+			continue
+		}
+
+		for _, s := range statuses {
+			key := fmt.Sprintf("%s\x00%s", s.Name, s.Status)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			result = append(result, provider.CommitStatusInfo{
+				Name:   s.Name,
+				Status: s.Status,
+			})
+		}
+	}
+
+	if len(result) > 0 {
+		return result, nil
+	}
+
+	return nil, firstErr
+}
+
 func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, provenance string) (string, error) {
 	if v.gitlabClient == nil {
 		return "", fmt.Errorf("no gitlab client has been initialized, " +

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	thelp "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab/test"
 	providerstatus "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
@@ -577,6 +578,97 @@ func TestGetCommitInfo(t *testing.T) {
 					}
 				}
 			}
+		})
+	}
+}
+
+func TestGetCommitStatuses(t *testing.T) {
+	tests := []struct {
+		name         string
+		event        *info.Event
+		provider     *Provider
+		mockHandlers map[string]func(http.ResponseWriter, *http.Request)
+		want         []provider.CommitStatusInfo
+	}{
+		{
+			name: "uses event source project statuses",
+			event: &info.Event{
+				SHA:             "abc123",
+				SourceProjectID: 101,
+				TargetProjectID: 202,
+			},
+			provider: &Provider{},
+			mockHandlers: map[string]func(http.ResponseWriter, *http.Request){
+				"/projects/101/repository/commits/abc123/statuses": func(rw http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, r.Method, http.MethodGet)
+					fmt.Fprint(rw, `[{"name":"Pipelines as Code CI / always-good-pipelinerun","status":"success"},{"name":"Pipelines as Code CI / pipelinerun-exit-1","status":"failed"}]`)
+				},
+			},
+			want: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / always-good-pipelinerun", Status: "success"},
+				{Name: "Pipelines as Code CI / pipelinerun-exit-1", Status: "failed"},
+			},
+		},
+		{
+			name: "falls back to provider source project id when event source project id is empty",
+			event: &info.Event{
+				SHA:             "def456",
+				TargetProjectID: 202,
+			},
+			provider: &Provider{
+				sourceProjectID: 303,
+			},
+			mockHandlers: map[string]func(http.ResponseWriter, *http.Request){
+				"/projects/303/repository/commits/def456/statuses": func(rw http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, r.Method, http.MethodGet)
+					fmt.Fprint(rw, `[{"name":"Pipelines as Code CI / from-provider-source","status":"success"}]`)
+				},
+			},
+			want: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / from-provider-source", Status: "success"},
+			},
+		},
+		{
+			name: "falls back to target project when source project lookup fails",
+			event: &info.Event{
+				SHA:             "fedcba",
+				SourceProjectID: 404,
+				TargetProjectID: 505,
+			},
+			provider: &Provider{},
+			mockHandlers: map[string]func(http.ResponseWriter, *http.Request){
+				"/projects/404/repository/commits/fedcba/statuses": func(rw http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, r.Method, http.MethodGet)
+					rw.WriteHeader(http.StatusNotFound)
+					fmt.Fprint(rw, `{"message":"404 Project Not Found"}`)
+				},
+				"/projects/505/repository/commits/fedcba/statuses": func(rw http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, r.Method, http.MethodGet)
+					fmt.Fprint(rw, `[{"name":"Pipelines as Code CI / from-target","status":"success"}]`)
+				},
+			},
+			want: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / from-target", Status: "success"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeclient, mux, tearDown := thelp.Setup(t)
+			defer tearDown()
+			logger, _ := logger.GetLogger()
+
+			for endpoint, handler := range tt.mockHandlers {
+				mux.HandleFunc(endpoint, handler)
+			}
+
+			tt.provider.gitlabClient = fakeclient
+			tt.provider.Logger = logger
+
+			got, err := tt.provider.GetCommitStatuses(context.Background(), tt.event)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
 		})
 	}
 }

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -33,6 +33,13 @@ type Interface interface {
 	CheckPolicyAllowing(context.Context, *info.Event, []string) (bool, string)
 	GetTemplate(CommentType) string
 	CreateComment(ctx context.Context, event *info.Event, comment, updateMarker string) error
+	GetCommitStatuses(ctx context.Context, event *info.Event) ([]CommitStatusInfo, error)
+}
+
+// CommitStatusInfo represents a commit status from a git provider.
+type CommitStatusInfo struct {
+	Name   string // e.g. "Pipelines as Code CI / always-good-pipelinerun"
+	Status string // provider-specific status string (e.g. "success", "failed")
 }
 
 const DefaultProviderAPIUser = "git"

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -34,6 +34,7 @@ type TestProviderImp struct {
 	FailGetCommitInfo      bool
 	CommitInfoErrorMsg     string
 	pacInfo                *info.PacOpts
+	CommitStatuses         []provider.CommitStatusInfo
 }
 
 func (v *TestProviderImp) SetPacInfo(pacInfo *info.PacOpts) {
@@ -141,4 +142,8 @@ func (v *TestProviderImp) CreateToken(_ context.Context, _ []string, _ *info.Eve
 
 func (v *TestProviderImp) GetTemplate(commentType provider.CommentType) string {
 	return provider.GetHTMLTemplate(commentType)
+}
+
+func (v *TestProviderImp) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
+	return v.CommitStatuses, nil
 }

--- a/test/README.md
+++ b/test/README.md
@@ -47,6 +47,8 @@ this repo should differ from the one which is configured as part of `TEST_GITHUB
 - `TEST_GITLAB_API_URL` - Gitlab API URL i.e: `https://gitlab.com`
 - `TEST_GITLAB_GROUP` - Gitlab group/namespace where test projects will be created and deleted
 - `TEST_GITLAB_TOKEN` - Gitlab Token
+- `TEST_GITLAB_SECOND_TOKEN` - Optional second GitLab token from a different user for fork-based GitLab tests
+- `TEST_GITLAB_SECOND_GROUP` - Optional group/namespace where the second user should create forks
 - `TEST_GITLAB_SMEEURL` - Smee URL for forwarding GitLab webhooks to the controller
 - `TEST_GITEA_API_URL` - URL where GITEA is running (i.e: [GITEA_HOST](http://localhost:3000))
 - `TEST_GITEA_SMEEURL` - URL of smee
@@ -132,10 +134,14 @@ instance to your local controller (the same pattern as Gitea tests).
    export TEST_GITLAB_API_URL=https://gitlab.pipelinesascode.com
    export TEST_GITLAB_TOKEN=<your-token>
    export TEST_GITLAB_GROUP=<your-group>
+   export TEST_GITLAB_SECOND_TOKEN=<second-user-token> # optional, required for real fork fallback tests
+   export TEST_GITLAB_SECOND_GROUP=<second-user-group> # optional, recommended when the second user has multiple namespaces
    export TEST_GITLAB_SMEEURL="${SMEE_URL}"
    export TEST_EL_URL=https://your-controller-url
    export TEST_EL_WEBHOOK_SECRET=<your-webhook-secret>
    ```
+
+   Fork-status fallback tests skip automatically when `TEST_GITLAB_SECOND_TOKEN` is not set.
 
 4. Run the tests:
 

--- a/test/e2e-config.yaml.example
+++ b/test/e2e-config.yaml.example
@@ -47,8 +47,14 @@ github_enterprise:
 gitlab:
   api_url: "https://gitlab.com"
   token: ""
+  # Optional second identity for fork-based GitLab tests.
+  # Use a token from a different GitLab user than `token`.
+  second_token: ""
   # Group/namespace where test projects will be created and deleted
   group: "pac-e2e-tests"
+  # Optional namespace for forks created by `second_token`.
+  # If omitted, GitLab uses the second user's default namespace.
+  second_group: ""
   smee_url: ""  # Auto-generated in CI; set manually for local testing
 
 # Gitea / Forgejo

--- a/test/gitlab_merge_request_retest_pruned_test.go
+++ b/test/gitlab_merge_request_retest_pruned_test.go
@@ -1,0 +1,397 @@
+//go:build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	clientGitlab "gitlab.com/gitlab-org/api/client-go"
+	"go.uber.org/zap"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestGitlabRetestAfterPipelineRunPruning reproduces the bug where /retest
+// re-runs all pipelines instead of only the failed ones when PipelineRun
+// objects have been pruned from the cluster.
+//
+// See: https://github.com/openshift-pipelines/pipelines-as-code/issues/2580
+//
+// Flow:
+// 1. Create MR with 2 pipelines: one that succeeds, one that fails
+// 2. Wait for both to complete
+// 3. Delete all PipelineRun objects (simulating pruning)
+// 4. Issue /retest
+// 5. Assert that only the failed pipeline is re-run (not both).
+func TestGitlabRetestAfterPipelineRunPruning(t *testing.T) {
+	topts := &tgitlab.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/always-good-pipelinerun.yaml": "testdata/always-good-pipelinerun.yaml",
+			".tekton/pipelinerun-exit-1.yaml":      "testdata/failures/pipelinerun-exit-1.yaml",
+		},
+	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
+
+	// Get MR to obtain the SHA
+	mr, _, err := topts.GLProvider.Client().MergeRequests.GetMergeRequest(topts.ProjectID, int64(topts.MRNumber), nil)
+	assert.NilError(t, err)
+
+	labelSelector := fmt.Sprintf("%s=%s", keys.SHA, formatting.CleanValueKubernetes(mr.SHA))
+
+	// Wait for both PipelineRuns to appear
+	topts.ParamsRun.Clients.Log.Infof("Waiting for 2 PipelineRuns to appear")
+	err = twait.UntilMinPRAppeared(ctx, topts.ParamsRun.Clients, twait.Opts{
+		RepoName:    topts.TargetNS,
+		Namespace:   topts.TargetNS,
+		PollTimeout: twait.DefaultTimeout,
+		TargetSHA:   formatting.CleanValueKubernetes(mr.SHA),
+	}, 2)
+	assert.NilError(t, err)
+
+	// Wait for repository to have at least 2 status entries (both pipelines reported)
+	topts.ParamsRun.Clients.Log.Infof("Waiting for Repository status to have 2 entries")
+	_, err = twait.UntilRepositoryUpdated(ctx, topts.ParamsRun.Clients, twait.Opts{
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
+		MinNumberStatus: 2,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       mr.SHA,
+	})
+	assert.NilError(t, err)
+
+	// Verify we have exactly 2 PipelineRuns
+	pruns, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pruns.Items), 2, "expected 2 initial PipelineRuns")
+
+	// Record initial PipelineRun names so we can distinguish old from new after /retest
+	initialPRNames := map[string]bool{}
+	for _, pr := range pruns.Items {
+		initialPRNames[pr.Name] = true
+	}
+
+	// Verify GitLab commit statuses: 1 success + 1 failure
+	commitStatuses, _, err := topts.GLProvider.Client().Commits.GetCommitStatuses(topts.ProjectID, mr.SHA, &clientGitlab.GetCommitStatusesOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, len(commitStatuses) >= 2, "expected at least 2 commit statuses, got %d", len(commitStatuses))
+
+	successCount := 0
+	failureCount := 0
+	for _, cs := range commitStatuses {
+		switch cs.Status {
+		case "success":
+			successCount++
+		case "failed":
+			failureCount++
+		}
+	}
+	assert.Assert(t, successCount >= 1, "expected at least 1 successful commit status")
+	assert.Assert(t, failureCount >= 1, "expected at least 1 failed commit status")
+
+	// Simulate pruning: delete all PipelineRun objects
+	topts.ParamsRun.Clients.Log.Infof("Deleting all PipelineRuns to simulate pruning")
+	err = topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).DeleteCollection(ctx,
+		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: labelSelector})
+	assert.NilError(t, err)
+
+	// Wait for pruning to complete (DeleteCollection is async)
+	// This is best-effort — the real assertion is on new PipelineRuns after /retest
+	topts.ParamsRun.Clients.Log.Infof("Waiting for PipelineRuns to be deleted")
+	pollErr := kubeinteraction.PollImmediateWithContext(ctx, twait.DefaultTimeout, func() (bool, error) {
+		pruns, err = topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			return false, err
+		}
+		topts.ParamsRun.Clients.Log.Infof("Waiting for PipelineRuns to be deleted: %d remaining", len(pruns.Items))
+		return len(pruns.Items) == 0, nil
+	})
+	if pollErr != nil {
+		topts.ParamsRun.Clients.Log.Infof("Warning: PipelineRuns not fully deleted after polling: %v (proceeding anyway)", pollErr)
+	}
+
+	// Issue /retest comment on the MR
+	topts.ParamsRun.Clients.Log.Infof("Posting /retest comment on MR %d", topts.MRNumber)
+	_, _, err = topts.GLProvider.Client().Notes.CreateMergeRequestNote(topts.ProjectID, int64(topts.MRNumber),
+		&clientGitlab.CreateMergeRequestNoteOptions{Body: clientGitlab.Ptr("/retest")})
+	assert.NilError(t, err)
+
+	// Wait for retest pipeline(s) to be created
+	// After /retest, we expect only 1 new PipelineRun (the failed one re-runs)
+	topts.ParamsRun.Clients.Log.Infof("Waiting for retest PipelineRun(s) to appear")
+	err = twait.UntilMinPRAppeared(ctx, topts.ParamsRun.Clients, twait.Opts{
+		RepoName:    topts.TargetNS,
+		Namespace:   topts.TargetNS,
+		PollTimeout: twait.DefaultTimeout,
+		TargetSHA:   formatting.CleanValueKubernetes(mr.SHA),
+	}, 1)
+	assert.NilError(t, err)
+
+	// Wait for repository status to be updated with the retest result
+	// We expect the re-run pipeline to fail (it's pipelinerun-exit-1), so disable
+	// the default FailOnRepoCondition=False check by setting it to a no-match value.
+	_, err = twait.UntilRepositoryUpdated(ctx, topts.ParamsRun.Clients, twait.Opts{
+		RepoName:            topts.TargetNS,
+		Namespace:           topts.TargetNS,
+		MinNumberStatus:     3,
+		PollTimeout:         twait.DefaultTimeout,
+		TargetSHA:           mr.SHA,
+		FailOnRepoCondition: "no-match",
+	})
+	assert.NilError(t, err)
+
+	// Assert: only the failed pipeline should have been re-run
+	prunsAfterRetest, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+
+	// Count only NEW PipelineRuns (filter out any old ones that may still be lingering)
+	newCount := 0
+	for _, pr := range prunsAfterRetest.Items {
+		if !initialPRNames[pr.Name] {
+			newCount++
+		}
+	}
+	assert.Equal(t, newCount, 1,
+		"expected only 1 new PipelineRun after /retest (only the failed pipeline should re-run), but got %d",
+		newCount)
+}
+
+func TestGitlabRetestAfterPipelineRunPruningFromFork(t *testing.T) {
+	if !tgitlab.HasSecondIdentity() {
+		t.Skip("Skipping fork retest pruning test: TEST_GITLAB_SECOND_TOKEN is not configured")
+	}
+
+	topts := &tgitlab.TestOpts{
+		NoMRCreation: true,
+		TargetEvent:  triggertype.PullRequest.String(),
+	}
+	ctx, cleanup := tgitlab.TestMR(t, topts)
+	defer cleanup()
+
+	assert.NilError(t, tgitlab.SetupSecondIdentity(ctx, topts))
+
+	secondUser, _, err := topts.SecondGLProvider.Client().Users.CurrentUser()
+	assert.NilError(t, err)
+	assert.NilError(t, tgitlab.AddGitLabProjectMember(
+		topts.GLProvider.Client(),
+		topts.ProjectID,
+		secondUser.ID,
+		clientGitlab.DeveloperPermissions,
+		topts.ParamsRun.Clients.Log,
+	))
+
+	topts.ParamsRun.Clients.Log.Infof("Fork destination group: %q (TEST_GITLAB_SECOND_GROUP)",
+		os.Getenv("TEST_GITLAB_SECOND_GROUP"))
+	forkProject, err := tgitlab.ForkGitLabProject(
+		topts.SecondGLProvider.Client(),
+		topts.ProjectID,
+		os.Getenv("TEST_GITLAB_SECOND_GROUP"),
+		topts.ParamsRun.Clients.Log,
+	)
+	assert.NilError(t, err)
+	defer func() {
+		topts.ParamsRun.Clients.Log.Infof("Deleting fork project %d", forkProject.ID)
+		_, err := topts.SecondGLProvider.Client().Projects.DeleteProject(forkProject.ID, nil)
+		if err != nil {
+			t.Logf("Error deleting fork project %d: %v", forkProject.ID, err)
+		}
+	}()
+
+	// Grant the first user (webhook token) access to the fork so the controller can read .tekton
+	firstUser, _, err := topts.GLProvider.Client().Users.CurrentUser()
+	assert.NilError(t, err)
+	assert.NilError(t, tgitlab.AddGitLabProjectMember(
+		topts.SecondGLProvider.Client(),
+		int(forkProject.ID),
+		firstUser.ID,
+		clientGitlab.DeveloperPermissions,
+		topts.ParamsRun.Clients.Log,
+	))
+
+	time.Sleep(5 * time.Second)
+
+	entries, err := payload.GetEntries(map[string]string{
+		".tekton/always-good-pipelinerun.yaml": "testdata/always-good-pipelinerun.yaml",
+		".tekton/pipelinerun-exit-1.yaml":      "testdata/failures/pipelinerun-exit-1.yaml",
+	}, topts.TargetNS, topts.DefaultBranch, triggertype.PullRequest.String(), map[string]string{})
+	assert.NilError(t, err)
+
+	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-fork-retest")
+	forkCloneURL, err := scm.MakeGitCloneURL(forkProject.WebURL, topts.SecondOpts.UserName, topts.SecondOpts.Password)
+	assert.NilError(t, err)
+
+	_ = scm.PushFilesToRefGit(t, &scm.Opts{
+		GitURL:        forkCloneURL,
+		CommitTitle:   "Add forked retest pruning fixtures - " + targetRefName,
+		Log:           topts.ParamsRun.Clients.Log,
+		WebURL:        forkProject.WebURL,
+		TargetRefName: targetRefName,
+		BaseRefName:   topts.DefaultBranch,
+	}, entries)
+
+	topts.ParamsRun.Clients.Log.Infof("Pushed test files to fork at ref %q", targetRefName)
+	mrTitle := "TestRetestAfterPipelineRunPruningFromFork - " + targetRefName
+	mr, _, err := topts.SecondGLProvider.Client().MergeRequests.CreateMergeRequest(forkProject.ID, &clientGitlab.CreateMergeRequestOptions{
+		Title:           &mrTitle,
+		SourceBranch:    &targetRefName,
+		TargetBranch:    &topts.DefaultBranch,
+		TargetProjectID: &topts.ProjectInfo.ID,
+	})
+	assert.NilError(t, err)
+	defer func() {
+		_, _, err := topts.GLProvider.Client().MergeRequests.UpdateMergeRequest(topts.ProjectID, mr.IID,
+			&clientGitlab.UpdateMergeRequestOptions{StateEvent: clientGitlab.Ptr("close")})
+		if err != nil {
+			t.Logf("Error closing MR %d: %v", mr.IID, err)
+		}
+	}()
+
+	mr, _, err = topts.GLProvider.Client().MergeRequests.GetMergeRequest(topts.ProjectID, mr.IID, nil)
+	assert.NilError(t, err)
+	topts.ParamsRun.Clients.Log.Infof("Created MR %q from fork with SHA %s", mr.WebURL, mr.SHA)
+
+	labelSelector := fmt.Sprintf("%s=%s", keys.SHA, formatting.CleanValueKubernetes(mr.SHA))
+
+	topts.ParamsRun.Clients.Log.Infof("Waiting for 2 PipelineRuns to appear for fork MR")
+	err = twait.UntilMinPRAppeared(ctx, topts.ParamsRun.Clients, twait.Opts{
+		RepoName:    topts.TargetNS,
+		Namespace:   topts.TargetNS,
+		PollTimeout: twait.DefaultTimeout,
+		TargetSHA:   formatting.CleanValueKubernetes(mr.SHA),
+	}, 2)
+	assert.NilError(t, err)
+
+	topts.ParamsRun.Clients.Log.Infof("Waiting for Repository status to have 2 entries for fork MR")
+	_, err = twait.UntilRepositoryUpdated(ctx, topts.ParamsRun.Clients, twait.Opts{
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
+		MinNumberStatus: 2,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       mr.SHA,
+	})
+	assert.NilError(t, err)
+
+	topts.ParamsRun.Clients.Log.Infof("Verifying commit statuses on fork (source) project for fork MR")
+	sourceStatusCount, err := waitForGitLabCommitStatusCount(ctx, topts.SecondGLProvider.Client(), topts.ParamsRun.Clients.Log, int(forkProject.ID), mr.SHA, 2)
+	assert.NilError(t, err)
+	assert.Assert(t, sourceStatusCount >= 2, "expected at least 2 commit statuses on fork (source) project, got %d", sourceStatusCount)
+
+	topts.ParamsRun.Clients.Log.Infof("Verifying no commit statuses on target project for fork MR")
+	targetStatusCount, err := gitlabCommitStatusCount(topts.GLProvider.Client(), topts.ProjectID, mr.SHA)
+	assert.NilError(t, err)
+	assert.Equal(t, targetStatusCount, 0,
+		"expected no commit statuses on target project; with Developer access on fork, statuses are written directly to the source project")
+
+	topts.ParamsRun.Clients.Log.Infof("Verifying initial PipelineRuns for fork MR")
+	pruns, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pruns.Items), 2, "expected 2 initial PipelineRuns")
+
+	initialPRNames := map[string]bool{}
+	for _, pr := range pruns.Items {
+		initialPRNames[pr.Name] = true
+	}
+
+	topts.ParamsRun.Clients.Log.Infof("Deleting all PipelineRuns to simulate pruning for fork MR")
+	err = topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).DeleteCollection(ctx,
+		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: labelSelector})
+	assert.NilError(t, err)
+
+	topts.ParamsRun.Clients.Log.Infof("Waiting for PipelineRuns to be deleted for fork MR")
+	pollErr := kubeinteraction.PollImmediateWithContext(ctx, twait.DefaultTimeout, func() (bool, error) {
+		pruns, err = topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			return false, err
+		}
+		return len(pruns.Items) == 0, nil
+	})
+	if pollErr != nil {
+		topts.ParamsRun.Clients.Log.Infof("Warning: PipelineRuns not fully deleted after polling: %v (proceeding anyway)", pollErr)
+	}
+
+	topts.ParamsRun.Clients.Log.Infof("Posting /retest comment on fork MR %d", topts.MRNumber)
+	_, _, err = topts.GLProvider.Client().Notes.CreateMergeRequestNote(topts.ProjectID, mr.IID,
+		&clientGitlab.CreateMergeRequestNoteOptions{Body: clientGitlab.Ptr("/retest")})
+	assert.NilError(t, err)
+
+	topts.ParamsRun.Clients.Log.Infof("Waiting for retest PipelineRun(s) to appear for fork MR")
+	err = twait.UntilMinPRAppeared(ctx, topts.ParamsRun.Clients, twait.Opts{
+		RepoName:    topts.TargetNS,
+		Namespace:   topts.TargetNS,
+		PollTimeout: twait.DefaultTimeout,
+		TargetSHA:   formatting.CleanValueKubernetes(mr.SHA),
+	}, 1)
+	assert.NilError(t, err)
+
+	topts.ParamsRun.Clients.Log.Infof("Waiting for Repository status to be updated with retest result for fork MR")
+	_, err = twait.UntilRepositoryUpdated(ctx, topts.ParamsRun.Clients, twait.Opts{
+		RepoName:            topts.TargetNS,
+		Namespace:           topts.TargetNS,
+		MinNumberStatus:     3,
+		PollTimeout:         twait.DefaultTimeout,
+		TargetSHA:           mr.SHA,
+		FailOnRepoCondition: "no-match",
+	})
+	assert.NilError(t, err)
+
+	topts.ParamsRun.Clients.Log.Infof("Asserting only the failed pipeline was re-run for fork MR")
+	prunsAfterRetest, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+
+	newCount := 0
+	for _, pr := range prunsAfterRetest.Items {
+		if !initialPRNames[pr.Name] {
+			newCount++
+		}
+	}
+	assert.Equal(t, newCount, 1,
+		"expected only 1 new PipelineRun after /retest from a fork MR, but got %d", newCount)
+}
+
+func waitForGitLabCommitStatusCount(ctx context.Context, client *clientGitlab.Client, logger *zap.SugaredLogger, projectID int, sha string, minCount int) (int, error) {
+	var count int
+	err := kubeinteraction.PollImmediateWithContext(ctx, twait.DefaultTimeout, func() (bool, error) {
+		currentCount, err := gitlabCommitStatusCount(client, projectID, sha)
+		logger.Infof("Current GitLab commit status count: %d (waiting for at least %d)", currentCount, minCount)
+		if err != nil {
+			return false, err
+		}
+		count = currentCount
+		return count >= minCount, nil
+	})
+	return count, err
+}
+
+func gitlabCommitStatusCount(client *clientGitlab.Client, projectID int, sha string) (int, error) {
+	statuses, _, err := client.Commits.GetCommitStatuses(projectID, sha, &clientGitlab.GetCommitStatusesOptions{})
+	if err != nil {
+		return 0, err
+	}
+	return len(statuses), nil
+}

--- a/test/pkg/configfile/config.go
+++ b/test/pkg/configfile/config.go
@@ -46,10 +46,12 @@ type GitHubEnterpriseConfig struct {
 }
 
 type GitLabConfig struct {
-	APIURL  string `env:"TEST_GITLAB_API_URL" json:"api_url"  yaml:"api_url"`
-	Token   string `env:"TEST_GITLAB_TOKEN"   json:"token"    yaml:"token"`
-	Group   string `env:"TEST_GITLAB_GROUP"   json:"group"    yaml:"group"`
-	SmeeURL string `env:"TEST_GITLAB_SMEEURL" json:"smee_url" yaml:"smee_url"`
+	APIURL      string `env:"TEST_GITLAB_API_URL"      json:"api_url"      yaml:"api_url"`
+	Token       string `env:"TEST_GITLAB_TOKEN"        json:"token"        yaml:"token"`
+	SecondToken string `env:"TEST_GITLAB_SECOND_TOKEN" json:"second_token" yaml:"second_token"`
+	Group       string `env:"TEST_GITLAB_GROUP"        json:"group"        yaml:"group"`
+	SecondGroup string `env:"TEST_GITLAB_SECOND_GROUP" json:"second_group" yaml:"second_group"`
+	SmeeURL     string `env:"TEST_GITLAB_SMEEURL"      json:"smee_url"     yaml:"smee_url"`
 }
 
 type GiteaConfig struct {

--- a/test/pkg/configfile/config_test.go
+++ b/test/pkg/configfile/config_test.go
@@ -136,7 +136,9 @@ github_enterprise:
 gitlab:
   api_url: "https://gitlab.com"
   token: "glpat-xyz"
+  second_token: "glpat-second"
   group: "pac-e2e-tests"
+  second_group: "pac-e2e-tests-second"
   smee_url: "https://hook.pipelinesascode.com/gitlab-test"
 gitea:
   api_url: "http://localhost:3000"
@@ -170,7 +172,8 @@ bitbucket_server:
 		"TEST_GITHUB_SECOND_API_URL", "TEST_GITHUB_SECOND_TOKEN",
 		"TEST_GITHUB_SECOND_EL_URL", "TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP",
 		"TEST_GITHUB_SECOND_REPO_INSTALLATION_ID",
-		"TEST_GITLAB_API_URL", "TEST_GITLAB_TOKEN", "TEST_GITLAB_GROUP", "TEST_GITLAB_SMEEURL",
+		"TEST_GITLAB_API_URL", "TEST_GITLAB_TOKEN", "TEST_GITLAB_SECOND_TOKEN",
+		"TEST_GITLAB_GROUP", "TEST_GITLAB_SECOND_GROUP", "TEST_GITLAB_SMEEURL",
 		"TEST_GITEA_API_URL", "TEST_GITEA_INTERNAL_URL", "TEST_GITEA_PASSWORD",
 		"TEST_GITEA_USERNAME", "TEST_GITEA_REPO_OWNER", "TEST_GITEA_SMEEURL",
 		"TEST_BITBUCKET_CLOUD_API_URL", "TEST_BITBUCKET_CLOUD_USER",
@@ -204,7 +207,9 @@ bitbucket_server:
 		"TEST_GITHUB_SECOND_REPO_INSTALLATION_ID": "1",
 		"TEST_GITLAB_API_URL":                     "https://gitlab.com",
 		"TEST_GITLAB_TOKEN":                       "glpat-xyz",
+		"TEST_GITLAB_SECOND_TOKEN":                "glpat-second",
 		"TEST_GITLAB_GROUP":                       "pac-e2e-tests",
+		"TEST_GITLAB_SECOND_GROUP":                "pac-e2e-tests-second",
 		"TEST_GITLAB_SMEEURL":                     "https://hook.pipelinesascode.com/gitlab-test",
 		"TEST_GITEA_API_URL":                      "http://localhost:3000",
 		"TEST_GITEA_INTERNAL_URL":                 "http://forgejo:3000",

--- a/test/pkg/gitlab/scm.go
+++ b/test/pkg/gitlab/scm.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"fmt"
+	"net/http"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"go.uber.org/zap"
@@ -45,4 +46,45 @@ func CreateGitLabProject(client *gitlab.Client, groupPath, projectName, hookURL,
 	}
 
 	return project, nil
+}
+
+func ForkGitLabProject(client *gitlab.Client, projectID int, namespacePath string, logger *zap.SugaredLogger) (*gitlab.Project, error) {
+	options := &gitlab.ForkProjectOptions{}
+	if namespacePath != "" {
+		options.NamespacePath = gitlab.Ptr(namespacePath)
+	}
+
+	currentUser, _, err := client.Users.CurrentUser()
+	if err != nil {
+		logger.Warnf("could not fetch current GitLab user: %v", err)
+		logger.Infof("Forking GitLab project %d into namespace %q", projectID, namespacePath)
+	} else {
+		logger.Infof("Forking GitLab project %d as user %s (ID %d) into namespace %q",
+			projectID, currentUser.Username, currentUser.ID, namespacePath)
+	}
+	project, resp, err := client.Projects.ForkProject(projectID, options)
+	if err != nil && namespacePath != "" && resp != nil && resp.StatusCode == http.StatusNotFound {
+		logger.Warnf("Fork into namespace %q failed (404) — second user may not be a member of that group; retrying into personal namespace", namespacePath)
+		project, _, err = client.Projects.ForkProject(projectID, &gitlab.ForkProjectOptions{})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to fork project %d: %w", projectID, err)
+	}
+
+	logger.Infof("Forked GitLab project into %s (ID %d)", project.PathWithNamespace, project.ID)
+
+	return project, nil
+}
+
+func AddGitLabProjectMember(client *gitlab.Client, projectID int, userID int64, accessLevel gitlab.AccessLevelValue, logger *zap.SugaredLogger) error {
+	logger.Infof("Granting user %d access level %d on GitLab project %d", userID, accessLevel, projectID)
+	_, _, err := client.ProjectMembers.AddProjectMember(projectID, &gitlab.AddProjectMemberOptions{
+		UserID:      userID,
+		AccessLevel: gitlab.Ptr(accessLevel),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to add user %d to project %d: %w", userID, projectID, err)
+	}
+
+	return nil
 }

--- a/test/pkg/gitlab/setup.go
+++ b/test/pkg/gitlab/setup.go
@@ -52,6 +52,49 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitlab.Provider, erro
 	return run, e2eoptions, glprovider, nil
 }
 
+func HasSecondIdentity() bool {
+	token, ok := os.LookupEnv("TEST_GITLAB_SECOND_TOKEN")
+	return ok && token != ""
+}
+
+func SetupSecond(ctx context.Context, run *params.Run) (options.E2E, gitlab.Provider, error) {
+	if err := setup.RequireEnvs(
+		"TEST_GITLAB_API_URL",
+		"TEST_GITLAB_SECOND_TOKEN",
+	); err != nil {
+		return options.E2E{}, gitlab.Provider{}, err
+	}
+
+	gitlabURL := os.Getenv("TEST_GITLAB_API_URL")
+	gitlabToken := os.Getenv("TEST_GITLAB_SECOND_TOKEN")
+	controllerURL := os.Getenv("TEST_EL_URL")
+
+	if run == nil {
+		run = params.New()
+		if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
+			return options.E2E{}, gitlab.Provider{}, err
+		}
+	}
+
+	e2eoptions := options.E2E{
+		ControllerURL: controllerURL,
+		UserName:      "oauth2",
+		Password:      gitlabToken,
+	}
+	glprovider := gitlab.Provider{}
+	err := glprovider.SetClient(ctx, run, &info.Event{
+		Provider: &info.Provider{
+			Token: gitlabToken,
+			URL:   gitlabURL,
+		},
+	}, nil, nil)
+	if err != nil {
+		return options.E2E{}, gitlab.Provider{}, err
+	}
+
+	return e2eoptions, glprovider, nil
+}
+
 func TearDown(ctx context.Context, t *testing.T, topts *TestOpts) {
 	if os.Getenv("TEST_NOCLEANUP") == "true" {
 		topts.ParamsRun.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")

--- a/test/pkg/gitlab/test.go
+++ b/test/pkg/gitlab/test.go
@@ -33,7 +33,9 @@ type TestOpts struct {
 	SHA                  string
 	ParamsRun            *params.Run
 	GLProvider           gitlab2.Provider
+	SecondGLProvider     gitlab2.Provider
 	Opts                 options.E2E
+	SecondOpts           options.E2E
 	YAMLFiles            map[string]string
 	ExtraArgs            map[string]string
 	Regexp               *regexp.Regexp
@@ -151,6 +153,24 @@ func CreateMR(client *gitlab.Client, pid int, sourceBranch, targetBranch, title 
 		return -1, err
 	}
 	return int(mr.IID), nil
+}
+
+func SetupSecondIdentity(ctx context.Context, topts *TestOpts) error {
+	if topts.SecondOpts.Password != "" {
+		return nil
+	}
+	if topts.ParamsRun == nil {
+		return fmt.Errorf("primary GitLab test setup must be initialized before the second identity")
+	}
+
+	opts, provider, err := SetupSecond(ctx, topts.ParamsRun)
+	if err != nil {
+		return err
+	}
+	topts.SecondOpts = opts
+	topts.SecondGLProvider = provider
+
+	return nil
 }
 
 func CreateTag(client *gitlab.Client, pid int, tagName string) error {


### PR DESCRIPTION
## 📝 Description of the Change

Added a fallback mechanism to retrieve commit statuses from the git
provider when the corresponding PipelineRuns are missing from the
cluster due to pruning. This ensures that the retest logic correctly
identifies previously successful templates and avoids re-running them
unnecessarily.

Issues Related (partial): #2580
Jira: <https://issues.redhat.com/browse/SRVKP-11112>
Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

## 🔗 Linked GitHub Issue

Partial #2580
<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [X] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
