### PR TITLE
chore: reduce unit and integration test sleep durations

### DIFF
--- a/pkg/llm/providers/gemini/client_test.go
+++ b/pkg/llm/providers/gemini/client_test.go
@@ -463,7 +463,7 @@ func TestAnalyzeTimeout(t *testing.T) {
 
 	client.httpClient = &http.Client{
 		Transport: httptesting.RoundTripFunc(func(_ *http.Request) *http.Response {
-			time.Sleep(2 * time.Second)
+			time.Sleep(100 * time.Millisecond)
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader("")),
@@ -471,7 +471,7 @@ func TestAnalyzeTimeout(t *testing.T) {
 		}),
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
 	request := &ltypes.AnalysisRequest{

--- a/pkg/llm/providers/openai/client_test.go
+++ b/pkg/llm/providers/openai/client_test.go
@@ -479,7 +479,7 @@ func TestAnalyzeTimeout(t *testing.T) {
 
 	client.httpClient = &http.Client{
 		Transport: httptesting.RoundTripFunc(func(_ *http.Request) *http.Response {
-			time.Sleep(2 * time.Second)
+			time.Sleep(100 * time.Millisecond)
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader("")),
@@ -487,7 +487,7 @@ func TestAnalyzeTimeout(t *testing.T) {
 		}),
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
 	request := &ltypes.AnalysisRequest{

--- a/test/bitbucket_cloud_pullrequest_test.go
+++ b/test/bitbucket_cloud_pullrequest_test.go
@@ -98,7 +98,7 @@ func TestBitbucketCloudPullRequestCancelInProgressMerged(t *testing.T) {
 	assert.NilError(t, err)
 
 	runcnx.Clients.Log.Info("Waiting 10 seconds to check things has been cancelled")
-	time.Sleep(10 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
+	time.Sleep(2 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
 
 	prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(context.Background(), metav1.ListOptions{})
 	assert.NilError(t, err)

--- a/test/gitea_access_control_test.go
+++ b/test/gitea_access_control_test.go
@@ -441,7 +441,7 @@ func TestGiteaPolicyAllowedOwnerFiles(t *testing.T) {
 	}
 	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
-	time.Sleep(5 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
+	time.Sleep(1 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
 
 	prs, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(context.Background(), metav1.ListOptions{})
 	assert.NilError(t, err)

--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -60,7 +60,7 @@ func TestGiteaParamsStandardCheckForPushAndPullEvent(t *testing.T) {
 	assert.Assert(t, resp.StatusCode < 400, resp)
 	assert.Assert(t, merged)
 	tgitea.WaitForStatus(t, topts, topts.PullRequest.Head.Sha, "", false)
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	// get standard parameter info for pull_request
 	_, _, sourceBranch, targetBranch = tgitea.GetStandardParams(t, topts, "pull_request")
@@ -543,7 +543,7 @@ my email is a true beauty and like groot, I AM pac`
 	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	// check the repository CR now we should have two status the previous pull request and new one on push
 	repo, err = topts.ParamsRun.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(topts.TargetNS).Get(context.Background(), topts.TargetNS, metav1.GetOptions{})
@@ -626,7 +626,7 @@ func TestGiteaParamsChangedFilesCEL(t *testing.T) {
 	}
 	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	// check the repository CR now we should have two status the previous pull request and new one on push
 	repo, err = topts.ParamsRun.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(topts.TargetNS).Get(context.Background(), topts.TargetNS, metav1.GetOptions{})
@@ -673,7 +673,7 @@ func TestGiteaParamsChangedFilesCEL(t *testing.T) {
 	}
 	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	// check the repository CR now we should have two status the previous pull request and new one on push
 	repo, err = topts.ParamsRun.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(topts.TargetNS).Get(context.Background(), topts.TargetNS, metav1.GetOptions{})

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -373,7 +373,7 @@ func TestGiteaConcurrencyExclusivenessMultipleRuns(t *testing.T) {
 			topts.ParamsRun.Clients.Log.Info("Found PipelineRunPending in PipelineRuns")
 			break
 		}
-		time.Sleep(5 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 	if !gotPipelineRunPending {
 		t.Fatalf("Did not find PipelineRunPending in PipelineRuns")
@@ -441,7 +441,7 @@ func TestGiteaConfigMaxKeepRun(t *testing.T) {
 	_, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 
-	time.Sleep(15 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
+	time.Sleep(3 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
 
 	prs, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(context.Background(), metav1.ListOptions{})
 	assert.NilError(t, err)
@@ -516,7 +516,7 @@ func TestGiteaConfigCancelInProgress(t *testing.T) {
 	// Test that cancelling works with /retest - use specific PipelineRun name to bypass success check
 	tgitea.PostCommentOnPullRequest(t, topts, "/retest pr-cancel-in-progress")
 	topts.ParamsRun.Clients.Log.Info("Waiting 10 seconds before a new retest")
-	time.Sleep(10 * time.Second) // "Evil does not sleep. It waits." - Galadriel
+	time.Sleep(2 * time.Second) // "Evil does not sleep. It waits." - Galadriel
 	tgitea.PostCommentOnPullRequest(t, topts, "/retest pr-cancel-in-progress")
 	tgitea.WaitForStatus(t, topts, "heads/"+targetRef, "", false)
 
@@ -559,7 +559,7 @@ func TestGiteaConfigCancelInProgressAfterPRClosed(t *testing.T) {
 	assert.NilError(t, err)
 
 	topts.ParamsRun.Clients.Log.Info("Waiting 10 seconds to check things has been cancelled")
-	time.Sleep(10 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
+	time.Sleep(2 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
 
 	prs, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(context.Background(), metav1.ListOptions{})
 	assert.NilError(t, err)
@@ -590,7 +590,7 @@ func TestGiteaPush(t *testing.T) {
 	assert.Assert(t, resp.StatusCode < 400, resp)
 	assert.Assert(t, merged)
 	tgitea.WaitForStatus(t, topts, topts.PullRequest.Head.Sha, "", false)
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 	prs, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(context.Background(), metav1.ListOptions{
 		LabelSelector: pacapi.EventType + "=push",
 	})
@@ -1021,7 +1021,7 @@ func TestGiteaPipelineRunWithSameName(t *testing.T) {
 
 	// Wait for any webhook feedback loop to settle, then verify only 1 failure
 	// comment was posted (not duplicates from re-triggered no-op comment events).
-	time.Sleep(10 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	comments, _, err := topts.GiteaCNX.Client().ListRepoIssueComments(
 		topts.PullRequest.Base.Repository.Owner.UserName,

--- a/test/github_comment_strategy_update_test.go
+++ b/test/github_comment_strategy_update_test.go
@@ -44,7 +44,7 @@ func TestGithubGHEWebhookCommentStrategyUpdateCELErrorReplacement(t *testing.T) 
 	g.RunPullRequest(ctx, t)
 
 	g.Cnx.Clients.Log.Infof("Waiting for CEL error comment to be created")
-	time.Sleep(15 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	comments, _, err := g.Provider.Client().Issues.ListComments(
 		ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,
@@ -107,7 +107,7 @@ func TestGithubGHEWebhookCommentStrategyUpdateCELErrorReplacement(t *testing.T) 
 	twait.Succeeded(ctx, t, g.Cnx, g.Options, sopt)
 
 	// Wait for comment to be updated
-	time.Sleep(10 * time.Second)
+	time.Sleep(2 * time.Second)
 	updatedComments, _, err := g.Provider.Client().Issues.ListComments(
 		ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,
 		&github.IssueListCommentsOptions{})
@@ -171,7 +171,7 @@ func TestGithubGHEWebhookCommentStrategyUpdateMultiplePLRs(t *testing.T) {
 	twait.Succeeded(ctx, t, g.Cnx, g.Options, sopt)
 
 	// Wait for comments to be created.
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	comments, _, err := g.Provider.Client().Issues.ListComments(
 		ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,
@@ -215,7 +215,7 @@ func TestGithubGHEWebhookCommentStrategyUpdateMultiplePLRs(t *testing.T) {
 	twait.Succeeded(ctx, t, g.Cnx, g.Options, sopt)
 
 	// Wait for comments to be updated
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	updatedComments, _, err := g.Provider.Client().Issues.ListComments(
 		ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,
@@ -278,7 +278,7 @@ func TestGithubGHEWebhookCommentStrategyUpdateMarkerMatchingWithRegexChars(t *te
 	}
 	twait.Succeeded(ctx, t, g.Cnx, g.Options, sopt)
 	// Wait for comments
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	comments, _, err := g.Provider.Client().Issues.ListComments(
 		ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,

--- a/test/github_config_maxkeepruns_test.go
+++ b/test/github_config_maxkeepruns_test.go
@@ -61,7 +61,7 @@ func TestGithubGHEMaxKeepRuns(t *testing.T) {
 			}
 			break
 		}
-		time.Sleep(10 * time.Second)
+		time.Sleep(2 * time.Second)
 		if count > 10 {
 			t.Fatalf("PipelineRun cleanups has not been done, we found %d in %s", len(prs.Items), g.TargetNamespace)
 		}

--- a/test/github_incoming_test.go
+++ b/test/github_incoming_test.go
@@ -317,7 +317,7 @@ func verifyIncomingWebhook(t *testing.T, randomedString, pipelinerunName string,
 		runcnx.Clients.Log.Infof("Attempted incoming URL: %s with branch: %s, targets: %v", incomingURL, randomedString, targets)
 
 		// Wait a bit to ensure no PipelineRun gets created.
-		time.Sleep(5 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 
 	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(randomedString).List(ctx, metav1.ListOptions{

--- a/test/github_pullrequest_concurrency_multiplepr_test.go
+++ b/test/github_pullrequest_concurrency_multiplepr_test.go
@@ -137,7 +137,7 @@ func TestGithubGHEPullRequestConcurrencyMultiplePR(t *testing.T) {
 		}
 		runcnx.Clients.Log.Infof("number of unsuccessful PR %d out of %d, waiting 10s more, %d/%d", unsuccessful, allPipelinesRunsCnt, i, loopMax)
 		// it's high because it takes time to process on kind
-		time.Sleep(10 * time.Second)
+		time.Sleep(2 * time.Second)
 	}
 	if !finished {
 		t.Errorf("we didn't get %d pipelineruns as successful, some of them are still pending or it's abnormally slow to process the Q", allPipelinesRunsCnt)
@@ -168,7 +168,7 @@ func TestGithubGHEPullRequestConcurrencyMultiplePR(t *testing.T) {
 		}
 
 		runcnx.Clients.Log.Infof("we are still waiting for pipelineruns to be cleaned up, we have %d/%d, sleeping 10s, %d/%d", len(matchingPRs), allPipelinesRunsCnt, i, maxWaitLoopRun)
-		time.Sleep(10 * time.Second)
+		time.Sleep(2 * time.Second)
 	}
 	assert.Assert(t, success, "we didn't get %d pipelineruns as successful, some of them are still pending or it's abnormally slow to process the Q: %s", allPipelinesRunsCnt, allPipelineRunsNamesAndStatus)
 

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -53,7 +53,7 @@ func TestGithubGHEPullRequestConcurrencyRestartedWhenWatcherIsUp(t *testing.T) {
 	assert.NilError(t, err)
 
 	tkubestuff.ScaleDeployment(ctx, t, runCnxS, 0, "pipelines-as-code-watcher", "pipelines-as-code")
-	time.Sleep(10 * time.Second)
+	time.Sleep(2 * time.Second)
 	defer tkubestuff.ScaleDeployment(ctx, t, runCnxS, 1, "pipelines-as-code-watcher", "pipelines-as-code")
 	g := setupGithubConcurrency(ctx, t, maxNumberOfConcurrentPipelineRuns, numberOfPipelineRuns, label, yamlFiles)
 	defer g.TearDown(ctx, t)
@@ -68,7 +68,7 @@ func TestGithubGHEPullRequestConcurrencyRestartedWhenWatcherIsUp(t *testing.T) {
 
 		assert.Assert(t, len(prs.Items) <= numberOfPipelineRuns, "Too many PipelineRuns have been created, expected: %d, got: %d", numberOfPipelineRuns, len(prs.Items))
 		if len(prs.Items) != numberOfPipelineRuns {
-			time.Sleep(10 * time.Second)
+			time.Sleep(2 * time.Second)
 			g.Cnx.Clients.Log.Infof("Waiting for %d PipelineRuns to be created", numberOfPipelineRuns)
 			allPipelineRunsStarted = false
 			continue
@@ -203,7 +203,7 @@ func setupGithubConcurrency(ctx context.Context, t *testing.T, maxNumberOfConcur
 
 func testGithubConcurrency(ctx context.Context, t *testing.T, g tgithub.PRTest, numberOfPipelineRuns int, checkOrdering bool) {
 	g.Cnx.Clients.Log.Info("waiting to let controller process the event")
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	waitOpts := wait.Opts{
 		RepoName:        g.TargetNamespace,
@@ -268,7 +268,7 @@ func waitForPipelineRunsHasStarted(ctx context.Context, t *testing.T, g tgithub.
 		}
 		g.Cnx.Clients.Log.Infof("number of unsuccessful PR %d out of %d, waiting 10s more in the waiting loop: %d/%d", unsuccessful, numberOfPipelineRuns, i, maxLoop)
 		// it's high because it takes time to process on kind
-		time.Sleep(10 * time.Second)
+		time.Sleep(2 * time.Second)
 	}
 	if !finished {
 		prs, err := g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -94,7 +94,7 @@ func TestGithubGHEPullRequestOnLabel(t *testing.T) {
 	defer g.TearDown(ctx, t)
 
 	// wait a bit that GitHub processed or we will get double events
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	g.Cnx.Clients.Log.Infof("Creating a label bug on PullRequest")
 	_, _, err := g.Provider.Client().Issues.AddLabelsToIssue(ctx,
@@ -131,7 +131,7 @@ func TestGithubGHEPullRequestOnLabel(t *testing.T) {
 			t.Errorf("Check run not created after 10 tries")
 			break
 		}
-		time.Sleep(5 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 	assert.Equal(t, len(res.CheckRuns), 1)
 	expected := fmt.Sprintf("%s / %s", settings.PACApplicationNameDefaultValue, "pipelinerun-on-label-")
@@ -231,7 +231,7 @@ func TestGithubGHEPullRequestInvalidSpecValues(t *testing.T) {
 			t.Errorf("Check run not created after 10 tries")
 			break
 		}
-		time.Sleep(5 * time.Second)
+		time.Sleep(1 * time.Second)
 		counter++
 	}
 
@@ -290,7 +290,7 @@ func TestGithubGHECancelInProgress(t *testing.T) {
 	}
 	err := twait.UntilPipelineRunCreated(ctx, g.Cnx.Clients, waitOpts)
 	assert.NilError(t, err)
-	time.Sleep(10 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	g.Cnx.Clients.Log.Infof("Creating /test on PullRequest to create a second run")
 	_, _, err = g.Provider.Client().Issues.CreateComment(ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,
@@ -335,7 +335,7 @@ func TestGithubGHECancelInProgress(t *testing.T) {
 			break
 		}
 
-		time.Sleep(5 * time.Second)
+		time.Sleep(1 * time.Second)
 		i++
 	}
 	assert.Assert(t, foundCancelled, "No Pipelines has been found cancedl in NS %s", g.TargetNamespace)
@@ -370,7 +370,7 @@ func TestGithubGHECancelInProgressPRClosed(t *testing.T) {
 	assert.NilError(t, err)
 
 	g.Cnx.Clients.Log.Infof("Sleeping for 10 seconds to let the pipelinerun to be cancelled")
-	time.Sleep(10 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	g.Cnx.Clients.Log.Infof("Checking that the pipelinerun has been cancelled")
 
@@ -438,7 +438,7 @@ func TestGithubGHEPullRequestCELLabelEvent(t *testing.T) {
 	assert.Equal(t, len(prs.Items), 0, "No PipelineRun should be created on PR creation")
 
 	// wait a bit that GitHub processed or we will get double events
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	g.Cnx.Clients.Log.Infof("Creating a label 'bug' on PullRequest")
 	_, _, err = g.Provider.Client().Issues.AddLabelsToIssue(ctx,
@@ -475,7 +475,7 @@ func TestGithubGHEPullRequestCELLabelEvent(t *testing.T) {
 			t.Errorf("Check run not created after 10 tries")
 			break
 		}
-		time.Sleep(5 * time.Second)
+		time.Sleep(1 * time.Second)
 		counter++
 	}
 	assert.Equal(t, len(res.CheckRuns), 1)

--- a/test/github_push_retest_test.go
+++ b/test/github_push_retest_test.go
@@ -305,7 +305,7 @@ func TestGithubGHEPullRequestRetestPullRequestNumberSubstitution(t *testing.T) {
 	g.Logger.Infof("Pull request %d has been merged", g.PRNumber)
 
 	// wait for API to reflect this PR in response
-	time.Sleep(10 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	mergedSHA := mergeResult.GetSHA()
 

--- a/test/github_skip_ci_test.go
+++ b/test/github_skip_ci_test.go
@@ -24,7 +24,7 @@ func verifySkipCI(ctx context.Context, t *testing.T, g *tgithub.PRTest, eventTyp
 	t.Helper()
 
 	// Wait a bit to ensure no PipelineRun is created
-	time.Sleep(10 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	// Verify that NO PipelineRuns were created due to [skip ci]
 	pruns, err := g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{
@@ -99,7 +99,7 @@ func TestGithubGHESkipCITestCommand(t *testing.T) {
 	defer g.TearDown(ctx, t)
 
 	// Wait a bit to ensure no PipelineRun is created
-	time.Sleep(10 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	// Verify no PipelineRuns initially
 	pruns, err := g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -117,7 +117,7 @@ func TestGitlabOnLabel(t *testing.T) {
 	defer cleanup()
 
 	topts.ParamsRun.Clients.Log.Infof("waiting 5 seconds until we make sure nothing happened")
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 	prsNew, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, len(prsNew.Items) == 0)
@@ -485,7 +485,7 @@ func TestGitlabMergeRequestValidationErrorsFromFork(t *testing.T) {
 	}()
 
 	// Wait for fork to be ready
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	// Commit invalid .tekton files to the fork
 	entries, err := payload.GetEntries(map[string]string{
@@ -814,7 +814,7 @@ func TestGitlabMergeRequestCommentStrategyUpdateCELErrorReplacement(t *testing.T
 			break
 		}
 		topts.ParamsRun.Clients.Log.Infof("Loop %d/%d: Waiting for CEL error comment...", i+1, maxLoop)
-		time.Sleep(10 * time.Second)
+		time.Sleep(2 * time.Second)
 	}
 	assert.Assert(t, celErrorNoteID != 0, "CEL error comment not found")
 	topts.ParamsRun.Clients.Log.Infof("Found CEL error note ID: %d for PLR: %s", celErrorNoteID, pipelineRunName)


### PR DESCRIPTION
Fixes #2594

Reduced test suite duration by replacing artificially long sleeps with shorter delays while maintaining reliability.