### PR TITLE
fix(gh): fix re-run button on Pull Requests

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -561,6 +561,10 @@ func (v *Provider) getPullRequest(ctx context.Context, runevent *info.Event) (*i
 	}
 	v.cachedPullRequest = pr
 
+	return v.populateRunEventFromPullRequest(runevent, pr), nil
+}
+
+func (v *Provider) populateRunEventFromPullRequest(runevent *info.Event, pr *github.PullRequest) *info.Event {
 	// Make sure to use the Base for Default BaseBranch or there would be a potential hijack
 	runevent.DefaultBranch = pr.GetBase().GetRepo().GetDefaultBranch()
 	runevent.URL = pr.GetBase().GetRepo().GetHTMLURL()
@@ -587,7 +591,7 @@ func (v *Provider) getPullRequest(ctx context.Context, runevent *info.Event) (*i
 	v.RepositoryIDs = []int64{
 		pr.GetBase().GetRepo().GetID(),
 	}
-	return runevent, nil
+	return runevent
 }
 
 // GetFiles gets and caches the list of files changed by a given event.

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -293,6 +293,36 @@ func (v *Provider) isCommitPartOfPullRequest(sha, org, repo string, prs []*githu
 	return false, 0
 }
 
+func selectSingleOpenPullRequest(prs []*github.PullRequest) (*github.PullRequest, error) {
+	var found *github.PullRequest
+	count := 0
+	for _, pr := range prs {
+		if pr.GetState() == "open" {
+			count++
+			if count == 1 {
+				found = pr
+			}
+		}
+	}
+	switch count {
+	case 0:
+		return nil, nil
+	case 1:
+		return found, nil
+	default:
+		return nil, fmt.Errorf("found %d open pull requests associated with the commit", count)
+	}
+}
+
+func (v *Provider) resolveReRequestPullRequest(ctx context.Context, runevent *info.Event) (*github.PullRequest, error) {
+	prs, err := v.getPullRequestsWithCommit(ctx, runevent.SHA, runevent.Organization, runevent.Repository, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return selectSingleOpenPullRequest(prs)
+}
+
 func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt any) (*info.Event, error) {
 	var processedEvent *info.Event
 	var err error
@@ -473,6 +503,22 @@ func (v *Provider) handleReRequestEvent(ctx context.Context, event *github.Check
 	runevent.HeadURL = event.GetCheckRun().GetCheckSuite().GetRepository().GetHTMLURL()
 	// If we don't have a pull_request in this it probably mean a push
 	if len(event.GetCheckRun().GetCheckSuite().PullRequests) == 0 {
+		// If head_branch is null, try to find a PR by SHA before assuming push
+		if runevent.HeadBranch == "" && runevent.SHA != "" {
+			pr, err := v.resolveReRequestPullRequest(ctx, runevent)
+			if err != nil {
+				return nil, fmt.Errorf("cannot determine pull request for check_run rerequest and SHA %s: %w", runevent.SHA, err)
+			}
+			if pr != nil {
+				runevent.PullRequestNumber = pr.GetNumber()
+				runevent.TriggerTarget = triggertype.PullRequest
+				v.Logger.Infof("Recheck of PR %s/%s#%d has been requested (resolved from SHA)", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
+				return v.populateRunEventFromPullRequest(runevent, pr), nil
+			}
+		}
+		if runevent.HeadBranch == "" {
+			return nil, fmt.Errorf("cannot determine branch for check_run rerequest: head_branch is null and no associated PR found for SHA %s", runevent.SHA)
+		}
 		runevent.BaseBranch = runevent.HeadBranch
 		runevent.BaseURL = runevent.HeadURL
 		runevent.EventType = "push"
@@ -503,6 +549,22 @@ func (v *Provider) handleCheckSuites(ctx context.Context, event *github.CheckSui
 	// If we don't have a pull_request in this it probably mean a push
 	// we are not able to know which
 	if len(event.GetCheckSuite().PullRequests) == 0 {
+		// If head_branch is null, try to find a PR by SHA before assuming push
+		if runevent.HeadBranch == "" && runevent.SHA != "" {
+			pr, err := v.resolveReRequestPullRequest(ctx, runevent)
+			if err != nil {
+				return nil, fmt.Errorf("cannot determine pull request for check_suite rerequest and SHA %s: %w", runevent.SHA, err)
+			}
+			if pr != nil {
+				runevent.PullRequestNumber = pr.GetNumber()
+				runevent.TriggerTarget = triggertype.PullRequest
+				v.Logger.Infof("Rerun of all checks on PR %s/%s#%d has been requested (resolved from SHA)", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
+				return v.populateRunEventFromPullRequest(runevent, pr), nil
+			}
+		}
+		if runevent.HeadBranch == "" {
+			return nil, fmt.Errorf("cannot determine branch for check_suite rerequest: head_branch is null and no associated PR found for SHA %s", runevent.SHA)
+		}
 		runevent.BaseBranch = runevent.HeadBranch
 		runevent.BaseURL = runevent.HeadURL
 		runevent.EventType = "push"
@@ -512,7 +574,6 @@ func (v *Provider) handleCheckSuites(ctx context.Context, event *github.CheckSui
 		runevent.Sender = event.GetSender().GetLogin()
 		v.userType = event.GetSender().GetType()
 		return runevent, nil
-		// return nil, fmt.Errorf("check suite event is not supported for push events")
 	}
 	runevent.PullRequestNumber = event.GetCheckSuite().PullRequests[0].GetNumber()
 	runevent.TriggerTarget = triggertype.PullRequest

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -74,23 +74,52 @@ var samplePRevent = github.PullRequestEvent{
 }
 
 var samplePR = github.PullRequest{
-	Number: github.Ptr(54321),
+	Number:  github.Ptr(54321),
+	State:   github.Ptr("open"),
+	HTMLURL: github.Ptr("https://github.com/owner/reponame/pull/54321"),
 	Head: &github.PullRequestBranch{
-		SHA:  github.Ptr("samplePRsha"),
-		Repo: sampleRepo,
+		SHA: github.Ptr("samplePRsha"),
+		Ref: github.Ptr("feature-branch"),
+		Repo: &github.Repository{
+			Owner: &github.User{
+				Login: github.Ptr("owner"),
+			},
+			Name:    github.Ptr("reponame"),
+			HTMLURL: github.Ptr("https://github.com/owner/reponame"),
+		},
 	},
 	Base: &github.PullRequestBranch{
+		Ref:  github.Ptr("main"),
 		SHA:  github.Ptr("samplePRsha"),
 		Repo: sampleRepo,
 	},
+	User: &github.User{
+		Login: github.Ptr("contributor"),
+	},
+	Title: github.Ptr("my first PR"),
 }
 
 var samplePRAnother = github.PullRequest{
-	Number: github.Ptr(54321),
+	Number:  github.Ptr(54321),
+	State:   github.Ptr("open"),
+	HTMLURL: github.Ptr("https://github.com/owner/reponame/pull/54321"),
 	Head: &github.PullRequestBranch{
-		SHA:  github.Ptr("samplePRshanew"),
+		SHA: github.Ptr("samplePRshanew"),
+		Ref: github.Ptr("feature-branch"),
+		Repo: &github.Repository{
+			Owner: &github.User{
+				Login: github.Ptr("owner"),
+			},
+			Name:    github.Ptr("reponame"),
+			HTMLURL: github.Ptr("https://github.com/owner/reponame"),
+		},
+	},
+	Base: &github.PullRequestBranch{
+		Ref:  github.Ptr("main"),
 		Repo: sampleRepo,
 	},
+	User:  &github.User{Login: github.Ptr("contributor")},
+	Title: github.Ptr("my first PR"),
 }
 
 func TestGetPullRequestsWithCommit(t *testing.T) {
@@ -588,11 +617,132 @@ func TestParsePayLoad(t *testing.T) {
 				Repo:   sampleRepo,
 				CheckRun: &github.CheckRun{
 					CheckSuite: &github.CheckSuite{
-						HeadSHA: github.Ptr("headSHACheckSuite"),
+						HeadBranch: github.Ptr("main"),
+						HeadSHA:    github.Ptr("headSHACheckSuite"),
 					},
 				},
 			},
 			shaRet: "headSHACheckSuite",
+		},
+		{
+			name:          "good/rerequest check_run null head_branch resolves PR from SHA",
+			eventType:     "check_run",
+			githubClient:  true,
+			triggerTarget: string(triggertype.PullRequest),
+			payloadEventStruct: github.CheckRunEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				CheckRun: &github.CheckRun{
+					CheckSuite: &github.CheckSuite{
+						HeadSHA: github.Ptr("samplePRsha"),
+					},
+				},
+			},
+			muxReplies: map[string]any{
+				"/repos/owner/reponame/commits/samplePRsha/pulls": []*github.PullRequest{&samplePR},
+			},
+			shaRet:                  "samplePRsha",
+			wantedPullRequestNumber: 54321,
+		},
+		{
+			name:          "good/rerequest check_suite null head_branch resolves PR from SHA",
+			eventType:     "check_suite",
+			githubClient:  true,
+			triggerTarget: string(triggertype.PullRequest),
+			payloadEventStruct: github.CheckSuiteEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				CheckSuite: &github.CheckSuite{
+					HeadSHA: github.Ptr("samplePRsha"),
+				},
+			},
+			muxReplies: map[string]any{
+				"/repos/owner/reponame/commits/samplePRsha/pulls": []*github.PullRequest{&samplePR},
+			},
+			shaRet:                  "samplePRsha",
+			wantedPullRequestNumber: 54321,
+		},
+		{
+			name:          "bad/rerequest check_run null head_branch no PR found",
+			eventType:     "check_run",
+			githubClient:  true,
+			wantErrString: "cannot determine branch for check_run rerequest",
+			payloadEventStruct: github.CheckRunEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				CheckRun: &github.CheckRun{
+					CheckSuite: &github.CheckSuite{
+						HeadSHA: github.Ptr("orphanSHA"),
+					},
+				},
+			},
+			muxReplies: map[string]any{
+				"/repos/owner/reponame/commits/orphanSHA/pulls": []*github.PullRequest{},
+			},
+		},
+		{
+			name:          "bad/rerequest check_suite null head_branch no PR found",
+			eventType:     "check_suite",
+			githubClient:  true,
+			wantErrString: "cannot determine branch for check_suite rerequest",
+			payloadEventStruct: github.CheckSuiteEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				CheckSuite: &github.CheckSuite{
+					HeadSHA: github.Ptr("orphanSHA"),
+				},
+			},
+			muxReplies: map[string]any{
+				"/repos/owner/reponame/commits/orphanSHA/pulls": []*github.PullRequest{},
+			},
+		},
+		{
+			name:          "bad/rerequest check_run null head_branch only closed PRs found",
+			eventType:     "check_run",
+			githubClient:  true,
+			wantErrString: "cannot determine branch for check_run rerequest",
+			payloadEventStruct: github.CheckRunEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				CheckRun: &github.CheckRun{
+					CheckSuite: &github.CheckSuite{
+						HeadSHA: github.Ptr("closedOnlySHA"),
+					},
+				},
+			},
+			muxReplies: map[string]any{
+				"/repos/owner/reponame/commits/closedOnlySHA/pulls": []*github.PullRequest{
+					{
+						Number: github.Ptr(111),
+						State:  github.Ptr("closed"),
+					},
+				},
+			},
+		},
+		{
+			name:          "bad/rerequest check_suite null head_branch multiple open PRs found",
+			eventType:     "check_suite",
+			githubClient:  true,
+			wantErrString: "found 2 open pull requests associated with the commit",
+			payloadEventStruct: github.CheckSuiteEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				CheckSuite: &github.CheckSuite{
+					HeadSHA: github.Ptr("ambiguousSHA"),
+				},
+			},
+			muxReplies: map[string]any{
+				"/repos/owner/reponame/commits/ambiguousSHA/pulls": []*github.PullRequest{
+					{
+						Number: github.Ptr(101),
+						State:  github.Ptr("open"),
+					},
+					{
+						Number: github.Ptr(202),
+						State:  github.Ptr("open"),
+					},
+				},
+			},
 		},
 		{
 			name:               "bad/issue_comment_not_from_created",

--- a/test/github_pullrequest_rerequest_test.go
+++ b/test/github_pullrequest_rerequest_test.go
@@ -146,4 +146,54 @@ func TestGithubGHEPullRerequest(t *testing.T) {
 		TargetSHA:       g.SHA,
 	})
 	assert.NilError(t, err)
+
+	// Third rerequest: null head_branch, empty pull_requests — resolved from SHA
+	g.Cnx.Clients.Log.Infof("Sending check_run rerequest with null head_branch (resolve PR from SHA)")
+	nullBranchEvent := github.CheckRunEvent{
+		Action: github.Ptr("rerequested"),
+		Installation: &github.Installation{
+			ID: &installID,
+		},
+		CheckRun: &github.CheckRun{
+			CheckSuite: &github.CheckSuite{
+				HeadSHA:      &runinfo.SHA,
+				PullRequests: []*github.PullRequest{},
+			},
+		},
+		Repo: &github.Repository{
+			DefaultBranch: &runinfo.DefaultBranch,
+			HTMLURL:       &runinfo.URL,
+			Name:          &runinfo.Repository,
+			Owner:         &github.User{Login: &runinfo.Organization},
+		},
+		Sender: &github.User{
+			Login: &runinfo.Sender,
+		},
+	}
+
+	err = payload.Send(ctx,
+		g.Cnx,
+		os.Getenv("TEST_GITHUB_SECOND_EL_URL"),
+		os.Getenv("TEST_GITHUB_SECOND_WEBHOOK_SECRET"),
+		os.Getenv("TEST_GITHUB_SECOND_API_URL"),
+		os.Getenv("TEST_GITHUB_SECOND_REPO_INSTALLATION_ID"),
+		nullBranchEvent,
+		"check_run",
+	)
+	assert.NilError(t, err)
+
+	g.Cnx.Clients.Log.Infof("Wait for the third repository update (null head_branch resolved from SHA)")
+	_, err = twait.UntilRepositoryUpdated(ctx, g.Cnx.Clients, twait.Opts{
+		RepoName:        g.TargetNamespace,
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: 3,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       g.SHA,
+	})
+	assert.NilError(t, err)
+
+	g.Cnx.Clients.Log.Infof("Check if the third run succeeded (null head_branch case)")
+	repo, err = g.Cnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(g.TargetNamespace).Get(ctx, g.TargetNamespace, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
 }


### PR DESCRIPTION
## 📝 Description of the Change

GitHub check_run and check_suite rerequests for fork PRs can have
a null head_branch and an empty pull_requests list. PAC was falling
back to treating these events as push events, causing the Re-run
button on PRs to have no effect.

When head_branch is null, fall back to looking up the associated PR
by commit SHA before deciding the event type. If a PR is found,
process as a PR rerequest. If not, return a clear error.


https://github.com/user-attachments/assets/2f177516-cafb-41ac-b1fa-98141c54d584


## 🔗 Linked Issue

Jira <https://redhat.atlassian.net/browse/SRVKP-11161>

## 🧪 Testing Strategy

- [X] Unit tests
- [ ] Integration tests
- [X] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [X] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
