### PR TITLE
fix(e2e): find controller in installation namespaces

### DIFF
--- a/test/pkg/github/instrumentation.go
+++ b/test/pkg/github/instrumentation.go
@@ -58,23 +58,34 @@ func (g *PRTest) collectGitHubAPICalls(ctx context.Context, _ *testing.T) {
 	if g.GHE {
 		controllerName = "ghe-controller"
 	}
-	ns := g.TargetNamespace
-	if ns == "" {
-		ns = info.GetNS(ctx)
+
+	var logContent string
+	var source tlogs.ControllerLogSource
+	var err error
+	var foundNS string
+
+	for _, installNS := range info.InstallNamespaces {
+		g.Logger.Infof(
+			"Attempting to collect GitHub API calls from controller: %s in namespace: %s",
+			controllerName, installNS,
+		)
+
+		logContent, source, err = tlogs.GetControllerLogByName(
+			ctx, g.Cnx.Clients.Kube.CoreV1(), installNS, controllerName, &numLines, nil,
+		)
+		if err == nil {
+			foundNS = installNS
+			break
+		}
+		g.Logger.Debugf("Controller not found in namespace %s: %v", installNS, err)
 	}
 
-	g.Logger.Infof(
-		"Attempting to collect GitHub API calls from controller: %s in namespace: %s",
-		controllerName, ns,
-	)
-
-	logContent, source, err := tlogs.GetControllerLogByName(
-		ctx, g.Cnx.Clients.Kube.CoreV1(), ns, controllerName, &numLines, nil,
-	)
 	if err != nil {
-		g.Logger.Warnf("Failed to get controller logs: %v", err)
+		g.Logger.Warnf("Failed to get controller logs from any installation namespace: %v", err)
 		return
 	}
+
+	g.Logger.Infof("Found controller in namespace: %s", foundNS)
 
 	g.Logger.Infof(
 		"Collected controller logs using label selector %q and container %q",
@@ -149,7 +160,7 @@ func parseAPICallLog(logLine string) *InstrumentationAPICall {
 	jsonStr := logLine[jsonStart:]
 
 	// Parse the JSON object
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	if err := json.Unmarshal([]byte(jsonStr), &logEntry); err != nil {
 		return nil
 	}


### PR DESCRIPTION
## 📝 Description of the Change
E2E instrumentation was broken because it searched for the controller in the test namespace (e.g., pac-e2e-ns-*), but controllers actually run in installation namespaces (pipelines-as-code or openshift-pipelines).

The fix iterates through info.InstallNamespaces to find the controller, restoring the original behavior that searched across all namespaces. Also fixed linter warning (interface{} to any).

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
