### PR TITLE
chore: replace real time.Sleep with clockwork in unit tests

### DIFF
--- a/pkg/llm/providers/gemini/client_test.go
+++ b/pkg/llm/providers/gemini/client_test.go
@@ -463,7 +463,7 @@ func TestAnalyzeTimeout(t *testing.T) {
 
 	client.httpClient = &http.Client{
 		Transport: httptesting.RoundTripFunc(func(_ *http.Request) *http.Response {
-			time.Sleep(2 * time.Second)
+			time.Sleep(200 * time.Millisecond)
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader("")),

--- a/pkg/llm/providers/openai/client_test.go
+++ b/pkg/llm/providers/openai/client_test.go
@@ -479,7 +479,7 @@ func TestAnalyzeTimeout(t *testing.T) {
 
 	client.httpClient = &http.Client{
 		Transport: httptesting.RoundTripFunc(func(_ *http.Request) *http.Response {
-			time.Sleep(2 * time.Second)
+			time.Sleep(200 * time.Millisecond)
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader("")),

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
+	"github.com/jonboulle/clockwork"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
@@ -68,6 +69,7 @@ type Provider struct {
 	triggerEvent       string
 	pacUserID          int64 // user login used by PAC
 	cachedChangedFiles *changedfiles.ChangedFiles
+	clock              clockwork.Clock
 }
 
 func (v *Provider) Client() *forgejo.Client {
@@ -80,6 +82,13 @@ func (v *Provider) Client() *forgejo.Client {
 		v.repo,
 	)
 	return v.giteaClient
+}
+
+func (v *Provider) getClock() clockwork.Clock {
+	if v.clock == nil {
+		return clockwork.NewRealClock()
+	}
+	return v.clock
 }
 
 func (v *Provider) SetGiteaClient(client *forgejo.Client) {
@@ -300,7 +309,7 @@ func (v *Provider) createStatusCommit(ctx context.Context, event *info.Event, pa
 			// Only retry on transient "user does not exist" errors
 			if strings.Contains(err.Error(), "user does not exist") {
 				v.Logger.Warnf("CreateStatus failed with transient error, retrying %d/%d: %v", i+1, maxRetries, err)
-				time.Sleep(time.Duration(i+1) * 500 * time.Millisecond)
+				v.getClock().Sleep(time.Duration(i+1) * 500 * time.Millisecond)
 				continue
 			}
 			return err

--- a/pkg/provider/gitea/gitea_test.go
+++ b/pkg/provider/gitea/gitea_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/jonboulle/clockwork"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
@@ -679,9 +680,11 @@ func TestProviderCreateStatusCommitRetryOnTransientError(t *testing.T) {
 				_, _ = rw.Write([]byte(`{"state":"success"}`))
 			})
 
+			fc := clockwork.NewFakeClock()
 			v := &Provider{
 				giteaClient: fakeclient,
 				Logger:      logger,
+				clock:       fc,
 			}
 
 			event := &info.Event{
@@ -696,7 +699,18 @@ func TestProviderCreateStatusCommitRetryOnTransientError(t *testing.T) {
 				Conclusion: "success",
 			}
 
-			err := v.createStatusCommit(context.Background(), event, pacopts, status)
+			ctx := context.Background()
+			if strings.Contains(tt.errorMessage, "user does not exist") && tt.failCount > 0 {
+				// Drive the fake clock only for retryable cases that actually sleep.
+				go func() {
+					for i := range 3 {
+						fc.BlockUntilContext(ctx, 1) //nolint:errcheck
+						fc.Advance(time.Duration(i+1) * 500 * time.Millisecond)
+					}
+				}()
+			}
+
+			err := v.createStatusCommit(ctx, event, pacopts, status)
 
 			if tt.wantErr {
 				assert.Assert(t, err != nil, "expected an error but got none")

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -64,6 +64,7 @@ type Provider struct {
 	cachedChangedFiles *changedfiles.ChangedFiles
 	commitInfo         *github.Commit
 	pacUserLogin       string // user/bot login used by PAC
+	clock              clockwork.Clock
 }
 
 type skippedRun struct {
@@ -78,7 +79,15 @@ func New() *Provider {
 		skippedRun: skippedRun{
 			mutex: &sync.Mutex{},
 		},
+		clock: clockwork.NewRealClock(),
 	}
+}
+
+func (v *Provider) getClock() clockwork.Clock {
+	if v.clock == nil {
+		return clockwork.NewRealClock()
+	}
+	return v.clock
 }
 
 func (v *Provider) Client() *github.Client {

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -269,7 +269,7 @@ func (v *Provider) getPullRequestsWithCommit(ctx context.Context, sha, org, repo
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
-			case <-time.After(backoff):
+			case <-v.getClock().After(backoff):
 			}
 		}
 	}

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v84/github"
+	"github.com/jonboulle/clockwork"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/env"
 	corev1 "k8s.io/api/core/v1"
@@ -266,6 +268,18 @@ func TestGetPullRequestsWithCommit(t *testing.T) {
 				provider = &Provider{
 					Logger: logger,
 				}
+			}
+
+			// Inject a fake clock for merge commit tests to avoid real backoff delays
+			if tt.isMergeCommit {
+				fc := clockwork.NewFakeClock()
+				provider.clock = fc
+				go func() {
+					for i := range maxRetriesForMergeCommit {
+						fc.BlockUntilContext(ctx, 1) //nolint:errcheck
+						fc.Advance(time.Duration(1<<uint(i)) * time.Second)
+					}
+				}()
 			}
 
 			prs, err := provider.getPullRequestsWithCommit(ctx, tt.sha, tt.org, tt.repo, tt.isMergeCommit)


### PR DESCRIPTION
## Summary

Fixes #2594

- Inject `clockwork.FakeClock` into Gitea and GitHub provider structs so retry/backoff loops use a fake clock in tests instead of real `time.Sleep`/`time.After`
- Reduce LLM timeout test mock handler sleep from 2s to 200ms (context timeout is 100ms, so timeout still triggers correctly)
- Total savings: ~10-13s per test run across 4 slow tests

## Changes

| Area | Before | After | Approach |
|------|--------|-------|----------|
| Gitea retry (`createStatusCommit`) | ~4.5s | ~0.01s | Added `clock` field + `getClock()` lazy helper to Provider |
| GitHub backoff (`getPullRequestsWithCommit`) | ~3-7s | ~0.01s | Same pattern, added `clock` field to Provider |
| Gemini `TestAnalyzeTimeout` | ~2s | ~0.2s | Reduced mock sleep duration |
| OpenAI `TestAnalyzeTimeout` | ~2s | ~0.2s | Reduced mock sleep duration |

## Test plan

- [x] `go test ./pkg/provider/gitea/` — all pass
- [x] `go test ./pkg/provider/github/` — all pass
- [x] `go test ./pkg/llm/providers/gemini/` — all pass
- [x] `go test ./pkg/llm/providers/openai/` — all pass
- [x] `golangci-lint run` — 0 issues
- [x] Pre-commit hooks — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)