### PR TITLE
fix: watcher secret creation log and osc link

### DIFF
--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -50,8 +50,7 @@ func (r *Run) UpdatePacConfig(ctx context.Context) error {
 	// This is the case when reverted settings for CustomConsole and TektonDashboard then URL should point to OpenshiftConsole for Openshift platform
 	if updatedPacInfo.CustomConsoleURL == "" &&
 		(updatedPacInfo.TektonDashboardURL == "" && os.Getenv("PAC_TEKTON_DASHBOARD_URL") == "") {
-		r.Clients.SetConsoleUI(&consoleui.OpenshiftConsole{})
-		_ = r.Clients.ConsoleUI().UI(ctx, r.Clients.Dynamic)
+		r.Clients.SetConsoleUI(consoleui.New(ctx, r.Clients.Dynamic, &r.Info))
 	}
 
 	return nil

--- a/pkg/params/run_test.go
+++ b/pkg/params/run_test.go
@@ -1,0 +1,91 @@
+package params
+
+import (
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	rtesting "knative.dev/pkg/reconciler/testing"
+
+	"go.uber.org/zap"
+	"gotest.tools/v3/assert"
+)
+
+func TestUpdatePacConfigResetConsoleUI(t *testing.T) {
+	tests := []struct {
+		name        string
+		dynamicObjs []runtime.Object
+		wantName    string
+		wantURL     string
+	}{
+		{
+			name: "reset to openshift console when route is available",
+			dynamicObjs: []runtime.Object{
+				func() *unstructured.Unstructured {
+					route := &unstructured.Unstructured{}
+					route.SetUnstructuredContent(map[string]any{
+						"apiVersion": "route.openshift.io/v1",
+						"kind":       "Route",
+						"metadata": map[string]any{
+							"name":      "console",
+							"namespace": "openshift-console",
+						},
+						"spec": map[string]any{
+							"host": "console.example.test",
+						},
+					})
+					return route
+				}(),
+			},
+			wantName: "OpenShift Console",
+			wantURL:  "https://console.example.test",
+		},
+		{
+			name:     "reset to fallback console when route lookup fails",
+			wantName: "Not configured",
+			wantURL:  consoleui.FallBackConsole{}.URL(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, "pac")
+
+			kubeClient := kubefake.NewSimpleClientset(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pac-config",
+					Namespace: "pac",
+				},
+				Data: map[string]string{},
+			})
+
+			run := &Run{
+				Clients: clients.Clients{
+					Kube:    kubeClient,
+					Dynamic: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), tt.dynamicObjs...),
+					Log:     zap.NewNop().Sugar(),
+				},
+				Info: info.Info{
+					Pac: info.NewPacOpts(),
+					Controller: &info.ControllerInfo{
+						Configmap: "pac-config",
+					},
+				},
+			}
+			run.Clients.SetConsoleUI(&consoleui.TektonDashboard{BaseURL: "https://old.example.test"})
+
+			err := run.UpdatePacConfig(ctx)
+			assert.NilError(t, err)
+			assert.Equal(t, run.Clients.ConsoleUI().GetName(), tt.wantName)
+			assert.Equal(t, run.Clients.ConsoleUI().URL(), tt.wantURL)
+		})
+	}
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -113,9 +113,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 		err := r.createSecretForPipelineRun(ctx, logger, pr, repo)
 		if err != nil && strings.Contains(err.Error(), "creating basic auth secret") {
 			return fmt.Errorf("failed to create secret for pipelineRun %s/%s: %w", pr.GetNamespace(), pr.GetName(), err)
+		} else if err != nil {
+			logger.Errorf("failed to create secret for pipelineRun %s/%s: %v", pr.GetNamespace(), pr.GetName(), err)
 		}
-
-		logger.Errorf("failed to create secret for pipelineRun %s/%s: %v", pr.GetNamespace(), pr.GetName(), err)
 	}
 
 	reason := ""

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -718,3 +718,87 @@ func TestCreateSecretForPipelineRun(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcileKindSecretCreationDoesNotLogOnSuccess(t *testing.T) {
+	observer, log := zapobserver.New(zap.ErrorLevel)
+	logger := zap.New(observer).Sugar()
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "test-pr",
+			Annotations: map[string]string{
+				keys.State:         kubeinteraction.StateStarted,
+				keys.Repository:    "test-repo",
+				keys.SecretCreated: "false",
+				keys.GitAuthSecret: "pac-git-basic-auth-owner-repo",
+				keys.GitProvider:   "github",
+				keys.RepoURL:       "https://github.com/org/repo",
+				keys.URLOrg:        "org",
+				keys.URLRepository: "repo",
+				keys.SHA:           "abc123",
+			},
+		},
+	}
+
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			GitProvider: &v1alpha1.GitProvider{
+				Secret: &v1alpha1.Secret{
+					Name: "pac-provider-secret",
+				},
+				User: "test-user",
+			},
+		},
+	}
+
+	testData := testclient.Data{
+		PipelineRuns: []*tektonv1.PipelineRun{pr},
+		Repositories: []*v1alpha1.Repository{repo},
+	}
+	stdata, informers := testclient.SeedTestData(t, ctx, testData)
+
+	r := &Reconciler{
+		repoLister: informers.Repository.Lister(),
+		run: &params.Run{
+			Clients: clients.Clients{
+				Tekton: stdata.Pipeline,
+				Log:    logger,
+			},
+			Info: info.Info{
+				Pac: &info.PacOpts{
+					Settings: settings.Settings{
+						SecretAutoCreation: true,
+					},
+				},
+				Kube: &info.KubeOpts{
+					Namespace: "global",
+				},
+				Controller: &info.ControllerInfo{
+					GlobalRepository: "global-repo",
+				},
+			},
+		},
+		kinteract: &testkubernetestint.KinterfaceTest{
+			GetSecretResult: map[string]string{
+				"pac-provider-secret": "test-token",
+			},
+		},
+	}
+
+	err := r.ReconcileKind(ctx, pr)
+	assert.NilError(t, err)
+
+	updatedPR, getErr := stdata.Pipeline.TektonV1().PipelineRuns(pr.Namespace).Get(ctx, pr.Name, metav1.GetOptions{})
+	assert.NilError(t, getErr)
+	assert.Equal(t, updatedPR.Annotations[keys.SecretCreated], "true")
+
+	logEntries := log.FilterMessageSnippet("failed to create secret for pipelineRun").TakeAll()
+	assert.Equal(t, len(logEntries), 0)
+}


### PR DESCRIPTION
## 📝 Description of the Change

Bug fixes for watcher secret creation logging and OpenShift console URL fallback handling.

Avoid logging a secret-creation failure when no error occurred in the watcher reconciler. After the secret creation flow moved into the reconciler, the error log ran even on success, which produced noisy messages such as "failed to create secret ...: <nil>".

Also fix console URL fallback handling when config resets from a custom console or Tekton dashboard back to the default cluster console. Instead of creating an empty OpenShift console client and ignoring route lookup failures, rebuild the console UI through the normal detection path so we either use the discovered OpenShift console URL or fall back cleanly.

Add regression tests for both cases:
- successful secret creation should not emit an error log
- console reset should use the discovered OpenShift route when present
- console reset should fall back cleanly when route lookup fails

Tested on dogfooding cluster.


## 🔗 Linked GitHub Issue

Fixes #2636 

## 🧪 Testing Strategy

- [x] Unit tests
- [x] Manual testing
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center