### PR TITLE
fix: populate DefaultBranch for incoming webhooks

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -463,6 +463,21 @@ func (v *Provider) GetCommitInfo(ctx context.Context, runevent *info.Event) erro
 		}
 	}
 
+	// For incoming webhooks, DefaultBranch is not populated from the event
+	// payload (since there is no webhook payload to parse). Fetch it from the
+	// GitHub API so that pipelinerun_provenance: default_branch works correctly.
+	// For other event types (push, pull_request), DefaultBranch is already set
+	// by ParsePayload from the webhook payload's repository.default_branch field.
+	if runevent.DefaultBranch == "" && runevent.EventType == "incoming" {
+		ghRepo, _, err := wrapAPI(v, "get_repo", func() (*github.Repository, *github.Response, error) {
+			return v.Client().Repositories.Get(ctx, runevent.Organization, runevent.Repository)
+		})
+		if err != nil {
+			return err
+		}
+		runevent.DefaultBranch = ghRepo.GetDefaultBranch()
+	}
+
 	return nil
 }
 

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -933,6 +933,31 @@ func TestGithubGetCommitInfo(t *testing.T) {
 			wantHasSkipCmd: true,
 		},
 		{
+			name: "incoming webhook populates DefaultBranch",
+			event: &info.Event{
+				Organization: "owner",
+				Repository:   "repository",
+				SHA:          "shacommitinfo",
+				EventType:    "incoming",
+			},
+			shaurl:   "https://git.provider/commit/info",
+			shatitle: "My beautiful pony",
+			message:  "My beautiful pony",
+		},
+		{
+			name: "DefaultBranch already set is preserved",
+			event: &info.Event{
+				Organization:  "owner",
+				Repository:    "repository",
+				SHA:           "shacommitinfo",
+				DefaultBranch: "develop",
+				EventType:     "incoming",
+			},
+			shaurl:   "https://git.provider/commit/info",
+			shatitle: "My beautiful pony",
+			message:  "My beautiful pony",
+		},
+		{
 			name: "error",
 			event: &info.Event{
 				Organization: "owner",
@@ -940,6 +965,7 @@ func TestGithubGetCommitInfo(t *testing.T) {
 				SHA:          "shacommitinfo",
 			},
 			apiReply: "hello moto",
+			wantErr:  "invalid character",
 		},
 		{
 			name:     "noclient",
@@ -952,6 +978,12 @@ func TestGithubGetCommitInfo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 			defer teardown()
+			// Mock the repo endpoint so GetCommitInfo can resolve DefaultBranch
+			// when it is not already set on the event (e.g. incoming webhooks).
+			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s",
+				tt.event.Organization, tt.event.Repository), func(rw http.ResponseWriter, _ *http.Request) {
+				fmt.Fprint(rw, `{"default_branch": "main"}`)
+			})
 			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/git/commits/%s",
 				tt.event.Organization, tt.event.Repository, tt.event.SHA), func(rw http.ResponseWriter, _ *http.Request) {
 				if tt.apiReply != "" {
@@ -1022,6 +1054,7 @@ func TestGithubGetCommitInfo(t *testing.T) {
 				assert.ErrorContains(t, err, tt.wantErr)
 				return
 			}
+			assert.NilError(t, err)
 			assert.Equal(t, tt.shatitle, tt.event.SHATitle)
 			assert.Equal(t, tt.shaurl, tt.event.SHAURL)
 
@@ -1040,6 +1073,16 @@ func TestGithubGetCommitInfo(t *testing.T) {
 				assert.DeepEqual(t, expectedCommitterDate, tt.event.SHACommitterDate)
 			}
 			assert.Equal(t, tt.wantHasSkipCmd, tt.event.HasSkipCommand)
+
+			// For incoming events, verify DefaultBranch is populated
+			if tt.event.EventType == "incoming" {
+				if tt.event.DefaultBranch == "develop" {
+					// If it was already set, it should be preserved
+					assert.Equal(t, "develop", tt.event.DefaultBranch, "DefaultBranch should be preserved")
+				} else {
+					assert.Equal(t, "main", tt.event.DefaultBranch, "DefaultBranch should be populated from API")
+				}
+			}
 		})
 	}
 }

--- a/test/github_incoming_test.go
+++ b/test/github_incoming_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	repository "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
 	"github.com/tektoncd/pipeline/pkg/names"
@@ -339,6 +340,160 @@ func verifyIncomingWebhook(t *testing.T, randomedString, pipelinerunName string,
 	} else {
 		runcnx.Clients.Log.Infof("Successfully verified no PipelineRun was created for non-matching branch %s with targets %v", randomedString, targets)
 	}
+}
+
+// TestGithubGHEAppIncomingDefaultBranchProvenance tests that incoming webhooks
+// work correctly with pipelinerun_provenance set to "default_branch".
+// This verifies the fix for https://github.com/tektoncd/pipelines-as-code/issues/2646
+// where DefaultBranch was not populated for incoming events.
+func TestGithubGHEAppIncomingDefaultBranchProvenance(t *testing.T) {
+	ctx := context.Background()
+	onGHE := true
+	ctx, runcnx, opts, ghprovider, err := tgithub.Setup(ctx, onGHE, false)
+	assert.NilError(t, err)
+
+	randomedString := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	targetBranch := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("incoming-branch")
+
+	runcnx.Clients.Log.Infof("Testing incoming webhook with default_branch provenance on %s", randomedString)
+
+	repoinfo, resp, err := ghprovider.Client().Repositories.Get(ctx, opts.Organization, opts.Repo)
+	assert.NilError(t, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	incoming := &[]v1alpha1.Incoming{
+		{
+			Type: "webhook-url",
+			Secret: v1alpha1.Secret{
+				Name: incomingSecretName,
+				Key:  "incoming",
+			},
+			Targets: []string{targetBranch},
+			Params: []string{
+				"the_best_superhero_is",
+			},
+		},
+	}
+
+	// Create Repository CR with pipelinerun_provenance: default_branch
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: randomedString,
+		},
+		Spec: v1alpha1.RepositorySpec{
+			URL:       repoinfo.GetHTMLURL(),
+			Incomings: incoming,
+			Settings: &v1alpha1.Settings{
+				PipelineRunProvenance: "default_branch",
+			},
+		},
+	}
+
+	err = repository.CreateNS(ctx, randomedString, runcnx)
+	assert.NilError(t, err)
+	err = repository.CreateRepo(ctx, randomedString, runcnx, repo)
+	assert.NilError(t, err)
+
+	err = secret.Create(ctx, runcnx, map[string]string{"incoming": incomingSecreteValue}, randomedString, incomingSecretName)
+	assert.NilError(t, err)
+
+	// Push .tekton/ files to the DEFAULT branch (not the incoming target branch)
+	entries, err := payload.GetEntries(map[string]string{
+		".tekton/pipelinerun-incoming.yaml": "testdata/pipelinerun-incoming.yaml",
+	}, randomedString, targetBranch, triggertype.Incoming.String(), map[string]string{})
+	assert.NilError(t, err)
+
+	defaultBranch := repoinfo.GetDefaultBranch()
+	title := "TestGithubAppIncomingDefaultBranchProvenance - " + randomedString
+	// Push .tekton/ to default branch by creating a commit and updating the ref
+	// (PushFilesToRef with empty targetRef creates the commit without creating a new ref)
+	sha, _, err := tgithub.PushFilesToRef(ctx, ghprovider.Client(), title,
+		defaultBranch,
+		"",
+		opts.Organization,
+		opts.Repo,
+		entries)
+	assert.NilError(t, err)
+	// Update the existing default branch ref to point to the new commit
+	_, _, err = ghprovider.Client().Git.UpdateRef(ctx, opts.Organization, opts.Repo,
+		"refs/heads/"+defaultBranch, github.UpdateRef{SHA: sha})
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to default branch %s", sha, defaultBranch)
+
+	// Create the target branch (the incoming webhook targets this branch)
+	targetSHA, _, err := tgithub.PushFilesToRef(ctx, ghprovider.Client(),
+		title,
+		defaultBranch,
+		fmt.Sprintf("refs/heads/%s", targetBranch),
+		opts.Organization,
+		opts.Repo,
+		map[string]string{"README.md": "# target branch"})
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Target branch %s created with SHA %s", targetBranch, targetSHA)
+
+	// Trigger incoming webhook targeting the non-default branch
+	incomingURL := fmt.Sprintf("%s/incoming", opts.ControllerURL)
+	jsonBody := map[string]interface{}{
+		"repository":  randomedString,
+		"branch":      targetBranch,
+		"pipelinerun": "pipelinerun-incoming",
+		"secret":      incomingSecreteValue,
+		"params": map[string]string{
+			"the_best_superhero_is": "Superman",
+		},
+	}
+	jsonData, err := json.Marshal(jsonBody)
+	assert.NilError(t, err)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, incomingURL, strings.NewReader(string(jsonData)))
+	assert.NilError(t, err)
+	req.Header.Add("Content-Type", "application/json")
+	if onGHE {
+		urlParse, _ := url.Parse(*ghprovider.APIURL)
+		req.Header.Add("X-GitHub-Enterprise-Host", urlParse.Host)
+	}
+
+	client := &http.Client{}
+	httpResp, err := client.Do(req)
+	assert.NilError(t, err)
+	defer httpResp.Body.Close()
+	assert.Assert(t, httpResp.StatusCode >= 200 && httpResp.StatusCode < 300,
+		"HTTP status code mismatch: expected=2xx, actual=%d", httpResp.StatusCode)
+
+	runcnx.Clients.Log.Infof("Incoming webhook triggered on URL: %s for branch: %s", incomingURL, targetBranch)
+
+	g := tgithub.PRTest{
+		Cnx:             runcnx,
+		Options:         opts,
+		Provider:        ghprovider,
+		TargetNamespace: randomedString,
+		TargetRefName:   fmt.Sprintf("refs/heads/%s", targetBranch),
+		PRNumber:        -1,
+		SHA:             targetSHA,
+		Logger:          runcnx.Clients.Log,
+		GHE:             onGHE,
+	}
+	defer g.TearDown(ctx, t)
+
+	sopt := wait.SuccessOpt{
+		Title:           title,
+		OnEvent:         triggertype.Incoming.String(),
+		TargetNS:        randomedString,
+		NumberofPRMatch: 1,
+		SHA:             "",
+	}
+	wait.Succeeded(ctx, t, runcnx, opts, sopt)
+
+	// Verify the PipelineRun was created
+	prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(randomedString).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, len(prs.Items) == 1, "Expected 1 PipelineRun, got %d", len(prs.Items))
+
+	err = wait.RegexpMatchingInPodLog(context.Background(), runcnx, randomedString,
+		"pipelinesascode.tekton.dev/event-type=incoming", "step-task",
+		*regexp.MustCompile(".*It's a Bird... It's a Plane... It's Superman"), "", 2, nil)
+	assert.NilError(t, err, "Error while checking the logs of the pods")
 }
 
 // Local Variables:


### PR DESCRIPTION
## 📝 Description of the Change

Incoming webhooks bypass `ParsePayload`, which means the event's
`DefaultBranch` field is never set. When `pipelinerun_provenance` is
set to `default_branch` on the Repository CR, `GetTektonDir()` uses
the empty `DefaultBranch` as the git tree revision, causing a 404
from the GitHub API.

### Root Cause

In `pkg/adapter/incoming.go`, the event fields set for incoming webhooks
include `HeadBranch`, `BaseBranch`, `URL`, etc., but `DefaultBranch` is
never populated. For push/PR events, it comes from the webhook payload's
`repository.default_branch` field via `ParsePayload`, but incoming
webhooks skip that code path entirely.

### Fix

In `GetCommitInfo()` (GitHub provider), when the event type is `incoming`
and `DefaultBranch` is empty, fetch the repository metadata from the
GitHub API to populate it. This is the same approach used by the
Bitbucket Data Center provider.

### Test Changes

- Added test cases for incoming webhook `DefaultBranch` population
- Fixed pre-existing test gap: the `error` test case was missing `wantErr`
- Added `assert.NilError` check on the success path

## 🔗 Linked GitHub Issue

Fixes #2646

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📖 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits).
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🐛 I have added end-to-end tests where feasible.
- [ ] 🔍 I have addressed any CI test flakiness or provided a clear reason to bypass it.

/kind bug