### PR TITLE
fix: recover fork PR re-runs when GitHub omits PR metadata

### DIFF
--- a/docs/content/docs/guides/running-pipelines.md
+++ b/docs/content/docs/guides/running-pipelines.md
@@ -183,4 +183,10 @@ re-executes the PipelineRun.
 
 You can rerun a specific pipeline or the entire suite of checks.
 
+Re-runs also work for pull requests coming from forks.
+
+The re-run is attributed to the user who clicked the "Re-Run" button, and that
+user must be authorized to run CI on the repository according to the
+[policy]({{< relref "/docs/advanced/policy-authorization" >}}) or ACL rules.
+
 ![github apps rerun check](/images/github-apps-rerun-checks.png)

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -439,13 +439,78 @@ func selectSingleOpenPullRequest(prs []*github.PullRequest) (*github.PullRequest
 	}
 }
 
+func selectSinglePullRequestFromPayload(prs []*github.PullRequest, eventName string) (*github.PullRequest, error) {
+	// A commit can be present in multiple open PRs. Re-runs must not guess which
+	// PR to target from webhook ordering because that can route work to the wrong PR.
+	switch len(prs) {
+	case 0:
+		return nil, nil
+	case 1:
+		return prs[0], nil
+	default:
+		return nil, fmt.Errorf("cannot determine pull request for %s rerequest: found %d associated pull requests in webhook payload", eventName, len(prs))
+	}
+}
+
+func filterPullRequestsByHeadSHA(prs []*github.PullRequest, sha string) []*github.PullRequest {
+	matches := []*github.PullRequest{}
+	for _, pr := range prs {
+		if pr.GetHead().GetSHA() == sha {
+			matches = append(matches, pr)
+		}
+	}
+	return matches
+}
+
+func (v *Provider) findOpenPullRequestBySHA(ctx context.Context, org, repo, sha string) (*github.PullRequest, error) {
+	opts := &github.PullRequestListOptions{
+		State:       "open",
+		Sort:        "updated",
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+
+	for {
+		prs, resp, err := wrapAPI(v, "list_pull_requests", func() ([]*github.PullRequest, *github.Response, error) {
+			return v.Client().PullRequests.List(ctx, org, repo, opts)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list open pull requests in %s/%s: %w", org, repo, err)
+		}
+
+		matches := filterPullRequestsByHeadSHA(prs. sha)
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return selectSingleOpenPullRequest(matches)
+}
+
 func (v *Provider) resolveReRequestPullRequest(ctx context.Context, runevent *info.Event) (*github.PullRequest, error) {
 	prs, err := v.getPullRequestsWithCommit(ctx, runevent.SHA, runevent.Organization, runevent.Repository, false)
 	if err != nil {
 		return nil, err
 	}
 
-	return selectSingleOpenPullRequest(prs)
+	pr, err := selectSingleOpenPullRequest(filterPullRequestsByHeadSHA(prs, runevent.SHA))
+	if err != nil {
+		return nil, err
+	}
+	if pr != nil {
+		return pr, nil
+	}
+
+	// ListPullRequestsWithCommit may return no matches for fork PR commits.
+	v.Logger.Infof("No PR found via commits API for SHA %s, falling back to open PR listing", runevent.SHA)
+	return v.findOpenPullRequestBySHA(ctx, runevent.Organization, runevent.Repository, runevent.SHA)
+}
+
+func (v *Provider) setReRequestSender(runevent *info.Event, sender *github.User) {
+	// Authorize reruns as the actor who clicked Re-run; otherwise PR population falls back to the PR author.
+	runevent.Sender = sender.GetLogin()
+	v.userType = sender.GetType()
 }
 
 func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt any) (*info.Event, error) {
@@ -614,45 +679,61 @@ func (v *Provider) handleReRequestEvent(ctx context.Context, event *github.Check
 	if event.GetRepo() == nil {
 		return nil, errors.New("error parsing payload the repository should not be nil")
 	}
+	checkRun := event.GetCheckRun()
+	checkSuite := checkRun.GetCheckSuite()
+
 	runevent.Organization = event.GetRepo().GetOwner().GetLogin()
 	runevent.Repository = event.GetRepo().GetName()
 	runevent.URL = event.GetRepo().GetHTMLURL()
 	runevent.DefaultBranch = event.GetRepo().GetDefaultBranch()
-	runevent.SHA = event.GetCheckRun().GetCheckSuite().GetHeadSHA()
-	runevent.HeadBranch = event.GetCheckRun().GetCheckSuite().GetHeadBranch()
-	runevent.HeadURL = event.GetCheckRun().GetCheckSuite().GetRepository().GetHTMLURL()
-	// If we don't have a pull_request in this it probably mean a push
-	if len(event.GetCheckRun().GetCheckSuite().PullRequests) == 0 {
-		// If head_branch is null, try to find a PR by SHA before assuming push
-		if runevent.HeadBranch == "" && runevent.SHA != "" {
-			pr, err := v.resolveReRequestPullRequest(ctx, runevent)
-			if err != nil {
-				return nil, fmt.Errorf("cannot determine pull request for check_run rerequest and SHA %s: %w", runevent.SHA, err)
-			}
-			if pr != nil {
-				runevent.PullRequestNumber = pr.GetNumber()
-				runevent.TriggerTarget = triggertype.PullRequest
-				v.Logger.Infof("Recheck of PR %s/%s#%d has been requested (resolved from SHA)", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
-				return v.populateRunEventFromPullRequest(runevent, pr), nil
-			}
-		}
-		if runevent.HeadBranch == "" {
-			return nil, fmt.Errorf("cannot determine branch for check_run rerequest: head_branch is null and no associated PR found for SHA %s", runevent.SHA)
-		}
-		runevent.BaseBranch = runevent.HeadBranch
-		runevent.BaseURL = runevent.HeadURL
-		runevent.EventType = "push"
-		// we allow the rerequest user here, not the push user, i guess it's
-		// fine because you can't do a rereq without being a github owner?
-		runevent.Sender = event.GetSender().GetLogin()
-		v.userType = event.GetSender().GetType()
-		v.RepositoryIDs = []int64{event.GetRepo().GetID()}
-		return runevent, nil
+	runevent.SHA = checkSuite.GetHeadSHA()
+	runevent.HeadBranch = checkSuite.GetHeadBranch()
+	runevent.HeadURL = checkSuite.GetRepository().GetHTMLURL()
+	v.setReRequestSender(runevent, event.GetSender())
+
+	pr, err := selectSinglePullRequestFromPayload(checkSuite.PullRequests, "check_run")
+	if err != nil {
+		return nil, err
 	}
-	runevent.PullRequestNumber = event.GetCheckRun().GetCheckSuite().PullRequests[0].GetNumber()
-	runevent.TriggerTarget = triggertype.PullRequest
-	v.Logger.Infof("Recheck of PR %s/%s#%d has been requested", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
-	return v.getPullRequest(ctx, runevent)
+	if pr != nil {
+		runevent.PullRequestNumber = pr.GetNumber()
+		runevent.TriggerTarget = triggertype.PullRequest
+		v.Logger.Infof("Recheck of PR %s/%s#%d has been requested", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
+		return v.getPullRequest(ctx, runevent)
+	}
+
+	pr, err = selectSinglePullRequestFromPayload(checkRun.PullRequests, "check_run")
+	if err != nil {
+		return nil, err
+	}
+	if pr != nil {
+		runevent.PullRequestNumber = pr.GetNumber()
+		runevent.TriggerTarget = triggertype.PullRequest
+		v.Logger.Infof("Recheck of PR %s/%s#%d has been requested (from check_run)", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
+		return v.getPullRequest(ctx, runevent)
+	}
+
+	// If head_branch is null, try to find a PR by SHA before assuming push.
+	if runevent.HeadBranch == "" && runevent.SHA != "" {
+		pr, err := v.resolveReRequestPullRequest(ctx, runevent)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine pull request for check_run rerequest and SHA %s: %w", runevent.SHA, err)
+		}
+		if pr != nil {
+			runevent.PullRequestNumber = pr.GetNumber()
+			runevent.TriggerTarget = triggertype.PullRequest
+			v.Logger.Infof("Recheck of PR %s/%s#%d has been requested (resolved from SHA)", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
+			return v.populateRunEventFromPullRequest(runevent, pr), nil
+		}
+	}
+	if runevent.HeadBranch == "" {
+		return nil, fmt.Errorf("cannot determine branch for check_run rerequest: head_branch is null and no associated PR found for SHA %s", runevent.SHA)
+	}
+	runevent.BaseBranch = runevent.HeadBranch
+	runevent.BaseURL = runevent.HeadURL
+	runevent.EventType = "push"
+	v.RepositoryIDs = []int64{event.GetRepo().GetID()}
+	return runevent, nil
 }
 
 func (v *Provider) handleCheckSuites(ctx context.Context, event *github.CheckSuiteEvent) (*info.Event, error) {
@@ -667,6 +748,7 @@ func (v *Provider) handleCheckSuites(ctx context.Context, event *github.CheckSui
 	runevent.SHA = event.GetCheckSuite().GetHeadSHA()
 	runevent.HeadBranch = event.GetCheckSuite().GetHeadBranch()
 	runevent.HeadURL = event.GetCheckSuite().GetRepository().GetHTMLURL()
+	v.setReRequestSender(runevent, event.GetSender())
 	// If we don't have a pull_request in this it probably mean a push
 	// we are not able to know which
 	if len(event.GetCheckSuite().PullRequests) == 0 {
@@ -690,14 +772,14 @@ func (v *Provider) handleCheckSuites(ctx context.Context, event *github.CheckSui
 		runevent.BaseURL = runevent.HeadURL
 		runevent.EventType = "push"
 		runevent.TriggerTarget = "push"
-		// we allow the rerequest user here, not the push user, i guess it's
-		// fine because you can't do a rereq without being a github owner?
-		runevent.Sender = event.GetSender().GetLogin()
-		v.userType = event.GetSender().GetType()
 		v.RepositoryIDs = []int64{event.GetRepo().GetID()}
 		return runevent, nil
 	}
-	runevent.PullRequestNumber = event.GetCheckSuite().PullRequests[0].GetNumber()
+	pr, err := selectSinglePullRequestFromPayload(event.GetCheckSuite().PullRequests, "check_suite")
+	if err != nil {
+		return nil, err
+	}
+	runevent.PullRequestNumber = pr.GetNumber()
 	runevent.TriggerTarget = triggertype.PullRequest
 	v.Logger.Infof("Rerun of all check on PR %s/%s#%d has been requested", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
 	return v.getPullRequest(ctx, runevent)

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -439,13 +439,79 @@ func selectSingleOpenPullRequest(prs []*github.PullRequest) (*github.PullRequest
 	}
 }
 
+func selectSinglePullRequestFromPayload(prs []*github.PullRequest, eventName string) (*github.PullRequest, error) {
+	// A commit can be present in multiple open PRs. Re-runs must not guess which
+	// PR to target from webhook ordering because that can route work to the wrong PR.
+	switch len(prs) {
+	case 0:
+		return nil, nil
+	case 1:
+		return prs[0], nil
+	default:
+		return nil, fmt.Errorf("cannot determine pull request for %s rerequest: found %d associated pull requests in webhook payload", eventName, len(prs))
+	}
+}
+
+func filterPullRequestsByHeadSHA(prs []*github.PullRequest, sha string) []*github.PullRequest {
+	matches := []*github.PullRequest{}
+	for _, pr := range prs {
+		if pr.GetHead().GetSHA() == sha {
+			matches = append(matches, pr)
+		}
+	}
+	return matches
+}
+
+func (v *Provider) findOpenPullRequestBySHA(ctx context.Context, org, repo, sha string) (*github.PullRequest, error) {
+	opts := &github.PullRequestListOptions{
+		State:       "open",
+		Sort:        "updated",
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+
+	var matches []*github.PullRequest
+	for {
+		prs, resp, err := wrapAPI(v, "list_pull_requests", func() ([]*github.PullRequest, *github.Response, error) {
+			return v.Client().PullRequests.List(ctx, org, repo, opts)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list open pull requests in %s/%s: %w", org, repo, err)
+		}
+
+		matches = append(matches, filterPullRequestsByHeadSHA(prs, sha)...)
+
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return selectSingleOpenPullRequest(matches)
+}
+
 func (v *Provider) resolveReRequestPullRequest(ctx context.Context, runevent *info.Event) (*github.PullRequest, error) {
 	prs, err := v.getPullRequestsWithCommit(ctx, runevent.SHA, runevent.Organization, runevent.Repository, false)
 	if err != nil {
 		return nil, err
 	}
 
-	return selectSingleOpenPullRequest(prs)
+	pr, err := selectSingleOpenPullRequest(filterPullRequestsByHeadSHA(prs, runevent.SHA))
+	if err != nil {
+		return nil, err
+	}
+	if pr != nil {
+		return pr, nil
+	}
+
+	// ListPullRequestsWithCommit may return no matches for fork PR commits.
+	v.Logger.Infof("No PR found via commits API for SHA %s, falling back to open PR listing", runevent.SHA)
+	return v.findOpenPullRequestBySHA(ctx, runevent.Organization, runevent.Repository, runevent.SHA)
+}
+
+func (v *Provider) setReRequestSender(runevent *info.Event, sender *github.User) {
+	// Authorize reruns as the actor who clicked Re-run; otherwise PR population falls back to the PR author.
+	runevent.Sender = sender.GetLogin()
+	v.userType = sender.GetType()
 }
 
 func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt any) (*info.Event, error) {
@@ -614,45 +680,61 @@ func (v *Provider) handleReRequestEvent(ctx context.Context, event *github.Check
 	if event.GetRepo() == nil {
 		return nil, errors.New("error parsing payload the repository should not be nil")
 	}
+	checkRun := event.GetCheckRun()
+	checkSuite := checkRun.GetCheckSuite()
+
 	runevent.Organization = event.GetRepo().GetOwner().GetLogin()
 	runevent.Repository = event.GetRepo().GetName()
 	runevent.URL = event.GetRepo().GetHTMLURL()
 	runevent.DefaultBranch = event.GetRepo().GetDefaultBranch()
-	runevent.SHA = event.GetCheckRun().GetCheckSuite().GetHeadSHA()
-	runevent.HeadBranch = event.GetCheckRun().GetCheckSuite().GetHeadBranch()
-	runevent.HeadURL = event.GetCheckRun().GetCheckSuite().GetRepository().GetHTMLURL()
-	// If we don't have a pull_request in this it probably mean a push
-	if len(event.GetCheckRun().GetCheckSuite().PullRequests) == 0 {
-		// If head_branch is null, try to find a PR by SHA before assuming push
-		if runevent.HeadBranch == "" && runevent.SHA != "" {
-			pr, err := v.resolveReRequestPullRequest(ctx, runevent)
-			if err != nil {
-				return nil, fmt.Errorf("cannot determine pull request for check_run rerequest and SHA %s: %w", runevent.SHA, err)
-			}
-			if pr != nil {
-				runevent.PullRequestNumber = pr.GetNumber()
-				runevent.TriggerTarget = triggertype.PullRequest
-				v.Logger.Infof("Recheck of PR %s/%s#%d has been requested (resolved from SHA)", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
-				return v.populateRunEventFromPullRequest(runevent, pr), nil
-			}
-		}
-		if runevent.HeadBranch == "" {
-			return nil, fmt.Errorf("cannot determine branch for check_run rerequest: head_branch is null and no associated PR found for SHA %s", runevent.SHA)
-		}
-		runevent.BaseBranch = runevent.HeadBranch
-		runevent.BaseURL = runevent.HeadURL
-		runevent.EventType = "push"
-		// we allow the rerequest user here, not the push user, i guess it's
-		// fine because you can't do a rereq without being a github owner?
-		runevent.Sender = event.GetSender().GetLogin()
-		v.userType = event.GetSender().GetType()
-		v.RepositoryIDs = []int64{event.GetRepo().GetID()}
-		return runevent, nil
+	runevent.SHA = checkSuite.GetHeadSHA()
+	runevent.HeadBranch = checkSuite.GetHeadBranch()
+	runevent.HeadURL = checkSuite.GetRepository().GetHTMLURL()
+	v.setReRequestSender(runevent, event.GetSender())
+
+	pr, err := selectSinglePullRequestFromPayload(checkSuite.PullRequests, "check_run")
+	if err != nil {
+		return nil, err
 	}
-	runevent.PullRequestNumber = event.GetCheckRun().GetCheckSuite().PullRequests[0].GetNumber()
-	runevent.TriggerTarget = triggertype.PullRequest
-	v.Logger.Infof("Recheck of PR %s/%s#%d has been requested", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
-	return v.getPullRequest(ctx, runevent)
+	if pr != nil {
+		runevent.PullRequestNumber = pr.GetNumber()
+		runevent.TriggerTarget = triggertype.PullRequest
+		v.Logger.Infof("Recheck of PR %s/%s#%d has been requested", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
+		return v.getPullRequest(ctx, runevent)
+	}
+
+	pr, err = selectSinglePullRequestFromPayload(checkRun.PullRequests, "check_run")
+	if err != nil {
+		return nil, err
+	}
+	if pr != nil {
+		runevent.PullRequestNumber = pr.GetNumber()
+		runevent.TriggerTarget = triggertype.PullRequest
+		v.Logger.Infof("Recheck of PR %s/%s#%d has been requested (from check_run)", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
+		return v.getPullRequest(ctx, runevent)
+	}
+
+	// If head_branch is null, try to find a PR by SHA before assuming push.
+	if runevent.HeadBranch == "" && runevent.SHA != "" {
+		pr, err := v.resolveReRequestPullRequest(ctx, runevent)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine pull request for check_run rerequest and SHA %s: %w", runevent.SHA, err)
+		}
+		if pr != nil {
+			runevent.PullRequestNumber = pr.GetNumber()
+			runevent.TriggerTarget = triggertype.PullRequest
+			v.Logger.Infof("Recheck of PR %s/%s#%d has been requested (resolved from SHA)", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
+			return v.populateRunEventFromPullRequest(runevent, pr), nil
+		}
+	}
+	if runevent.HeadBranch == "" {
+		return nil, fmt.Errorf("cannot determine branch for check_run rerequest: head_branch is null and no associated PR found for SHA %s", runevent.SHA)
+	}
+	runevent.BaseBranch = runevent.HeadBranch
+	runevent.BaseURL = runevent.HeadURL
+	runevent.EventType = "push"
+	v.RepositoryIDs = []int64{event.GetRepo().GetID()}
+	return runevent, nil
 }
 
 func (v *Provider) handleCheckSuites(ctx context.Context, event *github.CheckSuiteEvent) (*info.Event, error) {
@@ -667,6 +749,7 @@ func (v *Provider) handleCheckSuites(ctx context.Context, event *github.CheckSui
 	runevent.SHA = event.GetCheckSuite().GetHeadSHA()
 	runevent.HeadBranch = event.GetCheckSuite().GetHeadBranch()
 	runevent.HeadURL = event.GetCheckSuite().GetRepository().GetHTMLURL()
+	v.setReRequestSender(runevent, event.GetSender())
 	// If we don't have a pull_request in this it probably mean a push
 	// we are not able to know which
 	if len(event.GetCheckSuite().PullRequests) == 0 {
@@ -690,14 +773,14 @@ func (v *Provider) handleCheckSuites(ctx context.Context, event *github.CheckSui
 		runevent.BaseURL = runevent.HeadURL
 		runevent.EventType = "push"
 		runevent.TriggerTarget = "push"
-		// we allow the rerequest user here, not the push user, i guess it's
-		// fine because you can't do a rereq without being a github owner?
-		runevent.Sender = event.GetSender().GetLogin()
-		v.userType = event.GetSender().GetType()
 		v.RepositoryIDs = []int64{event.GetRepo().GetID()}
 		return runevent, nil
 	}
-	runevent.PullRequestNumber = event.GetCheckSuite().PullRequests[0].GetNumber()
+	pr, err := selectSinglePullRequestFromPayload(event.GetCheckSuite().PullRequests, "check_suite")
+	if err != nil {
+		return nil, err
+	}
+	runevent.PullRequestNumber = pr.GetNumber()
 	runevent.TriggerTarget = triggertype.PullRequest
 	v.Logger.Infof("Rerun of all check on PR %s/%s#%d has been requested", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
 	return v.getPullRequest(ctx, runevent)

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -346,6 +347,132 @@ func TestGetPullRequestsWithCommit(t *testing.T) {
 	}
 }
 
+func TestFindOpenPullRequestBySHA(t *testing.T) {
+	tests := []struct {
+		name         string
+		sha          string
+		setup        func(t *testing.T, mux *http.ServeMux)
+		wantPRNumber int
+		wantErr      string
+	}{
+		{
+			name: "single matching open PR",
+			sha:  "forkPRsha",
+			setup: func(t *testing.T, mux *http.ServeMux) {
+				t.Helper()
+				mux.HandleFunc("/repos/owner/reponame/pulls", func(rw http.ResponseWriter, _ *http.Request) {
+					fmt.Fprint(rw, `[
+						{"number": 101, "state": "open", "head": {"sha": "otherSHA"}},
+						{"number": 202, "state": "open", "head": {"sha": "forkPRsha"}}
+					]`)
+				})
+			},
+			wantPRNumber: 202,
+		},
+		{
+			name: "multiple matching open PRs across pages returns ambiguity error",
+			sha:  "ambiguousSHA",
+			setup: func(t *testing.T, mux *http.ServeMux) {
+				t.Helper()
+				mux.HandleFunc("/repos/owner/reponame/pulls", func(rw http.ResponseWriter, r *http.Request) {
+					switch r.URL.Query().Get("page") {
+					case "", "1":
+						rw.Header().Set("Link", `<https://api.github.com/repos/owner/reponame/pulls?page=2>; rel="next"`)
+						fmt.Fprint(rw, `[{"number": 101, "state": "open", "head": {"sha": "ambiguousSHA"}}]`)
+					case "2":
+						fmt.Fprint(rw, `[{"number": 202, "state": "open", "head": {"sha": "ambiguousSHA"}}]`)
+					default:
+						t.Fatalf("unexpected page %q", r.URL.Query().Get("page"))
+					}
+				})
+			},
+			wantErr: "found 2 open pull requests associated with the commit",
+		},
+		{
+			name: "matching open PR after ten pages",
+			sha:  "lateSHA",
+			setup: func(t *testing.T, mux *http.ServeMux) {
+				t.Helper()
+				mux.HandleFunc("/repos/owner/reponame/pulls", func(rw http.ResponseWriter, r *http.Request) {
+					page := r.URL.Query().Get("page")
+					if page == "" {
+						page = "1"
+					}
+					pageNumber, err := strconv.Atoi(page)
+					assert.NilError(t, err)
+
+					switch {
+					case pageNumber < 11:
+						rw.Header().Set("Link", fmt.Sprintf(`<https://api.github.com/repos/owner/reponame/pulls?page=%d>; rel="next"`, pageNumber+1))
+						fmt.Fprintf(rw, `[{"number": %d, "state": "open", "head": {"sha": "otherSHA"}}]`, pageNumber)
+					case pageNumber == 11:
+						fmt.Fprint(rw, `[{"number": 303, "state": "open", "head": {"sha": "lateSHA"}}]`)
+					default:
+						t.Fatalf("unexpected page %q", page)
+					}
+				})
+			},
+			wantPRNumber: 303,
+		},
+		{
+			name: "matching open PR before and after ten pages returns ambiguity error",
+			sha:  "lateAmbiguousSHA",
+			setup: func(t *testing.T, mux *http.ServeMux) {
+				t.Helper()
+				mux.HandleFunc("/repos/owner/reponame/pulls", func(rw http.ResponseWriter, r *http.Request) {
+					page := r.URL.Query().Get("page")
+					if page == "" {
+						page = "1"
+					}
+					pageNumber, err := strconv.Atoi(page)
+					assert.NilError(t, err)
+
+					switch {
+					case pageNumber < 11:
+						rw.Header().Set("Link", fmt.Sprintf(`<https://api.github.com/repos/owner/reponame/pulls?page=%d>; rel="next"`, pageNumber+1))
+						headSHA := "otherSHA"
+						if pageNumber == 1 {
+							headSHA = "lateAmbiguousSHA"
+						}
+						fmt.Fprintf(rw, `[{"number": %d, "state": "open", "head": {"sha": %q}}]`, pageNumber, headSHA)
+					case pageNumber == 11:
+						fmt.Fprint(rw, `[{"number": 303, "state": "open", "head": {"sha": "lateAmbiguousSHA"}}]`)
+					default:
+						t.Fatalf("unexpected page %q", page)
+					}
+				})
+			},
+			wantErr: "found 2 open pull requests associated with the commit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+
+			tt.setup(t, mux)
+
+			logger, _ := logger.GetLogger()
+			provider := &Provider{
+				ghClient: fakeclient,
+				Logger:   logger,
+			}
+
+			pr, err := provider.findOpenPullRequestBySHA(ctx, "owner", "reponame", tt.sha)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Assert(t, pr != nil)
+			assert.Equal(t, tt.wantPRNumber, pr.GetNumber())
+		})
+	}
+}
+
 func TestIsCommitPartOfPullRequest(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -450,6 +577,10 @@ func TestParsePayLoad(t *testing.T) {
 			State:  github.Ptr("open"),
 		},
 	}
+	rerunSender := &github.User{
+		Login: github.Ptr("maintainer"),
+		Type:  github.Ptr("User"),
+	}
 
 	tests := []struct {
 		name                       string
@@ -464,6 +595,10 @@ func TestParsePayLoad(t *testing.T) {
 		targetPipelinerun          string
 		targetCancelPipelinerun    string
 		wantedBranchName           string
+		wantedHeadBranch           string
+		wantedHeadURL              string
+		wantedSender               string
+		wantedUserType             string
 		wantedTagName              string
 		wantedPullRequestNumber    int
 		isCancelPipelineRunEnabled bool
@@ -571,14 +706,17 @@ func TestParsePayLoad(t *testing.T) {
 			payloadEventStruct: github.CheckRunEvent{
 				Action: github.Ptr("rerequested"),
 				Repo:   sampleRepo,
+				Sender: rerunSender,
 				CheckRun: &github.CheckRun{
 					CheckSuite: &github.CheckSuite{
 						PullRequests: []*github.PullRequest{&samplePR},
 					},
 				},
 			},
-			muxReplies: map[string]any{"/repos/owner/reponame/pulls/54321": samplePR},
-			shaRet:     "samplePRsha",
+			muxReplies:     map[string]any{"/repos/owner/reponame/pulls/54321": samplePR},
+			shaRet:         "samplePRsha",
+			wantedSender:   "maintainer",
+			wantedUserType: "User",
 		},
 		// all checks in a check_suite
 		{
@@ -589,12 +727,15 @@ func TestParsePayLoad(t *testing.T) {
 			payloadEventStruct: github.CheckSuiteEvent{
 				Action: github.Ptr("rerequested"),
 				Repo:   sampleRepo,
+				Sender: rerunSender,
 				CheckSuite: &github.CheckSuite{
 					PullRequests: []*github.PullRequest{&samplePR},
 				},
 			},
-			muxReplies: map[string]any{"/repos/owner/reponame/pulls/54321": samplePR},
-			shaRet:     "samplePRsha",
+			muxReplies:     map[string]any{"/repos/owner/reponame/pulls/54321": samplePR},
+			shaRet:         "samplePRsha",
+			wantedSender:   "maintainer",
+			wantedUserType: "User",
 		},
 		{
 			name:         "good/rerequest on push",
@@ -603,6 +744,7 @@ func TestParsePayLoad(t *testing.T) {
 			payloadEventStruct: github.CheckRunEvent{
 				Action: github.Ptr("rerequested"),
 				Repo:   sampleRepo,
+				Sender: rerunSender,
 				CheckRun: &github.CheckRun{
 					CheckSuite: &github.CheckSuite{
 						HeadBranch: github.Ptr("main"),
@@ -610,7 +752,9 @@ func TestParsePayLoad(t *testing.T) {
 					},
 				},
 			},
-			shaRet: "headSHACheckSuite",
+			shaRet:         "headSHACheckSuite",
+			wantedSender:   "maintainer",
+			wantedUserType: "User",
 		},
 		{
 			name:          "good/rerequest check_run null head_branch resolves PR from SHA",
@@ -620,6 +764,7 @@ func TestParsePayLoad(t *testing.T) {
 			payloadEventStruct: github.CheckRunEvent{
 				Action: github.Ptr("rerequested"),
 				Repo:   sampleRepo,
+				Sender: rerunSender,
 				CheckRun: &github.CheckRun{
 					CheckSuite: &github.CheckSuite{
 						HeadSHA: github.Ptr("samplePRsha"),
@@ -631,6 +776,236 @@ func TestParsePayLoad(t *testing.T) {
 			},
 			shaRet:                  "samplePRsha",
 			wantedPullRequestNumber: 54321,
+			wantedSender:            "maintainer",
+			wantedUserType:          "User",
+		},
+		{
+			name:          "good/rerequest check_run resolves PR from check_run pull requests",
+			eventType:     "check_run",
+			githubClient:  true,
+			triggerTarget: string(triggertype.PullRequest),
+			payloadEventStruct: github.CheckRunEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				Sender: rerunSender,
+				CheckRun: &github.CheckRun{
+					PullRequests: []*github.PullRequest{&samplePR},
+					CheckSuite: &github.CheckSuite{
+						HeadSHA: github.Ptr("samplePRsha"),
+					},
+				},
+			},
+			muxReplies: map[string]any{
+				"/repos/owner/reponame/pulls/54321": samplePR,
+			},
+			shaRet:                  "samplePRsha",
+			wantedPullRequestNumber: 54321,
+			wantedSender:            "maintainer",
+			wantedUserType:          "User",
+		},
+		{
+			name:          "bad/rerequest check_run with multiple pull requests in payload",
+			eventType:     "check_run",
+			githubClient:  true,
+			wantErrString: "cannot determine pull request for check_run rerequest: found 2 associated pull requests in webhook payload",
+			payloadEventStruct: github.CheckRunEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				CheckRun: &github.CheckRun{
+					PullRequests: []*github.PullRequest{
+						&samplePR,
+						&samplePRAnother,
+					},
+					CheckSuite: &github.CheckSuite{
+						HeadSHA: github.Ptr("samplePRsha"),
+					},
+				},
+			},
+			shaRet: "samplePRsha",
+		},
+		{
+			name:          "bad/rerequest check_run with multiple check suite pull requests in payload",
+			eventType:     "check_run",
+			githubClient:  true,
+			wantErrString: "cannot determine pull request for check_run rerequest: found 2 associated pull requests in webhook payload",
+			payloadEventStruct: github.CheckRunEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				CheckRun: &github.CheckRun{
+					CheckSuite: &github.CheckSuite{
+						PullRequests: []*github.PullRequest{
+							&samplePR,
+							&samplePRAnother,
+						},
+						HeadSHA: github.Ptr("samplePRsha"),
+					},
+				},
+			},
+			shaRet: "samplePRsha",
+		},
+		{
+			name:          "bad/rerequest check_suite with multiple pull requests in payload",
+			eventType:     "check_suite",
+			githubClient:  true,
+			wantErrString: "cannot determine pull request for check_suite rerequest: found 2 associated pull requests in webhook payload",
+			payloadEventStruct: github.CheckSuiteEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				CheckSuite: &github.CheckSuite{
+					PullRequests: []*github.PullRequest{
+						&samplePR,
+						&samplePRAnother,
+					},
+					HeadSHA: github.Ptr("samplePRsha"),
+				},
+			},
+			shaRet: "samplePRsha",
+		},
+		{
+			name:          "good/rerequest check_run null head_branch resolves fork PR from open PR list",
+			eventType:     "check_run",
+			githubClient:  true,
+			triggerTarget: string(triggertype.PullRequest),
+			payloadEventStruct: github.CheckRunEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				Sender: rerunSender,
+				CheckRun: &github.CheckRun{
+					CheckSuite: &github.CheckSuite{
+						HeadSHA: github.Ptr("forkPRsha"),
+					},
+				},
+			},
+			muxReplies: map[string]any{
+				"/repos/owner/reponame/commits/forkPRsha/pulls": []*github.PullRequest{},
+				"/repos/owner/reponame/pulls": []*github.PullRequest{
+					{
+						Number:  github.Ptr(987),
+						State:   github.Ptr("open"),
+						HTMLURL: github.Ptr("https://github.com/owner/reponame/pull/987"),
+						Head: &github.PullRequestBranch{
+							SHA: github.Ptr("forkPRsha"),
+							Ref: github.Ptr("fork-feature"),
+							Repo: &github.Repository{
+								Owner: &github.User{
+									Login: github.Ptr("fork-owner"),
+								},
+								Name:    github.Ptr("reponame"),
+								HTMLURL: github.Ptr("https://github.com/fork-owner/reponame"),
+							},
+						},
+						Base: &github.PullRequestBranch{
+							Ref:  github.Ptr("main"),
+							SHA:  github.Ptr("basesha"),
+							Repo: sampleRepo,
+						},
+						User: &github.User{
+							Login: github.Ptr("fork-contributor"),
+						},
+						Title: github.Ptr("fork PR"),
+					},
+				},
+			},
+			shaRet:                  "forkPRsha",
+			wantedPullRequestNumber: 987,
+			wantedHeadBranch:        "fork-feature",
+			wantedHeadURL:           "https://github.com/fork-owner/reponame",
+			wantedSender:            "maintainer",
+			wantedUserType:          "User",
+		},
+		{
+			name:          "good/rerequest check_run ignores commit API PR when SHA is not PR head",
+			eventType:     "check_run",
+			githubClient:  true,
+			triggerTarget: string(triggertype.PullRequest),
+			payloadEventStruct: github.CheckRunEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				Sender: rerunSender,
+				CheckRun: &github.CheckRun{
+					CheckSuite: &github.CheckSuite{
+						HeadSHA: github.Ptr("forkPRsha"),
+					},
+				},
+			},
+			muxReplies: map[string]any{
+				"/repos/owner/reponame/commits/forkPRsha/pulls": []*github.PullRequest{
+					{
+						Number: github.Ptr(654),
+						State:  github.Ptr("open"),
+						Head: &github.PullRequestBranch{
+							SHA: github.Ptr("newerSHA"),
+						},
+					},
+				},
+				"/repos/owner/reponame/pulls": []*github.PullRequest{
+					{
+						Number:  github.Ptr(987),
+						State:   github.Ptr("open"),
+						HTMLURL: github.Ptr("https://github.com/owner/reponame/pull/987"),
+						Head: &github.PullRequestBranch{
+							SHA: github.Ptr("forkPRsha"),
+							Ref: github.Ptr("fork-feature"),
+							Repo: &github.Repository{
+								Owner: &github.User{
+									Login: github.Ptr("fork-owner"),
+								},
+								Name:    github.Ptr("reponame"),
+								HTMLURL: github.Ptr("https://github.com/fork-owner/reponame"),
+							},
+						},
+						Base: &github.PullRequestBranch{
+							Ref:  github.Ptr("main"),
+							SHA:  github.Ptr("basesha"),
+							Repo: sampleRepo,
+						},
+						User: &github.User{
+							Login: github.Ptr("fork-contributor"),
+						},
+						Title: github.Ptr("fork PR"),
+					},
+				},
+			},
+			shaRet:                  "forkPRsha",
+			wantedPullRequestNumber: 987,
+			wantedHeadBranch:        "fork-feature",
+			wantedHeadURL:           "https://github.com/fork-owner/reponame",
+			wantedSender:            "maintainer",
+			wantedUserType:          "User",
+		},
+		{
+			name:          "bad/rerequest check_run null head_branch ambiguous fallback PRs found",
+			eventType:     "check_run",
+			githubClient:  true,
+			wantErrString: "found 2 open pull requests associated with the commit",
+			payloadEventStruct: github.CheckRunEvent{
+				Action: github.Ptr("rerequested"),
+				Repo:   sampleRepo,
+				CheckRun: &github.CheckRun{
+					CheckSuite: &github.CheckSuite{
+						HeadSHA: github.Ptr("ambiguousFallbackSHA"),
+					},
+				},
+			},
+			muxReplies: map[string]any{
+				"/repos/owner/reponame/commits/ambiguousFallbackSHA/pulls": []*github.PullRequest{},
+				"/repos/owner/reponame/pulls": []*github.PullRequest{
+					{
+						Number: github.Ptr(301),
+						State:  github.Ptr("open"),
+						Head: &github.PullRequestBranch{
+							SHA: github.Ptr("ambiguousFallbackSHA"),
+						},
+					},
+					{
+						Number: github.Ptr(302),
+						State:  github.Ptr("open"),
+						Head: &github.PullRequestBranch{
+							SHA: github.Ptr("ambiguousFallbackSHA"),
+						},
+					},
+				},
+			},
 		},
 		{
 			name:          "good/rerequest check_suite null head_branch resolves PR from SHA",
@@ -640,6 +1015,7 @@ func TestParsePayLoad(t *testing.T) {
 			payloadEventStruct: github.CheckSuiteEvent{
 				Action: github.Ptr("rerequested"),
 				Repo:   sampleRepo,
+				Sender: rerunSender,
 				CheckSuite: &github.CheckSuite{
 					HeadSHA: github.Ptr("samplePRsha"),
 				},
@@ -649,6 +1025,8 @@ func TestParsePayLoad(t *testing.T) {
 			},
 			shaRet:                  "samplePRsha",
 			wantedPullRequestNumber: 54321,
+			wantedSender:            "maintainer",
+			wantedUserType:          "User",
 		},
 		{
 			name:          "bad/rerequest check_run null head_branch no PR found",
@@ -666,6 +1044,7 @@ func TestParsePayLoad(t *testing.T) {
 			},
 			muxReplies: map[string]any{
 				"/repos/owner/reponame/commits/orphanSHA/pulls": []*github.PullRequest{},
+				"/repos/owner/reponame/pulls":                   []*github.PullRequest{},
 			},
 		},
 		{
@@ -682,6 +1061,7 @@ func TestParsePayLoad(t *testing.T) {
 			},
 			muxReplies: map[string]any{
 				"/repos/owner/reponame/commits/orphanSHA/pulls": []*github.PullRequest{},
+				"/repos/owner/reponame/pulls":                   []*github.PullRequest{},
 			},
 		},
 		{
@@ -705,6 +1085,7 @@ func TestParsePayLoad(t *testing.T) {
 						State:  github.Ptr("closed"),
 					},
 				},
+				"/repos/owner/reponame/pulls": []*github.PullRequest{},
 			},
 		},
 		{
@@ -724,10 +1105,16 @@ func TestParsePayLoad(t *testing.T) {
 					{
 						Number: github.Ptr(101),
 						State:  github.Ptr("open"),
+						Head: &github.PullRequestBranch{
+							SHA: github.Ptr("ambiguousSHA"),
+						},
 					},
 					{
 						Number: github.Ptr(202),
 						State:  github.Ptr("open"),
+						Head: &github.PullRequestBranch{
+							SHA: github.Ptr("ambiguousSHA"),
+						},
 					},
 				},
 			},
@@ -1551,6 +1938,18 @@ func TestParsePayLoad(t *testing.T) {
 				assert.Equal(t, tt.wantedBranchName, ret.HeadBranch)
 				assert.Equal(t, tt.wantedBranchName, ret.BaseBranch)
 				assert.Equal(t, tt.isCancelPipelineRunEnabled, ret.CancelPipelineRuns)
+			}
+			if tt.wantedHeadBranch != "" {
+				assert.Equal(t, tt.wantedHeadBranch, ret.HeadBranch)
+			}
+			if tt.wantedHeadURL != "" {
+				assert.Equal(t, tt.wantedHeadURL, ret.HeadURL)
+			}
+			if tt.wantedSender != "" {
+				assert.Equal(t, tt.wantedSender, ret.Sender)
+			}
+			if tt.wantedUserType != "" {
+				assert.Equal(t, tt.wantedUserType, gprovider.userType)
 			}
 			if tt.wantedPullRequestNumber != 0 {
 				assert.Equal(t, tt.wantedPullRequestNumber, ret.PullRequestNumber)

--- a/test/github_pullrequest_rerequest_test.go
+++ b/test/github_pullrequest_rerequest_test.go
@@ -20,7 +20,11 @@ import (
 )
 
 // TestGithubPullRerequest is a test that will create a pull request and check
-// if we can rerequest a specific check or the full check suite.
+// if we can rerequest a specific check or the full check suite. It also
+// covers the fork PR re-run recovery cases: resolving the PR from the SHA
+// when head_branch/pull_requests are missing from the check_suite payload,
+// and resolving the PR from pull_requests data attached directly to the
+// check_run event (as GitHub sometimes only populates it there).
 func TestGithubGHEPullRerequest(t *testing.T) {
 	ctx := context.TODO()
 	g := &tgithub.PRTest{
@@ -194,5 +198,62 @@ func TestGithubGHEPullRerequest(t *testing.T) {
 	assert.Assert(t, len(prs) >= 3, "no successful pipelineruns found")
 
 	g.Cnx.Clients.Log.Infof("Check if the third run succeeded (null head_branch case)")
+	assert.Assert(t, prs[len(prs)-1].Status.Conditions[0].Status == corev1.ConditionTrue)
+
+	// Fourth rerequest: pull_requests data attached directly to the
+	// check_run event (not check_suite) — this is what GitHub sends for
+	// re-runs on fork PRs when it omits the pull_requests on check_suite.
+	g.Cnx.Clients.Log.Infof("Sending check_run rerequest with pull_requests attached directly to check_run")
+	directPREvent := github.CheckRunEvent{
+		Action: github.Ptr("rerequested"),
+		Installation: &github.Installation{
+			ID: &installID,
+		},
+		CheckRun: &github.CheckRun{
+			CheckSuite: &github.CheckSuite{
+				HeadBranch:   &runinfo.HeadBranch,
+				HeadSHA:      &runinfo.SHA,
+				PullRequests: []*github.PullRequest{},
+			},
+			PullRequests: []*github.PullRequest{
+				{
+					Number: github.Ptr(g.PRNumber),
+				},
+			},
+		},
+		Repo: &github.Repository{
+			DefaultBranch: &runinfo.DefaultBranch,
+			HTMLURL:       &runinfo.URL,
+			Name:          &runinfo.Repository,
+			Owner:         &github.User{Login: &runinfo.Organization},
+		},
+		Sender: &github.User{
+			Login: &runinfo.Sender,
+		},
+	}
+
+	err = payload.Send(
+		ctx,
+		g.Cnx,
+		os.Getenv("TEST_GITHUB_SECOND_EL_URL"),
+		os.Getenv("TEST_GITHUB_SECOND_WEBHOOK_SECRET"),
+		os.Getenv("TEST_GITHUB_SECOND_API_URL"),
+		os.Getenv("TEST_GITHUB_SECOND_REPO_INSTALLATION_ID"),
+		directPREvent,
+		"check_run",
+	)
+	assert.NilError(t, err)
+
+	g.Cnx.Clients.Log.Infof("Waiting for PipelineRun to succeed (PR resolved from check_run.pull_requests)")
+	prs, err = twait.UntilPipelineRunsFinished(ctx, g.Cnx.Clients, twait.Opts{
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: 4,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       []string{g.SHA},
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, len(prs) >= 4, "no successful pipelineruns found")
+
+	g.Cnx.Clients.Log.Infof("Check if the fourth run succeeded (check_run.pull_requests case)")
 	assert.Assert(t, prs[len(prs)-1].Status.Conditions[0].Status == corev1.ConditionTrue)
 }


### PR DESCRIPTION
When GitHub receives a Re-run request for a Pipelines as Code check tied to a pull request from a fork, the webhook payload can omit the usual pull request metadata. PAC could already recover by looking up pull requests for the head SHA, but fork PRs still failed when GitHub's `commits/{sha}/pulls` API returned no matches.

This change makes rerequest handling more resilient and keeps the selection rules safe:

- check_run rerequests now honor pull request data attached directly to the event when GitHub provides it
- if the commit lookup API returns no open PR, PAC falls back to listing open pull requests and matching by head SHA so fork PR rerequests can still resolve
- the SHA fallback now preserves the existing ambiguity guard and fails if more than one open PR shares the same head SHA instead of picking one arbitrarily
- re-runs are now attributed to the user who clicked the Re-run button rather than falling back to the pull request author, so authorization checks apply to the person actually requesting the re-run
- tests now cover the direct-event path, fork fallback success, missing-PR failures, and the ambiguous fallback regression
- the "Restarting the PipelineRun" section of the running-pipelines guide now documents the fork re-run behavior and sender attribution

## 📝 Description of the Change

Improve GitHub rerequest PR resolution so fork pull requests can be recovered safely even when GitHub omits PR metadata or the commit lookup API returns no match.

## 🔗 Linked GitHub Issue

 [SRVKP-12590](https://redhat.atlassian.net/browse/SRVKP-12590).

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

Ran:
- `go test ./pkg/provider/github`

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

AI assistance was used to help draft and refine the code change, tests, and PR description. The resulting changes were reviewed and validated with the package test run above.

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
