### PR TITLE
fix(webhook): prevent duplicate repository CR on trailing slash

### DIFF
--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -90,7 +90,7 @@ func checkIfRepoExist(pac pac.RepositoryLister, repo *v1alpha1.Repository, ns st
 	}
 	for i := len(repositories) - 1; i >= 0; i-- {
 		repoFromCluster := repositories[i]
-		if repoFromCluster.Spec.URL == repo.Spec.URL &&
+		if strings.TrimRight(strings.TrimSpace(repoFromCluster.Spec.URL), "/") == strings.TrimRight(strings.TrimSpace(repo.Spec.URL), "/") &&
 			(repoFromCluster.Name != repo.Name || repoFromCluster.Namespace != repo.Namespace) {
 			return true, nil
 		}

--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -171,6 +171,26 @@ func TestReconcilerAdmit(t *testing.T) {
 			}),
 			allowed: true,
 		},
+		{
+			name: "reject repository URL with trailing slash",
+			repo: testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
+				Name:             "test-run",
+				InstallNamespace: "namespace",
+				URL:              "https://pac.test/already/installed/",
+			}),
+			allowed: false,
+			result:  "repository already exists with URL: https://pac.test/already/installed/",
+		},
+		{
+			name: "reject repository URL with multiple trailing slashes",
+			repo: testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
+				Name:             "test-run",
+				InstallNamespace: "namespace",
+				URL:              "https://pac.test/already/installed//////",
+			}),
+			allowed: false,
+			result:  "repository already exists with URL: https://pac.test/already/installed//////",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/repository_webhook_test.go
+++ b/test/repository_webhook_test.go
@@ -46,3 +46,37 @@ func TestOthersRepositoryCreation(t *testing.T) {
 	assert.Assert(t, err != nil)
 	assert.Equal(t, err.Error(), "admission webhook \"validation.pipelinesascode.tekton.dev\" denied the request: repository already exists with URL: https://pac.test/pac/app")
 }
+
+func TestOthersRepositoryCreationWithTrailingSlash(t *testing.T) {
+	ctx := context.TODO()
+	ctx, runcnx, _, _, err := ghtest.Setup(ctx, false, false)
+	assert.NilError(t, err)
+
+	targetNs := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("test-repo")
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: targetNs,
+		},
+		Spec: v1alpha1.RepositorySpec{
+			URL: "https://pac.test/pac/app",
+		},
+	}
+
+	defer repository.NSTearDown(ctx, t, runcnx, targetNs)
+	err = repository.CreateNS(ctx, targetNs, runcnx)
+	assert.NilError(t, err)
+	err = repository.CreateRepo(ctx, targetNs, runcnx, repo)
+	assert.NilError(t, err)
+
+	// create a new cr with same git url
+	targetNsNew := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("test-repo-new")
+	repo.Name = "test-repo-new"
+	repo.Spec.URL = "https://pac.test/pac/app/"
+
+	defer repository.NSTearDown(ctx, t, runcnx, targetNsNew)
+	err = repository.CreateNS(ctx, targetNsNew, runcnx)
+	assert.NilError(t, err)
+	err = repository.CreateRepo(ctx, targetNsNew, runcnx, repo)
+	assert.Assert(t, err != nil)
+	assert.Equal(t, err.Error(), "admission webhook \"validation.pipelinesascode.tekton.dev\" denied the request: repository already exists with URL: https://pac.test/pac/app/")
+}


### PR DESCRIPTION
The webhook admission controller's checkIfRepoExist used exact string equality to compare repository URLs. This allowed users to create a second Repository CR with the same URL by simply appending a trailing slash (e.g. https://github.com/org/repo vs https://github.com/org/repo/), bypassing the uniqueness validation.

And in [matching logic](https://github.com/tektoncd/pipelines-as-code/blob/de6de63d849a739ce61ddbc458de0faaa3462248/pkg/matcher/repo_runinfo_matcher.go#L27) we compare repository CRs by trimming suffix slash `"/"` which was facilitating this flaw. if there are two repository CRs with URLs https://github.com/pac/repo and https://github.com/pac/repo/ then in matching the repo with slash would be matched

  - pkg/webhook/validation.go:
    - Normalize URLs with strings.TrimSuffix before comparison in checkIfRepoExist to treat trailing slash variants as identical

  - pkg/webhook/validation_test.go:
    - Add test case for rejecting repository URL with trailing slash when a matching repo already exists

  - test/repository_webhook_test.go:
    - Add e2e test TestOthersRepositoryCreationWithTrailingSlash to verify the webhook rejects duplicate repos created via trailing slash bypass


## 🔗 Linked GitHub Issue

Fixes #

## JIRA

https://redhat.atlassian.net/browse/SRVKP-11295

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center 