### PR TITLE
fix(logging): log sinker errors , emit event on repository config error

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -253,10 +253,9 @@ func (l listener) handleEvent(ctx context.Context) http.HandlerFunc {
 
 		go func() {
 			defer span.End()
-			err := s.processEvent(tracedCtx, localRequest)
+			err := s.handleEvent(tracedCtx, localRequest)
 			if err != nil {
 				span.RecordError(err)
-				logger.Errorf("an error occurred: %v", err)
 			}
 		}()
 

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -271,10 +271,9 @@ func (l listener) handleEvent(ctx context.Context) http.HandlerFunc {
 
 		go func() {
 			defer span.End()
-			err := s.processEvent(tracedCtx, localRequest)
+			err := s.handleEvent(tracedCtx, localRequest)
 			if err != nil {
 				span.RecordError(err)
-				logger.Errorf("an error occurred: %v", err)
 			}
 		}()
 

--- a/pkg/adapter/sinker.go
+++ b/pkg/adapter/sinker.go
@@ -3,10 +3,12 @@ package adapter
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/gitclient"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
@@ -15,10 +17,12 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/secrets"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/tracing"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 type sinker struct {
@@ -70,6 +74,14 @@ func (s *sinker) processEventPayload(ctx context.Context, request *http.Request)
 	return nil
 }
 
+func (s *sinker) handleEvent(ctx context.Context, request *http.Request) error {
+	err := s.processEvent(ctx, request)
+	if err != nil {
+		s.logger.Errorf("error handling event: %v", err)
+	}
+	return err
+}
+
 func (s *sinker) processEvent(ctx context.Context, request *http.Request) error {
 	if s.event.EventType != "incoming" {
 		if err := s.processEventPayload(ctx, request); err != nil {
@@ -89,6 +101,14 @@ func (s *sinker) processEvent(ctx context.Context, request *http.Request) error 
 			// We found the repository, now setup client with token scoping
 			// If setup fails here, it's a configuration error and we should fail fast
 			if err := s.setupClient(ctx, repo); err != nil {
+				if errors.Is(err, secrets.ErrSecretNotFound) {
+					events.NewEventEmitter(s.run.Clients.Kube, s.logger).EmitMessage(
+						repo,
+						zapcore.ErrorLevel,
+						"RepositorySecretMissing",
+						fmt.Sprintf("cannot process event, cannot setup vcs client: %v", err),
+					)
+				}
 				return fmt.Errorf("client setup failed: %w", err)
 			}
 			s.logger.Debugf("Client setup completed for event type: %s", s.event.EventType)

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -647,7 +647,7 @@ func TestVerifyRepoAndUser(t *testing.T) {
 			}},
 			wantRepoNil: false,
 			wantErr:     true,
-			wantErrMsg:  "cannot get secret from repository: failed to find git_provider details in repository spec: ns/repo",
+			wantErrMsg:  "cannot get secret from repository: secret not found: failed to find git_provider details in repository spec: ns/repo",
 		},
 		{
 			name: "webhook validation failure",

--- a/pkg/secrets/secret.go
+++ b/pkg/secrets/secret.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -19,6 +20,11 @@ const (
 	defaultPipelinesAscodeSecretWebhookSecretKey = "webhook.secret"
 )
 
+// ErrSecretNotFound indicates that a Repository's secret is misconfigured.
+// For example if a required secret is not specified or the required secret
+// does not exist.
+var ErrSecretNotFound = errors.New("secret not found")
+
 type SecretFromRepository struct {
 	K8int                 kubeinteraction.Interface
 	Config                *info.ProviderConfig
@@ -34,7 +40,7 @@ type SecretFromRepository struct {
 func (s *SecretFromRepository) Get(ctx context.Context) error {
 	var err error
 	if s.Repo.Spec.GitProvider == nil {
-		return fmt.Errorf("failed to find git_provider details in repository spec: %v/%v", s.Repo.Namespace, s.Repo.Name)
+		return fmt.Errorf("%w: failed to find git_provider details in repository spec: %v/%v", ErrSecretNotFound, s.Repo.Namespace, s.Repo.Name)
 	}
 	if s.Repo.Spec.GitProvider.URL == "" {
 		s.Repo.Spec.GitProvider.URL = s.Config.APIURL
@@ -44,7 +50,7 @@ func (s *SecretFromRepository) Get(ctx context.Context) error {
 	s.Logger.Debugf("secretFromRepository: repo=%s/%s provider_url=%s namespace=%s", s.Repo.Namespace, s.Repo.Name, s.Repo.Spec.GitProvider.URL, s.Namespace)
 
 	if s.Repo.Spec.GitProvider.Secret == nil {
-		return fmt.Errorf("failed to find secret in git_provider section in repository spec: %v/%v", s.Repo.Namespace, s.Repo.Name)
+		return fmt.Errorf("%w: failed to find secret in git_provider section in repository spec: %v/%v", ErrSecretNotFound, s.Repo.Namespace, s.Repo.Name)
 	}
 	gitProviderSecretKey := s.Repo.Spec.GitProvider.Secret.Key
 	if gitProviderSecretKey == "" {
@@ -57,7 +63,7 @@ func (s *SecretFromRepository) Get(ctx context.Context) error {
 		Name:      s.Repo.Spec.GitProvider.Secret.Name,
 		Key:       gitProviderSecretKey,
 	}); err != nil {
-		return err
+		return fmt.Errorf("%w: error getting provider secret: %w", ErrSecretNotFound, err)
 	}
 	s.Event.Provider.GitProviderSecretNamespace = s.Namespace
 	s.Event.Provider.GitProviderSecretFromGlobalRepo = s.InheritedGlobalSecret
@@ -91,7 +97,7 @@ func (s *SecretFromRepository) Get(ctx context.Context) error {
 		Name:      s.Repo.Spec.GitProvider.WebhookSecret.Name,
 		Key:       gitProviderWebhookSecretKey,
 	}); err != nil {
-		return err
+		return fmt.Errorf("%w: error getting webhook secret: %w", ErrSecretNotFound, err)
 	}
 	if s.Event.Provider.WebhookSecret != "" {
 		s.Event.Provider.WebhookSecretFromRepo = true

--- a/pkg/secrets/secret.go
+++ b/pkg/secrets/secret.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -18,6 +19,11 @@ const (
 	DefaultGitProviderWebhookSecretKey           = "webhook.secret"
 	defaultPipelinesAscodeSecretWebhookSecretKey = "webhook.secret"
 )
+
+// ErrSecretNotFound indicates that a Repository's secret is misconfigured.
+// For example if a required secret is not specified or the required secret
+// does not exist.
+var ErrSecretNotFound = errors.New("secret not found")
 
 type SecretFromRepository struct {
 	K8int                 kubeinteraction.Interface
@@ -57,7 +63,7 @@ func (s *SecretFromRepository) Get(ctx context.Context) error {
 		Name:      s.Repo.Spec.GitProvider.Secret.Name,
 		Key:       gitProviderSecretKey,
 	}); err != nil {
-		return err
+		return fmt.Errorf("%w: error getting provider secret: %w", ErrSecretNotFound, err)
 	}
 	s.Event.Provider.GitProviderSecretNamespace = s.Namespace
 	s.Event.Provider.GitProviderSecretFromGlobalRepo = s.InheritedGlobalSecret
@@ -91,7 +97,7 @@ func (s *SecretFromRepository) Get(ctx context.Context) error {
 		Name:      s.Repo.Spec.GitProvider.WebhookSecret.Name,
 		Key:       gitProviderWebhookSecretKey,
 	}); err != nil {
-		return err
+		return fmt.Errorf("%w: error getting webhook secret: %w", ErrSecretNotFound, err)
 	}
 	if s.Event.Provider.WebhookSecret != "" {
 		s.Event.Provider.WebhookSecretFromRepo = true

--- a/pkg/secrets/secret_test.go
+++ b/pkg/secrets/secret_test.go
@@ -6,11 +6,18 @@ import (
 	"testing"
 
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	kitesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/kubernetestint"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
@@ -125,6 +132,124 @@ func TestSecretFromRepository(t *testing.T) {
 				assert.Assert(t, tt.logmatch[key].MatchString(value.Message), "no match on logs %s => %s", tt.logmatch[key], value.Message)
 			}
 			assert.Equal(t, tt.expectedSecret, event.Provider.Token)
+		})
+	}
+}
+
+func TestSecretFromRepositoryError(t *testing.T) {
+	namespace := "test"
+	tdata := testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "good-name",
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"good-key": []byte(`keep it secret, keep it safe`),
+			},
+		}},
+	}
+
+	tests := []struct {
+		name     string
+		repoSpec apipac.RepositorySpec
+		wantErr  string
+	}{
+		{
+			name: "no git provider",
+			repoSpec: apipac.RepositorySpec{
+				GitProvider: nil,
+			},
+			wantErr: "failed to find git_provider details",
+		},
+		{
+			name: "no git provider secret",
+			repoSpec: apipac.RepositorySpec{
+				GitProvider: &apipac.GitProvider{},
+			},
+			wantErr: "failed to find secret in git_provider section in repository",
+		},
+		{
+			name: "git provider secret doesn't exist",
+			repoSpec: apipac.RepositorySpec{
+				GitProvider: &apipac.GitProvider{
+					Secret: &apipac.Secret{Name: "bad-name"},
+				},
+			},
+			wantErr: "error getting provider secret",
+		},
+		{
+			name: "git provider secret bad key",
+			repoSpec: apipac.RepositorySpec{
+				GitProvider: &apipac.GitProvider{
+					Secret: &apipac.Secret{Name: "good-name", Key: "bad-key"},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			// webhook secret being unspecified is OK, but if it is specified it must exist
+			name: "webhook secret missing",
+			repoSpec: apipac.RepositorySpec{
+				GitProvider: &apipac.GitProvider{
+					Secret:        &apipac.Secret{Name: "good-name", Key: "good-key"},
+					WebhookSecret: &apipac.Secret{Name: "bad-name"},
+				},
+			},
+			wantErr: "error getting webhook secret",
+		},
+		{
+			name: "webhook secret bad key",
+			repoSpec: apipac.RepositorySpec{
+				GitProvider: &apipac.GitProvider{
+					Secret:        &apipac.Secret{Name: "good-name", Key: "good-key"},
+					WebhookSecret: &apipac.Secret{Name: "good-name", Key: "bad-key"},
+				},
+			},
+			wantErr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+
+			stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+			run := &params.Run{
+				Clients: clients.Clients{
+					Kube:           stdata.Kube,
+					PipelineAsCode: stdata.PipelineAsCode,
+					Log:            logger,
+				},
+			}
+			kint, err := kubeinteraction.NewKubernetesInteraction(run)
+			assert.NilError(t, err)
+
+			repo := &apipac.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.name, Namespace: namespace},
+				Spec:       tt.repoSpec,
+			}
+
+			event := info.NewEvent()
+			sfr := SecretFromRepository{
+				K8int:       kint,
+				Config:      &info.ProviderConfig{APIURL: "https://fake"},
+				Event:       event,
+				Repo:        repo,
+				WebhookType: "subversion",
+				Namespace:   repo.Namespace,
+				Logger:      logger,
+			}
+
+			err = sfr.Get(ctx)
+			if tt.wantErr != "" {
+				assert.Assert(t, err != nil, "expected error: "+tt.wantErr)
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.ErrorIs(t, err, ErrSecretNotFound)
+			} else {
+				assert.NilError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/secrets/secret_test.go
+++ b/pkg/secrets/secret_test.go
@@ -8,6 +8,7 @@ import (
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	kitesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/kubernetestint"
+
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
@@ -16,34 +17,35 @@ import (
 
 func TestSecretFromRepository(t *testing.T) {
 	tests := []struct {
-		name                  string
-		repo                  *apipac.Repository
-		providerconfig        *info.ProviderConfig
-		logmatch              []*regexp.Regexp
-		expectedSecret        string
-		expectedWebhookSecret string
-		providerType          string
+		name           string
+		repo           *apipac.Repository
+		providerconfig *info.ProviderConfig
+		providerType   string
+		secrets        map[string]string
+		logmatch       []*regexp.Regexp
+		expectedSecret string
+		wantErr        string
+		wantErrIs      error
 	}{
 		{
 			name: "config default",
 			providerconfig: &info.ProviderConfig{
 				APIURL: "https://apiurl.default",
 			},
-			expectedSecret:        "configdefault",
-			expectedWebhookSecret: "webhooksecret",
 			repo: &apipac.Repository{
 				Spec: apipac.RepositorySpec{
 					GitProvider: &apipac.GitProvider{
-						Secret: &apipac.Secret{
-							Name: "repo-secret",
-						},
-						WebhookSecret: &apipac.Secret{
-							Name: "repo-webhook-secret",
-						},
+						Secret:        &apipac.Secret{Name: "repo-secret"},
+						WebhookSecret: &apipac.Secret{Name: "repo-webhook-secret"},
 					},
 				},
 			},
 			providerType: "lalala",
+			secrets: map[string]string{
+				"repo-secret":         "configdefault",
+				"repo-webhook-secret": "webhooksecret",
+			},
+			expectedSecret: "configdefault",
 			logmatch: []*regexp.Regexp{
 				regexp.MustCompile(fmt.Sprintf(
 					"^Using git provider lalala: apiurl=https://apiurl.default user= token-secret=repo-secret token-key=%s",
@@ -59,10 +61,15 @@ func TestSecretFromRepository(t *testing.T) {
 			repo: &apipac.Repository{
 				Spec: apipac.RepositorySpec{
 					GitProvider: &apipac.GitProvider{
-						URL:    "https://dowant",
-						Secret: &apipac.Secret{},
+						URL:           "https://dowant",
+						Secret:        &apipac.Secret{Name: "provider-secret"},
+						WebhookSecret: &apipac.Secret{Name: "webhook-secret"},
 					},
 				},
+			},
+			secrets: map[string]string{
+				"provider-secret": "setapiurl",
+				"webhook-secret":  "",
 			},
 			expectedSecret: "setapiurl",
 			logmatch: []*regexp.Regexp{
@@ -75,14 +82,107 @@ func TestSecretFromRepository(t *testing.T) {
 			repo: &apipac.Repository{
 				Spec: apipac.RepositorySpec{
 					GitProvider: &apipac.GitProvider{
-						User:   "userfoo",
-						Secret: &apipac.Secret{},
+						User:          "userfoo",
+						Secret:        &apipac.Secret{Name: "provider-secret"},
+						WebhookSecret: &apipac.Secret{Name: "webhook-secret"},
 					},
 				},
+			},
+			secrets: map[string]string{
+				"provider-secret": "set user",
+				"webhook-secret":  "",
 			},
 			expectedSecret: "set user",
 			logmatch: []*regexp.Regexp{
 				regexp.MustCompile(".*user=userfoo*"),
+			},
+		},
+		{
+			name:           "no git provider",
+			providerconfig: &info.ProviderConfig{APIURL: "https://fake"},
+			providerType:   "subversion",
+			repo: &apipac.Repository{
+				Spec: apipac.RepositorySpec{GitProvider: nil},
+			},
+			wantErr: "failed to find git_provider details",
+		},
+		{
+			name:           "no git provider secret",
+			providerconfig: &info.ProviderConfig{APIURL: "https://fake"},
+			providerType:   "subversion",
+			repo: &apipac.Repository{
+				Spec: apipac.RepositorySpec{GitProvider: &apipac.GitProvider{}},
+			},
+			wantErr: "failed to find secret in git_provider section in repository",
+		},
+		{
+			name:           "git provider secret doesn't exist",
+			providerconfig: &info.ProviderConfig{APIURL: "https://fake"},
+			providerType:   "subversion",
+			repo: &apipac.Repository{
+				Spec: apipac.RepositorySpec{
+					GitProvider: &apipac.GitProvider{
+						Secret: &apipac.Secret{Name: "bad-name"},
+					},
+				},
+			},
+			wantErr:   "error getting provider secret",
+			wantErrIs: ErrSecretNotFound,
+		},
+		{
+			// a bad key on an existing secret is not an error, it just resolves to an empty value
+			name:           "git provider secret bad key",
+			providerconfig: &info.ProviderConfig{APIURL: "https://fake"},
+			providerType:   "subversion",
+			repo: &apipac.Repository{
+				Spec: apipac.RepositorySpec{
+					GitProvider: &apipac.GitProvider{
+						Secret: &apipac.Secret{Name: "good-name", Key: "bad-key"},
+					},
+				},
+			},
+			secrets: map[string]string{
+				"good-name": "keep it secret, keep it safe",
+			},
+			expectedSecret: "keep it secret, keep it safe",
+		},
+		{
+			// webhook secret being unspecified is OK, but if it is specified it must exist
+			name:           "webhook secret missing",
+			providerconfig: &info.ProviderConfig{APIURL: "https://fake"},
+			providerType:   "subversion",
+			repo: &apipac.Repository{
+				Spec: apipac.RepositorySpec{
+					GitProvider: &apipac.GitProvider{
+						Secret:        &apipac.Secret{Name: "good-name", Key: "good-key"},
+						WebhookSecret: &apipac.Secret{Name: "bad-name"},
+					},
+				},
+			},
+			secrets: map[string]string{
+				"good-name": "keep it secret, keep it safe",
+			},
+			wantErr:   "error getting webhook secret",
+			wantErrIs: ErrSecretNotFound,
+		},
+		{
+			name:           "webhook secret bad key",
+			providerconfig: &info.ProviderConfig{APIURL: "https://fake"},
+			providerType:   "subversion",
+			repo: &apipac.Repository{
+				Spec: apipac.RepositorySpec{
+					GitProvider: &apipac.GitProvider{
+						Secret:        &apipac.Secret{Name: "good-name", Key: "good-key"},
+						WebhookSecret: &apipac.Secret{Name: "good-name", Key: "bad-key"},
+					},
+				},
+			},
+			secrets: map[string]string{
+				"good-name": "keep it secret, keep it safe",
+			},
+			expectedSecret: "keep it secret, keep it safe",
+			logmatch: []*regexp.Regexp{
+				regexp.MustCompile("^Using git provider subversion:.*"),
 			},
 		},
 	}
@@ -91,20 +191,9 @@ func TestSecretFromRepository(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			observer, log := zapobserver.New(zap.InfoLevel)
 			logger := zap.New(observer).Sugar()
-			retsecret := map[string]string{}
-			if tt.repo.Spec.GitProvider.Secret != nil {
-				retsecret[tt.repo.Spec.GitProvider.Secret.Name] = tt.expectedSecret
-			} else {
-				tt.repo.Spec.GitProvider.Secret = &apipac.Secret{}
-			}
-			if tt.repo.Spec.GitProvider.WebhookSecret != nil {
-				retsecret[tt.repo.Spec.GitProvider.WebhookSecret.Name] = tt.expectedWebhookSecret
-			} else {
-				tt.repo.Spec.GitProvider.WebhookSecret = &apipac.Secret{}
-			}
 
 			k8int := &kitesthelper.KinterfaceTest{
-				GetSecretResult: retsecret,
+				GetSecretResult: tt.secrets,
 			}
 			event := info.NewEvent()
 			sfr := SecretFromRepository{
@@ -118,6 +207,14 @@ func TestSecretFromRepository(t *testing.T) {
 			}
 
 			err := sfr.Get(ctx)
+			if tt.wantErr != "" {
+				assert.Assert(t, err != nil, "expected error: "+tt.wantErr)
+				assert.ErrorContains(t, err, tt.wantErr)
+				if tt.wantErrIs != nil {
+					assert.ErrorIs(t, err, tt.wantErrIs)
+				}
+				return
+			}
 			assert.NilError(t, err)
 			logs := log.TakeAll()
 			assert.Equal(t, len(tt.logmatch), len(logs), "we didn't get the number of logging message: %+v", logs)


### PR DESCRIPTION
## 📝 Description of the Change
Since `sinker.logger` is modified during `sinker.processEvent()`, if an error is returned from `processEvent()` logging from the adapter logs without these modifications (i.e. the log won't have added context like repository URL, commit sha, etc)

This change also improves the logging when PaC fails to process an event due to a misconfigured Repository CR. Specifically, when the required GitProvider.Secret is either unspecified or missing PaC will now emit an Event on the Repository CR. Events are a clearer signal to users than logs since tenants may be given access to events in their namespace whereas PaC logs are considered more sensitive

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ x 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
