### PR TITLE
feat(bitbucket-cloud): add HMAC webhook secret validation

### DIFF
--- a/docs/content/docs/providers/bitbucket-cloud.md
+++ b/docs/content/docs/providers/bitbucket-cloud.md
@@ -109,12 +109,13 @@ Create a Kubernetes secret containing your API token in the `target-namespace`
 
 ```shell
 kubectl -n target-namespace create secret generic bitbucket-cloud-token \
-        --from-literal provider.token="BITBUCKET_CLOUD_API_TOKEN"
+        --from-literal provider.token="BITBUCKET_CLOUD_API_TOKEN" \
+        --from-literal webhook.secret="YOUR_WEBHOOK_SECRET" # required when IP-Based validation is disabled in pipelines-as-code configmap.
 ```
 
 ### Create the Repository CR
 
-Create a [`Repository` CR]({{< relref "/docs/guides/repository-crd" >}}) with the secret field referencing it:
+Create a [`Repository` CR]({{< relref "/docs/guides/repository-crd" >}}) with the secret and webhook secret fields referencing it:
 
 ```yaml
   ---
@@ -131,6 +132,11 @@ Create a [`Repository` CR]({{< relref "/docs/guides/repository-crd" >}}) with th
         name: "bitbucket-cloud-token"
         # Set this if you have a different key in your secret
         # key: "provider.token"
+      webhook_secret:
+        # required when IP-Based validation is disabled in pipelines-as-code configmap.
+        name: "bitbucket-cloud-token"
+        # Set this if you have a different key in your secret
+        # key: "webhook.secret"
 ```
 
 You must use your Bitbucket/Atlassian account email address in the `user` field
@@ -155,21 +161,38 @@ You can only reference a user by the `ACCOUNT_ID` in a owner file. For reason se
 <https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/#introducing-atlassian-account-id-and-nicknames>
 {{< /callout >}}
 
-{{< callout type="error" >}}
+{{< callout type="info" >}}
 
-- There is no webhook secret support in Bitbucket Cloud. To secure
-  the payload and prevent hijacking of the CI, Pipelines-as-Code will fetch the
-  IP addresses list from <https://ip-ranges.atlassian.com/> and ensure that the
-  webhook receptions come only from the Bitbucket Cloud IPs.
-- If you want to add some IP addresses or networks, you can add them to the
-  `bitbucket-cloud-additional-source-ip` key in the pipelines-as-code
-  `ConfigMap` in the `pipelines-as-code` namespace. You can add multiple
-  network or IPs separated by a comma.
+### IP-based validation (defense-in-depth)
 
-- If you want to disable this behavior you can set the
-  `bitbucket-cloud-check-source-ip` key to `false` in the pipelines-as-code
-  `ConfigMap` in the `pipelines-as-code` namespace.
+Pipelines-as-Code verifies that webhooks originate from Bitbucket Cloud IP addresses by fetching the
+IP list from <https://ip-ranges.atlassian.com/>.
+
+- To add extra IP addresses or networks, set the
+  `bitbucket-cloud-additional-source-ip` key in the `pipelines-as-code`
+  ConfigMap. You can add multiple networks or IPs separated by a comma.
+
+- To disable IP checking, set `bitbucket-cloud-check-source-ip` to `false`
+  in the `pipelines-as-code` ConfigMap.
 {{< /callout >}}
+
+### Webhook Secret Validation
+
+In addition to IP-based validation, Pipelines-as-Code can also verify
+Bitbucket Cloud supports HMAC webhook secrets. When you configure a
+webhook secret on the Repository CR, Pipelines-as-Code validates the
+signature header on every incoming webhook to verify the payload was
+sent by Bitbucket Cloud and has not been tampered with.
+
+Note: If IP-Based validation is disabled, Pipelines-as-Code falls back to
+webhook secret validation to protect PipelineRuns being triggered from unverified source.
+
+Pipelines-as-Code checks the `X-Hub-Signature-256` header (HMAC-SHA256)
+first and falls back to `X-Hub-Signature` (HMAC-SHA1) if the SHA256 header
+is not present.
+
+Make sure the same secret value is configured in your Bitbucket Cloud webhook
+settings under **Repository settings → Workflow → Webhooks → Edit → Secret**.
 
 ## Add Webhook Secret
 

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/go-github/v85/github"
 	"github.com/ktrysmt/go-bitbucket"
 	"github.com/mitchellh/mapstructure"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
@@ -67,8 +68,25 @@ func (v *Provider) SetPacInfo(pacInfo *info.PacOpts) {
 const taskStatusTemplate = `{{range $taskrun := .TaskRunList }} | **{{ formatCondition $taskrun.PipelineRunTaskRunStatus.Status.Conditions }}** | {{ $taskrun.ConsoleLogURL }} | *{{ formatDuration $taskrun.PipelineRunTaskRunStatus.Status.StartTime $taskrun.PipelineRunTaskRunStatus.Status.CompletionTime }}* |
 {{ end }}`
 
-func (v *Provider) Validate(_ context.Context, _ *params.Run, _ *info.Event) error {
-	return nil
+func (v *Provider) Validate(_ context.Context, _ *params.Run, event *info.Event) error {
+	if v.pacInfo.BitbucketCloudCheckSourceIP {
+		v.Logger.Info("Skipping signature validation because source IP check is enabled")
+		return nil
+	}
+
+	v.Logger.Info("Validating signature for the event as bitbucket-cloud-check-source-ip is disabled in PaC configmap")
+
+	signature := event.Request.Header.Get(github.SHA256SignatureHeader)
+	if signature == "" {
+		signature = event.Request.Header.Get(github.SHA1SignatureHeader)
+	}
+	if signature == "" || signature == "sha256=" {
+		return fmt.Errorf("no signature has been detected, for security reason we are not allowing webhooks that has no secret (hint: did you forget to set webhook secret in your repository settings?)")
+	}
+	if event.Provider.WebhookSecret == "" {
+		return fmt.Errorf("no webhook secret has been set, in repository CR or secret")
+	}
+	return github.ValidateSignature(signature, event.Request.Payload, []byte(event.Provider.WebhookSecret))
 }
 
 func (v *Provider) SetLogger(logger *zap.SugaredLogger) {

--- a/pkg/provider/bitbucketcloud/bitbucket_test.go
+++ b/pkg/provider/bitbucketcloud/bitbucket_test.go
@@ -1,7 +1,13 @@
 package bitbucketcloud
 
 import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"hash"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -391,6 +397,144 @@ func TestCreateStatus(t *testing.T) {
 
 			err := v.CreateStatus(ctx, event, tt.status)
 			assert.NilError(t, err)
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	observer, log := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+
+	tests := []struct {
+		name          string
+		wantErr       bool
+		secret        string
+		webhookSecret string
+		payload       string
+		hashFunc      func() hash.Hash
+		prefixheader  string
+		header        string
+		sourceIPCheck bool
+		wantLog       string
+	}{
+		{
+			name:          "valid SHA256 signature",
+			secret:        "mysecret",
+			webhookSecret: "mysecret",
+			payload:       `{"hello": "moto"}`,
+			hashFunc:      sha256.New,
+			prefixheader:  "sha256",
+			header:        "X-Hub-Signature-256",
+		},
+		{
+			name:          "valid SHA1 signature",
+			secret:        "mysecret",
+			webhookSecret: "mysecret",
+			payload:       `{"ola": "amigo"}`,
+			hashFunc:      sha256.New,
+			prefixheader:  "sha256",
+			header:        "X-Hub-Signature",
+		},
+		{
+			name:          "invalid signature",
+			secret:        "",
+			webhookSecret: "wrongsecret",
+			payload:       `{"ciao": "ragazzo"}`,
+			hashFunc:      sha256.New,
+			prefixheader:  "sha1",
+			header:        "X-Hub-Signature",
+			wantErr:       true,
+		},
+		{
+			name:    "missing signature header",
+			secret:  "mysecret",
+			payload: `{"hello": "moto"}`,
+			wantErr: true,
+		},
+		{
+			name:         "no webhook secret configured",
+			secret:       "",
+			payload:      `{"hello": "moto"}`,
+			hashFunc:     sha256.New,
+			prefixheader: "sha256",
+			header:       "X-Hub-Signature-256",
+			wantErr:      true,
+		},
+		{
+			name:          "HMAC signature mismatch",
+			secret:        "mysecret",
+			webhookSecret: "wrongsecret",
+			payload:       `{"hola": "mundo"}`,
+			hashFunc:      sha256.New,
+			prefixheader:  "sha256",
+			header:        "X-Hub-Signature-256",
+			wantErr:       true,
+		},
+		{
+			name:          "source IP check enabled",
+			secret:        "mysecret",
+			webhookSecret: "wrongsecret",
+			payload:       `{"hola": "mundo"}`,
+			hashFunc:      sha256.New,
+			prefixheader:  "sha256",
+			header:        "X-Hub-Signature-256",
+			sourceIPCheck: true,
+			wantLog:       "Skipping signature validation because source IP check is enabled",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Provider{Logger: logger}
+
+			httpHeader := http.Header{}
+			if tt.hashFunc != nil {
+				mac := hmac.New(tt.hashFunc, []byte(tt.secret))
+				mac.Write([]byte(tt.payload))
+				signature := hex.EncodeToString(mac.Sum(nil))
+				httpHeader.Add(tt.header, fmt.Sprintf("%s=%s", tt.prefixheader, signature))
+			}
+
+			webhookSecret := tt.webhookSecret
+			if webhookSecret == "" {
+				webhookSecret = tt.secret
+			}
+
+			event := info.NewEvent()
+			event.Request = &info.Request{
+				Header:  httpHeader,
+				Payload: []byte(tt.payload),
+			}
+
+			pacInfo := &info.PacOpts{
+				Settings: settings.Settings{
+					BitbucketCloudCheckSourceIP: tt.sourceIPCheck,
+				},
+			}
+			v.SetPacInfo(pacInfo)
+
+			event.Provider = &info.Provider{
+				WebhookSecret: webhookSecret,
+			}
+
+			err := v.Validate(context.TODO(), nil, event)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected error but got nil")
+			} else {
+				assert.NilError(t, err)
+			}
+
+			if tt.wantLog != "" {
+				assert.Assert(t, log.Len() > 0, "We didn't get any log message")
+				all := log.TakeAll()
+				matched := false
+				for _, entry := range all {
+					if strings.Contains(entry.Message, tt.wantLog) {
+						matched = true
+						break
+					}
+				}
+				assert.Assert(t, matched, "We didn't get the expected log message: %s", tt.wantLog)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## 📝 Description of the Change
Implement X-Hub-Signature / X-Hub-Signature-256 HMAC validation for Bitbucket Cloud webhooks, matching the existing GitHub and Bitbucket Data Center pattern. PaC first checks IP-Based validation if it's disabled then fallback to webhook secret validation and checks if a webhook_secret is configured on the Repository CR, incoming payloads are verified against the signature header.

Assisted-by: Claude Opus 4.6 (via Claude Code)

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [x] Bitbucket Cloud
  - [ ] Bitbucket Data Center
