### PR TITLE
fix(gitlab): handle branch creation without commits

### DIFF
--- a/pkg/adapter/sinker.go
+++ b/pkg/adapter/sinker.go
@@ -94,9 +94,11 @@ func (s *sinker) processEvent(ctx context.Context, request *http.Request) error 
 			s.logger.Debugf("Client setup completed for event type: %s", s.event.EventType)
 		}
 
-		// For PUSH events: commit message is already in event.SHATitle from the webhook payload
-		// We can check immediately without any API calls or repository lookups
-		if s.event.EventType == "push" && provider.SkipCI(s.event.SHATitle) {
+		skipPush, err := s.shouldSkipPushEvent(ctx, repo)
+		if err != nil {
+			return err
+		}
+		if skipPush {
 			s.logger.Infof("CI skipped for push event: commit %s contains skip command in message", s.event.SHA)
 			return s.createSkipCIStatus(ctx)
 		}
@@ -122,6 +124,23 @@ func (s *sinker) processEvent(ctx context.Context, request *http.Request) error 
 
 	p := pipelineascode.NewPacs(s.event, s.vcx, s.run, s.pacInfo, s.kint, s.logger, s.globalRepo)
 	return p.Run(ctx)
+}
+
+func (s *sinker) shouldSkipPushEvent(ctx context.Context, repo *v1alpha1.Repository) (bool, error) {
+	if s.event.EventType != "push" {
+		return false, nil
+	}
+
+	resolvedMetadata := false
+	if repo != nil && s.event.CommitMetadataIncomplete {
+		// GitLab branch creation payloads omit commits, so fetch metadata before the early skip-CI check.
+		if err := s.vcx.GetCommitInfo(ctx, s.event); err != nil {
+			return false, fmt.Errorf("could not get commit info: %w", err)
+		}
+		resolvedMetadata = true
+	}
+
+	return provider.SkipCI(s.event.SHATitle) || (resolvedMetadata && s.event.HasSkipCommand), nil
 }
 
 // findMatchingRepository finds the Repository CR that matches the event.

--- a/pkg/adapter/sinker_test.go
+++ b/pkg/adapter/sinker_test.go
@@ -2,19 +2,25 @@ package adapter
 
 import (
 	"context"
+	"fmt"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	providerstatus "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	testprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/test/provider"
 	testnewrepo "github.com/openshift-pipelines/pipelines-as-code/pkg/test/repository"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -202,6 +208,235 @@ type trackingProviderImpl struct {
 
 func (t *trackingProviderImpl) CreateToken(_ context.Context, _ []string, _ *info.Event) (string, error) {
 	return "fake-token", nil
+}
+
+type commitInfoProvider struct {
+	testprovider.TestProviderImp
+	commitInfoCalls   int
+	commitTitle       string
+	commitMessage     string
+	commitInfoFailure bool
+	statusCalls       int
+	lastStatus        providerstatus.StatusOpts
+}
+
+func (p *commitInfoProvider) GetCommitInfo(_ context.Context, event *info.Event) error {
+	p.commitInfoCalls++
+	if p.commitInfoFailure {
+		return fmt.Errorf("commit lookup failed")
+	}
+	event.SHATitle = p.commitTitle
+	event.SHAMessage = p.commitMessage
+	event.HasSkipCommand = provider.SkipCI(p.commitMessage)
+	event.CommitMetadataIncomplete = false
+	return nil
+}
+
+func (p *commitInfoProvider) CreateStatus(_ context.Context, _ *info.Event, status providerstatus.StatusOpts) error {
+	p.statusCalls++
+	p.lastStatus = status
+	return nil
+}
+
+func TestShouldSkipPushEvent(t *testing.T) {
+	tests := []struct {
+		name              string
+		event             *info.Event
+		commitTitle       string
+		commitMessage     string
+		commitInfoFailure bool
+		nilRepo           bool
+		wantSkip          bool
+		wantErr           string
+		wantCalls         int
+	}{
+		{
+			name: "ordinary push with skip command uses payload metadata",
+			event: &info.Event{
+				EventType: "push",
+				SHA:       "abc123",
+				SHATitle:  "fix: bug [skip ci]",
+				SHAURL:    "https://gitlab.example/commit/abc123",
+			},
+			wantSkip: true,
+		},
+		{
+			name: "ordinary push without skip command makes no API call",
+			event: &info.Event{
+				EventType: "push",
+				SHA:       "abc123",
+				SHATitle:  "fix: bug",
+				SHAURL:    "https://gitlab.example/commit/abc123",
+			},
+		},
+		{
+			name: "push with missing metadata resolves skip command from full message",
+			event: &info.Event{
+				EventType:                "push",
+				SHA:                      "abc123",
+				CommitMetadataIncomplete: true,
+			},
+			commitTitle:   "fix: bug",
+			commitMessage: "fix: bug\n\n[skip ci]",
+			wantSkip:      true,
+			wantCalls:     1,
+		},
+		{
+			name: "push with missing metadata propagates lookup failure",
+			event: &info.Event{
+				EventType:                "push",
+				SHA:                      "abc123",
+				CommitMetadataIncomplete: true,
+			},
+			commitInfoFailure: true,
+			wantErr:           "commit lookup failed",
+			wantCalls:         1,
+		},
+		{
+			name: "ordinary push with empty payload metadata makes no API call",
+			event: &info.Event{
+				EventType:      "push",
+				SHA:            "abc123",
+				HasSkipCommand: true,
+			},
+		},
+		{
+			// Without a matched repository there are no credentials to authenticate the
+			// lookup, so the incomplete metadata is left alone instead of erroring.
+			name: "push with missing metadata and no matched repository makes no API call",
+			event: &info.Event{
+				EventType:                "push",
+				SHA:                      "abc123",
+				CommitMetadataIncomplete: true,
+			},
+			nilRepo:       true,
+			commitMessage: "fix: bug\n\n[skip ci]",
+		},
+		{
+			name: "non-push event makes no API call",
+			event: &info.Event{
+				EventType: "pull_request",
+				SHA:       "abc123",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			commitProvider := &commitInfoProvider{
+				commitTitle:       tt.commitTitle,
+				commitMessage:     tt.commitMessage,
+				commitInfoFailure: tt.commitInfoFailure,
+			}
+			s := &sinker{
+				vcx:   commitProvider,
+				event: tt.event,
+			}
+
+			repo := &v1alpha1.Repository{}
+			if tt.nilRepo {
+				repo = nil
+			}
+
+			got, err := s.shouldSkipPushEvent(ctx, repo)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, tt.wantSkip, got)
+			}
+			assert.Equal(t, tt.wantCalls, commitProvider.commitInfoCalls)
+		})
+	}
+}
+
+func TestProcessEventBranchCreation(t *testing.T) {
+	tests := []struct {
+		name              string
+		commitMessage     string
+		commitInfoFailure bool
+		wantErr           string
+		wantStatusCalls   int
+	}{
+		{
+			name:            "skip command in the resolved message skips the run",
+			commitMessage:   "fix: branch creation\n\n[skip ci]",
+			wantStatusCalls: 1,
+		},
+		{
+			// A failed lookup must abort processEvent rather than silently continue with
+			// the incomplete metadata the webhook delivered.
+			name:              "commit lookup failure aborts the event",
+			commitInfoFailure: true,
+			wantErr:           "could not get commit info",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			log, _ := logger.GetLogger()
+			repo := testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
+				Name:             "test-repo",
+				URL:              "https://gitlab.example/org/repo",
+				InstallNamespace: "default",
+			})
+			repo.Spec.GitProvider = &v1alpha1.GitProvider{
+				URL: "https://gitlab.example",
+				Secret: &v1alpha1.Secret{
+					Name: "test-secret",
+					Key:  "provider.token",
+				},
+				WebhookSecret: &v1alpha1.Secret{
+					Name: "test-secret",
+					Key:  "webhook.secret",
+				},
+			}
+			run := setupTestData(t, []*v1alpha1.Repository{repo})
+			run.Clients.SetConsoleUI(consoleui.FallBackConsole{})
+			event := &info.Event{
+				EventType:                "push",
+				URL:                      repo.Spec.URL,
+				SHA:                      "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+				Provider:                 &info.Provider{},
+				CommitMetadataIncomplete: true,
+				TriggerTarget:            triggertype.Push,
+				Event: &gitlab.PushEvent{
+					Before: "0000000000000000000000000000000000000000",
+					After:  "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+					Ref:    "refs/heads/release-0.1",
+				},
+			}
+			commitProvider := &commitInfoProvider{
+				TestProviderImp: testprovider.TestProviderImp{
+					AllowIT: true,
+					Event:   event,
+				},
+				commitTitle:       "fix: branch creation",
+				commitMessage:     tt.commitMessage,
+				commitInfoFailure: tt.commitInfoFailure,
+			}
+			s := &sinker{
+				run:     run,
+				vcx:     commitProvider,
+				kint:    &kubeinteraction.Interaction{Run: run},
+				event:   event,
+				logger:  log,
+				pacInfo: &info.PacOpts{},
+			}
+
+			err := s.processEvent(ctx, httptest.NewRequestWithContext(ctx, "POST", repo.Spec.URL, nil))
+			assert.Equal(t, 1, commitProvider.commitInfoCalls)
+			assert.Equal(t, tt.wantStatusCalls, commitProvider.statusCalls)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, providerstatus.ConclusionSkipped, commitProvider.lastStatus.Conclusion)
+		})
+	}
 }
 
 // TestGetCommitInfoError tests that GetCommitInfo errors work correctly with test provider.
@@ -540,8 +775,7 @@ func TestProcessEventSkipCIIntegration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Simulate the skip-CI logic from sinker.go processEvent()
-			// Line 92-95: Push event skip-CI check
+			// Simulate the payload-based push decision. API-resolved metadata is covered by TestShouldSkipPushEvent.
 			pushSkip := tt.eventType == "push" && provider.SkipCI(tt.shaTitle)
 
 			// Line 99-108: PR event skip-CI check

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -26,10 +26,11 @@ const (
 )
 
 type RemoteTasks struct {
-	Run               *params.Run
-	ProviderInterface provider.Interface
-	Event             *info.Event
-	Logger            *zap.SugaredLogger
+	Run                *params.Run
+	ProviderInterface  provider.Interface
+	Event              *info.Event
+	Logger             *zap.SugaredLogger
+	RepositoryRevision string
 }
 
 // nolint: dupl
@@ -138,7 +139,7 @@ func (rt *RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool, 
 		var data string
 		var err error
 		if rt.Event.SHA != "" {
-			data, err = rt.ProviderInterface.GetFileInsideRepo(ctx, rt.Event, uri, "")
+			data, err = rt.ProviderInterface.GetFileInsideRepo(ctx, rt.Event, uri, rt.RepositoryRevision)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/matcher/annotation_tasks_install_test.go
+++ b/pkg/matcher/annotation_tasks_install_test.go
@@ -1,6 +1,7 @@
 package matcher
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -30,6 +31,16 @@ const (
 	testHubURL         = "https://mybelovedhub"
 	testCatalogHubName = "tekton"
 )
+
+type revisionRecordingProvider struct {
+	*provider.TestProviderImp
+	fileInsideRepoRevision string
+}
+
+func (v *revisionRecordingProvider) GetFileInsideRepo(ctx context.Context, event *info.Event, file, revision string) (string, error) {
+	v.fileInsideRepoRevision = revision
+	return v.TestProviderImp.GetFileInsideRepo(ctx, event, file, revision)
+}
 
 func createArtifactHubResponse(t *testing.T, manifestContent string) string {
 	t.Helper()
@@ -219,6 +230,7 @@ func TestGetTaskFromAnnotationName(t *testing.T) {
 		gotTaskName            string
 		name                   string
 		remoteURLS             map[string]map[string]string
+		repositoryRevision     string
 		runevent               info.Event
 		wantErr                string
 		wantLog                string
@@ -301,6 +313,7 @@ func TestGetTaskFromAnnotationName(t *testing.T) {
 			filesInsideRepo: map[string]string{
 				"be/healthy": readTDfile(t, "task-good"),
 			},
+			repositoryRevision: "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
 			runevent: info.Event{
 				SHA: "007",
 			},
@@ -412,14 +425,18 @@ func TestGetTaskFromAnnotationName(t *testing.T) {
 				},
 			}
 			ctx, _ := rtesting.SetupFakeContext(t)
-			rt := RemoteTasks{
-				Run:    cs,
-				Logger: logger,
-				ProviderInterface: &provider.TestProviderImp{
+			providerImp := &revisionRecordingProvider{
+				TestProviderImp: &provider.TestProviderImp{
 					FilesInsideRepo:        tt.filesInsideRepo,
 					WantProviderRemoteTask: tt.wantProviderRemoteTask,
 				},
-				Event: &tt.runevent,
+			}
+			rt := RemoteTasks{
+				Run:                cs,
+				Logger:             logger,
+				ProviderInterface:  providerImp,
+				Event:              &tt.runevent,
+				RepositoryRevision: tt.repositoryRevision,
 			}
 
 			got, err := rt.GetTaskFromAnnotationName(ctx, tt.task)
@@ -435,6 +452,9 @@ func TestGetTaskFromAnnotationName(t *testing.T) {
 
 			if tt.gotTaskName != "" {
 				assert.Equal(t, tt.gotTaskName, got.GetName())
+			}
+			if tt.repositoryRevision != "" {
+				assert.Equal(t, tt.repositoryRevision, providerImp.fileInsideRepoRevision)
 			}
 		})
 	}

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -39,6 +39,12 @@ type Event struct {
 	URL           string // WEB url not the git URL, which would match to the repo.spec
 	SHAURL        string // pretty URL for web browsing for UIs (cli/web)
 	SHATitle      string // commit title for UIs
+	// CommitMetadataIncomplete marks webhook events that need an authenticated commit lookup
+	// before consumers can rely on title, URL, message, author, or committer fields.
+	CommitMetadataIncomplete bool
+	// PipelineRunSourceRevision records the immutable repository revision supplied by an event.
+	// PipelineRun provenance may explicitly select another revision, such as the default branch.
+	PipelineRunSourceRevision string
 
 	// Full commit information populated by provider.GetCommitInfo()
 	SHAMessage        string    // full commit message (not just title)

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/gitclient"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	providerstatus "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
@@ -147,6 +148,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 	if repo.Spec.Settings != nil && repo.Spec.Settings.PipelineRunProvenance != "" {
 		provenance = repo.Spec.Settings.PipelineRunProvenance
 	}
+	repositoryRevision := getRepositoryRevisionForProvenance(p.event, provenance)
 	p.debugf("getPipelineRunsFromRepo: repo=%s/%s provenance=%s", repo.GetNamespace(), repo.GetName(), provenance)
 	rawTemplates, err := p.vcx.GetTektonDir(ctx, p.event, tektonDir, provenance)
 	if err != nil && p.event.TriggerTarget == triggertype.PullRequest && strings.Contains(err.Error(), "error unmarshalling yaml file") {
@@ -353,8 +355,9 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		}
 		p.debugf("getPipelineRunsFromRepo: resolving remote tasks for pipelineRuns=%d", len(types.PipelineRuns))
 		pipelineRuns, err = resolve.Resolve(ctx, p.run, p.logger, p.vcx, types, p.event, &resolve.Opts{
-			GenerateName: true,
-			RemoteTasks:  true,
+			GenerateName:       true,
+			RemoteTasks:        true,
+			RepositoryRevision: repositoryRevision,
 		})
 		if err != nil {
 			p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryFailedToMatch", fmt.Sprintf("failed to match pipelineRuns: %s", err.Error()))
@@ -398,6 +401,17 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 	p.debugf("getPipelineRunsFromRepo: final match count=%d", len(matchedPRs))
 
 	return matchedPRs, nil
+}
+
+func getRepositoryRevisionForProvenance(event *info.Event, provenance string) string {
+	// Preserve existing provider behavior unless the event requires pinned repository resolution.
+	if event.PipelineRunSourceRevision == "" {
+		return ""
+	}
+	if provenance == "default_branch" {
+		return event.DefaultBranch
+	}
+	return event.PipelineRunSourceRevision
 }
 
 func filterRunningPipelineRunOnTargetTest(testPipeline string, prs []*tektonv1.PipelineRun) *tektonv1.PipelineRun {

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -1,6 +1,7 @@
 package pipelineascode
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -59,6 +60,46 @@ func TestPacRunCheckNeedUpdate(t *testing.T) {
 				assert.Assert(t, strings.Contains(got, tt.upgradeMessageSubstr))
 			}
 			assert.Assert(t, needupdate == tt.needupdate)
+		})
+	}
+}
+
+func TestGetRepositoryRevisionForProvenance(t *testing.T) {
+	tests := []struct {
+		name       string
+		event      *info.Event
+		provenance string
+		want       string
+	}{
+		{
+			name: "source provenance uses immutable event revision",
+			event: &info.Event{
+				PipelineRunSourceRevision: "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+			},
+			provenance: "source",
+			want:       "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+		},
+		{
+			name: "default branch provenance uses default branch",
+			event: &info.Event{
+				DefaultBranch:             "main",
+				PipelineRunSourceRevision: "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+			},
+			provenance: "default_branch",
+			want:       "main",
+		},
+		{
+			name: "ordinary event leaves repository revision unset",
+			event: &info.Event{
+				DefaultBranch: "main",
+			},
+			provenance: "default_branch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, getRepositoryRevisionForProvenance(tt.event, tt.provenance))
 		})
 	}
 }
@@ -280,6 +321,136 @@ spec:
 			assert.Assert(t, matchedPRs[0].Repo != nil)
 			assert.Equal(t, matchedPRs[0].Repo.GetNamespace(), tt.wantRepositoryNS)
 			assert.Equal(t, matchedPRs[0].Repo.GetName(), tt.wantRepositoryName)
+		})
+	}
+}
+
+// revisionRecordingProvider captures the revision getPipelineRunsFromRepo ends up handing to
+// the provider when it resolves a repository-local Task reference.
+type revisionRecordingProvider struct {
+	*testprovider.TestProviderImp
+	fileInsideRepoRevision string
+}
+
+func (v *revisionRecordingProvider) GetFileInsideRepo(ctx context.Context, event *info.Event, file, revision string) (string, error) {
+	v.fileInsideRepoRevision = revision
+	return v.TestProviderImp.GetFileInsideRepo(ctx, event, file, revision)
+}
+
+// TestGetPipelineRunsFromRepoRepositoryRevision guards the wiring that carries the revision
+// chosen for the event all the way into resolve.Opts, not just the selection helper itself.
+func TestGetPipelineRunsFromRepoRepositoryRevision(t *testing.T) {
+	const (
+		branchCreateSHA = "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e"
+		localTaskPath   = "tasks/repository-local-task.yaml"
+	)
+	template := `apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pr-push
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/task: "` + localTaskPath + `"
+spec:
+  pipelineSpec:
+    tasks:
+    - name: repository-local
+      taskRef:
+        name: repository-local-task
+`
+	localTask := `apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: repository-local-task
+spec:
+  steps:
+  - name: task
+    image: quay.io/prometheus/busybox
+    script: |
+      exit 0
+`
+
+	tests := []struct {
+		name         string
+		provenance   string
+		event        *info.Event
+		wantRevision string
+	}{
+		{
+			name: "source provenance pins repository-local tasks to the event revision",
+			event: &info.Event{
+				PipelineRunSourceRevision: branchCreateSHA,
+				DefaultBranch:             "main",
+			},
+			wantRevision: branchCreateSHA,
+		},
+		{
+			name:       "default_branch provenance pins repository-local tasks to the default branch",
+			provenance: "default_branch",
+			event: &info.Event{
+				PipelineRunSourceRevision: branchCreateSHA,
+				DefaultBranch:             "main",
+			},
+			wantRevision: "main",
+		},
+		{
+			name:  "ordinary event leaves the provider to pick its own revision",
+			event: &info.Event{DefaultBranch: "main"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observerCore, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observerCore).Sugar()
+			ctx, _ := rtesting.SetupFakeContext(t)
+
+			repo := &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "foo"},
+				Spec: v1alpha1.RepositorySpec{
+					URL:      "https://ghe.pipelinesascode.com/pipelines-as-code/e2e",
+					Settings: &v1alpha1.Settings{PipelineRunProvenance: tt.provenance},
+				},
+			}
+			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Repositories: []*v1alpha1.Repository{repo},
+			})
+			cs := &params.Run{
+				Clients: clients.Clients{
+					PipelineAsCode: stdata.PipelineAsCode,
+					Kube:           stdata.Kube,
+					Tekton:         stdata.Pipeline,
+					Log:            logger,
+				},
+			}
+			cs.Clients.SetConsoleUI(consoleui.FallBackConsole{})
+
+			event := tt.event
+			event.URL = repo.Spec.URL
+			event.Organization = "pipelines-as-code"
+			event.Repository = "e2e"
+			event.Sender = "foo"
+			event.SHA = branchCreateSHA
+			event.HeadBranch = "main"
+			event.BaseBranch = "main"
+			event.EventType = "push"
+			event.TriggerTarget = triggertype.Push
+
+			vcx := &revisionRecordingProvider{
+				TestProviderImp: &testprovider.TestProviderImp{
+					TektonDirTemplate: template,
+					FilesInsideRepo:   map[string]string{localTaskPath: localTask},
+				},
+			}
+			pacInfo := &info.PacOpts{Settings: settings.Settings{RemoteTasks: true}}
+			p := NewPacs(event, vcx, cs, pacInfo, nil, logger, nil)
+			p.eventEmitter = events.NewEventEmitter(stdata.Kube, logger)
+
+			matchedPRs, err := p.getPipelineRunsFromRepo(ctx, repo)
+			assert.NilError(t, err)
+			assert.Equal(t, 1, len(matchedPRs))
+			assert.Equal(t, tt.wantRevision, vcx.fileInsideRepoRevision)
 		})
 	}
 }

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -575,19 +575,23 @@ func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, prov
 		return "", fmt.Errorf("no gitlab client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
-	// default set provenance from head
+	branchCreate := isBranchCreationRunEvent(event)
+	// Default to the branch ref for existing event types.
 	revision := event.HeadBranch
 	if provenance == "default_branch" {
 		revision = event.DefaultBranch
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", event.DefaultBranch)
 	} else {
+		if branchCreate {
+			// Pin branch creation to the webhook SHA so a later push cannot change the matched definitions.
+			revision = event.SHA
+		}
 		trigger := event.TriggerTarget.String()
 		if event.TriggerTarget == triggertype.PullRequest {
 			trigger = "merge request"
 		}
 		v.Logger.Infof("Using PipelineRun definition from source %s on commit SHA: %s", trigger, event.SHA)
 	}
-
 	opt := &gitlab.ListTreeOptions{
 		Path:      gitlab.Ptr(path),
 		Ref:       gitlab.Ptr(revision),
@@ -665,8 +669,16 @@ func (v *Provider) getObject(fname, branch string, pid int64) ([]byte, *gitlab.R
 	return file, resp, nil
 }
 
-func (v *Provider) GetFileInsideRepo(_ context.Context, runevent *info.Event, path, _ string) (string, error) {
-	getobj, _, err := v.getObject(path, runevent.HeadBranch, v.sourceProjectID)
+func (v *Provider) GetFileInsideRepo(_ context.Context, runevent *info.Event, path, targetRevision string) (string, error) {
+	revision := targetRevision
+	if revision == "" {
+		revision = runevent.HeadBranch
+		if isBranchCreationRunEvent(runevent) {
+			// The immutable event SHA is the source revision when no explicit target was selected.
+			revision = runevent.SHA
+		}
+	}
+	getobj, _, err := v.getObject(path, revision, v.sourceProjectID)
 	if err != nil {
 		return "", err
 	}
@@ -678,33 +690,55 @@ func (v *Provider) GetCommitInfo(_ context.Context, runevent *info.Event) error 
 		return fmt.Errorf("%s", noClientErrStr)
 	}
 
-	// if we don't have a SHA (ie: incoming-webhook) then get it from the branch
-	// and populate in the runevent.
-	if runevent.SHA == "" && runevent.HeadBranch != "" {
-		branchinfo, _, err := v.Client().Commits.GetCommit(v.sourceProjectID, runevent.HeadBranch, &gitlab.GetCommitOptions{})
+	commitRef := ""
+	expectedSHA := ""
+	if isBranchCreationRunEvent(runevent) {
+		// Resolve the immutable event SHA so a later push cannot move the branch creation to a new HEAD.
+		commitRef = runevent.SHA
+		expectedSHA = runevent.SHA
+	} else if runevent.SHA == "" && runevent.HeadBranch != "" {
+		// Incoming webhooks do not carry a SHA, so resolve their mutable branch ref as before.
+		commitRef = runevent.HeadBranch
+	}
+
+	if commitRef != "" {
+		commitInfo, _, err := v.Client().Commits.GetCommit(v.sourceProjectID, commitRef, &gitlab.GetCommitOptions{})
 		if err != nil {
 			return err
 		}
-		runevent.SHA = branchinfo.ID
-		runevent.SHATitle = branchinfo.Title
-		runevent.SHAURL = branchinfo.WebURL
+		if expectedSHA != "" && !strings.EqualFold(commitInfo.ID, expectedSHA) {
+			return fmt.Errorf("resolved commit SHA %s does not match event SHA %s", commitInfo.ID, expectedSHA)
+		}
+		runevent.SHA = commitInfo.ID
+		runevent.SHATitle = commitInfo.Title
+		runevent.SHAURL = commitInfo.WebURL
 
 		// Populate full commit information for LLM context
-		runevent.SHAMessage = branchinfo.Message
-		runevent.SHAAuthorName = branchinfo.AuthorName
-		runevent.SHAAuthorEmail = branchinfo.AuthorEmail
-		if branchinfo.AuthoredDate != nil {
-			runevent.SHAAuthorDate = *branchinfo.AuthoredDate
+		runevent.SHAMessage = commitInfo.Message
+		runevent.SHAAuthorName = commitInfo.AuthorName
+		runevent.SHAAuthorEmail = commitInfo.AuthorEmail
+		if commitInfo.AuthoredDate != nil {
+			runevent.SHAAuthorDate = *commitInfo.AuthoredDate
 		}
-		runevent.SHACommitterName = branchinfo.CommitterName
-		runevent.SHACommitterEmail = branchinfo.CommitterEmail
-		if branchinfo.CommittedDate != nil {
-			runevent.SHACommitterDate = *branchinfo.CommittedDate
+		runevent.SHACommitterName = commitInfo.CommitterName
+		runevent.SHACommitterEmail = commitInfo.CommitterEmail
+		if commitInfo.CommittedDate != nil {
+			runevent.SHACommitterDate = *commitInfo.CommittedDate
 		}
+		runevent.CommitMetadataIncomplete = false
 	}
 	runevent.HasSkipCommand = provider.SkipCI(runevent.SHAMessage)
 
 	return nil
+}
+
+func isBranchCreationRunEvent(runevent *info.Event) bool {
+	pushEvent, ok := runevent.Event.(*gitlab.PushEvent)
+	return ok &&
+		runevent.TriggerTarget == triggertype.Push &&
+		strings.EqualFold(runevent.SHA, pushEvent.After) &&
+		len(pushEvent.Commits) == 0 &&
+		isBranchCreationPayload(pushEvent)
 }
 
 // GetFiles gets and caches the list of files changed by a given event.

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -800,8 +800,12 @@ func TestGetCommitInfo(t *testing.T) {
 		name                string
 		event               *info.Event
 		sourceProjectID     int
+		commitRef           string
 		mockCommitResponse  string
+		mockStatus          int
 		wantErr             bool
+		wantErrMsg          string
+		wantSHA             string
 		wantSHATitle        string
 		wantSHAURL          string
 		wantSHAMessage      string
@@ -812,6 +816,7 @@ func TestGetCommitInfo(t *testing.T) {
 		wantCommitterEmail  string
 		wantCommitterDate   string
 		checkExtendedFields bool
+		wantHasSkipCommand  bool
 		noClient            bool
 	}{
 		{
@@ -820,6 +825,7 @@ func TestGetCommitInfo(t *testing.T) {
 				HeadBranch: "feature-branch",
 			},
 			sourceProjectID: 123,
+			commitRef:       "feature-branch",
 			mockCommitResponse: `{
 				"id": "abc123",
 				"title": "feat: add new feature",
@@ -832,6 +838,7 @@ func TestGetCommitInfo(t *testing.T) {
 				"committer_email": "noreply@gitlab.com",
 				"committed_date": "2024-01-15T10:31:00Z"
 			}`,
+			wantSHA:             "abc123",
 			wantSHATitle:        "feat: add new feature",
 			wantSHAURL:          "https://gitlab.com/owner/repo/-/commit/abc123",
 			wantSHAMessage:      "feat: add new feature\n\nThis is the full commit message with details.",
@@ -849,26 +856,126 @@ func TestGetCommitInfo(t *testing.T) {
 				HeadBranch: "main",
 			},
 			sourceProjectID: 123,
+			commitRef:       "main",
 			mockCommitResponse: `{
 				"id": "def456",
 				"title": "fix: simple fix",
 				"message": "fix: simple fix",
 				"web_url": "https://gitlab.com/owner/repo/-/commit/def456"
 			}`,
+			wantSHA:        "def456",
 			wantSHATitle:   "fix: simple fix",
 			wantSHAURL:     "https://gitlab.com/owner/repo/-/commit/def456",
 			wantSHAMessage: "fix: simple fix",
+		},
+		{
+			name: "resolve branch creation metadata by event SHA",
+			event: &info.Event{
+				TriggerTarget: triggertype.Push,
+				SHA:           "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+				HeadBranch:    "refs/heads/release-0.1",
+				Event: &gitlab.PushEvent{
+					Before: "0000000000000000000000000000000000000000",
+					After:  "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+					Ref:    "refs/heads/release-0.1",
+				},
+			},
+			sourceProjectID: 123,
+			commitRef:       "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+			mockCommitResponse: `{
+				"id": "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+				"title": "sync: bump artifacts versions.yaml",
+				"message": "sync: bump artifacts versions.yaml [skip ci]",
+				"web_url": "https://gitlab.com/owner/repo/-/commit/dc922f5e",
+				"author_name": "Test User",
+				"author_email": "testuser@example.com",
+				"committer_name": "Test User",
+				"committer_email": "testuser@example.com"
+			}`,
+			wantSHA:             "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+			wantSHATitle:        "sync: bump artifacts versions.yaml",
+			wantSHAURL:          "https://gitlab.com/owner/repo/-/commit/dc922f5e",
+			wantSHAMessage:      "sync: bump artifacts versions.yaml [skip ci]",
+			wantAuthorName:      "Test User",
+			wantAuthorEmail:     "testuser@example.com",
+			wantCommitterName:   "Test User",
+			wantCommitterEmail:  "testuser@example.com",
+			checkExtendedFields: true,
+			wantHasSkipCommand:  true,
+		},
+		{
+			name: "reject branch creation metadata for a different SHA",
+			event: &info.Event{
+				TriggerTarget: triggertype.Push,
+				SHA:           "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+				Event: &gitlab.PushEvent{
+					Before: "0000000000000000000000000000000000000000",
+					After:  "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+					Ref:    "refs/heads/release-0.1",
+				},
+			},
+			sourceProjectID: 123,
+			commitRef:       "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+			mockCommitResponse: `{
+				"id": "1111111111111111111111111111111111111111",
+				"title": "different commit",
+				"web_url": "https://gitlab.com/owner/repo/-/commit/11111111"
+			}`,
+			wantErr:    true,
+			wantErrMsg: "does not match event SHA",
+		},
+		{
+			name: "accept canonical metadata SHA with different hex casing",
+			event: &info.Event{
+				TriggerTarget: triggertype.Push,
+				SHA:           "DC922F5EA0C57EF5FB1CBC0F3EA550DFE3B5786E",
+				Event: &gitlab.PushEvent{
+					Before: "0000000000000000000000000000000000000000",
+					After:  "DC922F5EA0C57EF5FB1CBC0F3EA550DFE3B5786E",
+					Ref:    "refs/heads/release-0.1",
+				},
+			},
+			sourceProjectID: 123,
+			commitRef:       "DC922F5EA0C57EF5FB1CBC0F3EA550DFE3B5786E",
+			mockCommitResponse: `{
+				"id": "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+				"title": "canonical commit",
+				"message": "canonical commit",
+				"web_url": "https://gitlab.com/owner/repo/-/commit/dc922f5e"
+			}`,
+			wantSHA:        "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+			wantSHATitle:   "canonical commit",
+			wantSHAURL:     "https://gitlab.com/owner/repo/-/commit/dc922f5e",
+			wantSHAMessage: "canonical commit",
+		},
+		{
+			name: "branch creation commit lookup failure",
+			event: &info.Event{
+				TriggerTarget: triggertype.Push,
+				SHA:           "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+				Event: &gitlab.PushEvent{
+					Before: "0000000000000000000000000000000000000000",
+					After:  "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+					Ref:    "refs/heads/release-0.1",
+				},
+			},
+			sourceProjectID: 123,
+			commitRef:       "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+			mockStatus:      http.StatusNotFound,
+			wantErr:         true,
+			wantErrMsg:      "404",
 		},
 		{
 			name: "no client error",
 			event: &info.Event{
 				HeadBranch: "main",
 			},
-			noClient: true,
-			wantErr:  true,
+			noClient:   true,
+			wantErr:    true,
+			wantErrMsg: noClientErrStr,
 		},
 		{
-			name: "no SHA, no HeadBranch - no API call",
+			name: "event with existing SHA makes no API call",
 			event: &info.Event{
 				SHA: "already-set",
 			},
@@ -885,10 +992,14 @@ func TestGetCommitInfo(t *testing.T) {
 				client, mux, tearDown := thelp.Setup(t)
 				defer tearDown()
 
-				// Mock the GetCommit API endpoint if we expect it to be called
-				if tt.event.SHA == "" && tt.event.HeadBranch != "" {
-					mux.HandleFunc(fmt.Sprintf("/projects/%d/repository/commits/%s", tt.sourceProjectID, tt.event.HeadBranch),
+				// Register only the expected ref so an unintended branch lookup cannot satisfy an exact-SHA test.
+				if tt.commitRef != "" {
+					mux.HandleFunc(fmt.Sprintf("/projects/%d/repository/commits/%s", tt.sourceProjectID, tt.commitRef),
 						func(rw http.ResponseWriter, _ *http.Request) {
+							if tt.mockStatus != 0 {
+								rw.WriteHeader(tt.mockStatus)
+								return
+							}
 							fmt.Fprint(rw, tt.mockCommitResponse)
 						})
 				}
@@ -905,13 +1016,19 @@ func TestGetCommitInfo(t *testing.T) {
 
 			if tt.wantErr {
 				assert.Assert(t, err != nil, "expected error but got nil")
+				if tt.wantErrMsg != "" {
+					assert.ErrorContains(t, err, tt.wantErrMsg)
+				}
 				return
 			}
 
 			assert.NilError(t, err)
 
-			// Only check fields if API was supposed to be called
-			if tt.event.SHA == "" && tt.event.HeadBranch != "" {
+			// Only check fields if the API returned commit metadata.
+			if tt.commitRef != "" {
+				if tt.wantSHA != "" {
+					assert.Equal(t, tt.wantSHA, tt.event.SHA, "SHA should match")
+				}
 				assert.Equal(t, tt.wantSHATitle, tt.event.SHATitle, "SHATitle should match")
 				assert.Equal(t, tt.wantSHAURL, tt.event.SHAURL, "SHAURL should match")
 				assert.Equal(t, tt.wantSHAMessage, tt.event.SHAMessage, "SHAMessage should match")
@@ -933,6 +1050,7 @@ func TestGetCommitInfo(t *testing.T) {
 					}
 				}
 			}
+			assert.Equal(t, tt.wantHasSkipCommand, tt.event.HasSkipCommand, "HasSkipCommand should match")
 		})
 	}
 }
@@ -1433,6 +1551,7 @@ func TestGetTektonDir(t *testing.T) {
 		wantFilesAPIErr      bool
 		wantClient           bool
 		prcontent            string
+		wantRevision         string
 		filterMessageSnippet string
 	}{
 		{
@@ -1490,6 +1609,82 @@ func TestGetTektonDir(t *testing.T) {
 			wantClient:           true,
 			wantStr:              "kind: PipelineRun",
 			filterMessageSnippet: `Using PipelineRun definition from source push on commit SHA`,
+		},
+		{
+			name:      "list tekton dir for branch creation by event SHA",
+			prcontent: string(samplePR),
+			args: args{
+				path: ".tekton",
+				event: &info.Event{
+					SHA:           "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+					HeadBranch:    "refs/heads/release-0.1",
+					TriggerTarget: triggertype.Push,
+					Event: &gitlab.PushEvent{
+						Before: "0000000000000000000000000000000000000000",
+						After:  "DC922F5EA0C57EF5FB1CBC0F3EA550DFE3B5786E",
+						Ref:    "refs/heads/release-0.1",
+					},
+				},
+			},
+			fields: fields{
+				sourceProjectID: 100,
+			},
+			wantClient:           true,
+			wantStr:              "kind: PipelineRun",
+			wantRevision:         "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+			filterMessageSnippet: `Using PipelineRun definition from source push on commit SHA`,
+		},
+		{
+			// A branch created together with new commits is an ordinary push as far as
+			// definition lookup goes, so it must stay on the branch ref.
+			name:      "list tekton dir for branch creation carrying commits uses head branch",
+			prcontent: string(samplePR),
+			args: args{
+				path: ".tekton",
+				event: &info.Event{
+					SHA:           "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+					HeadBranch:    "refs/heads/release-0.1",
+					TriggerTarget: triggertype.Push,
+					Event: &gitlab.PushEvent{
+						Before:  "0000000000000000000000000000000000000000",
+						After:   "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+						Ref:     "refs/heads/release-0.1",
+						Commits: []*gitlab.PushEventCommit{{ID: "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e"}},
+					},
+				},
+			},
+			fields: fields{
+				sourceProjectID: 100,
+			},
+			wantClient:           true,
+			wantStr:              "kind: PipelineRun",
+			wantRevision:         "refs/heads/release-0.1",
+			filterMessageSnippet: `Using PipelineRun definition from source push on commit SHA`,
+		},
+		{
+			name:      "list tekton dir for branch creation from default branch",
+			prcontent: string(samplePR),
+			args: args{
+				path:       ".tekton",
+				provenance: "default_branch",
+				event: &info.Event{
+					SHA:           "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+					HeadBranch:    "refs/heads/release-0.1",
+					DefaultBranch: "main",
+					TriggerTarget: triggertype.Push,
+					Event: &gitlab.PushEvent{
+						Before: "0000000000000000000000000000000000000000",
+						After:  "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+						Ref:    "refs/heads/release-0.1",
+					},
+				},
+			},
+			fields: fields{
+				sourceProjectID: 100,
+			},
+			wantClient:   true,
+			wantStr:      "kind: PipelineRun",
+			wantRevision: "main",
 		},
 		{
 			name:      "list tekton dir on default_branch",
@@ -1573,6 +1768,8 @@ func TestGetTektonDir(t *testing.T) {
 				muxbranch := tt.args.event.HeadBranch
 				if tt.args.provenance == "default_branch" {
 					muxbranch = tt.args.event.DefaultBranch
+				} else if tt.wantRevision != "" {
+					muxbranch = tt.wantRevision
 				}
 				if tt.args.path != "" && tt.prcontent != "" {
 					thelp.MuxListTektonDir(t, mux, tt.fields.sourceProjectID, muxbranch, tt.prcontent, tt.wantTreeAPIErr, tt.wantFilesAPIErr)
@@ -1598,25 +1795,155 @@ func TestGetTektonDir(t *testing.T) {
 }
 
 func TestGetFileInsideRepo(t *testing.T) {
-	content := "hello moto"
-	ctx, _ := rtesting.SetupFakeContext(t)
-	client, mux, tearDown := thelp.Setup(t)
-	defer tearDown()
-
-	event := &info.Event{
-		HeadBranch: "branch",
+	const content = "hello moto"
+	tests := []struct {
+		name           string
+		event          *info.Event
+		path           string
+		targetRevision string
+		wantRevision   string
+		wantErr        bool
+	}{
+		{
+			name: "ordinary event uses head branch",
+			event: &info.Event{
+				HeadBranch: "branch",
+			},
+			wantRevision: "branch",
+		},
+		{
+			name: "missing file returns an error",
+			event: &info.Event{
+				HeadBranch: "branch",
+			},
+			path:         "notfound",
+			wantRevision: "branch",
+			wantErr:      true,
+		},
+		{
+			// A branch created together with new commits carries a zero before SHA but a
+			// non-empty commits array, so it stays on the ordinary branch ref.
+			name: "push creating a branch with commits keeps using head branch",
+			event: &info.Event{
+				SHA:           "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+				HeadBranch:    "refs/heads/release-0.1",
+				TriggerTarget: triggertype.Push,
+				Event: &gitlab.PushEvent{
+					Before:  "0000000000000000000000000000000000000000",
+					After:   "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+					Ref:     "refs/heads/release-0.1",
+					Commits: []*gitlab.PushEventCommit{{ID: "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e"}},
+				},
+			},
+			wantRevision: "refs/heads/release-0.1",
+		},
+		{
+			// The event SHA must match the payload after SHA, otherwise the event is not the
+			// immutable branch creation it claims to be.
+			name: "push whose SHA differs from the payload after SHA keeps using head branch",
+			event: &info.Event{
+				SHA:           "1111111111111111111111111111111111111111",
+				HeadBranch:    "refs/heads/release-0.1",
+				TriggerTarget: triggertype.Push,
+				Event: &gitlab.PushEvent{
+					Before: "0000000000000000000000000000000000000000",
+					After:  "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+					Ref:    "refs/heads/release-0.1",
+				},
+			},
+			wantRevision: "refs/heads/release-0.1",
+		},
+		{
+			name: "non push trigger target keeps using head branch",
+			event: &info.Event{
+				SHA:           "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+				HeadBranch:    "refs/heads/release-0.1",
+				TriggerTarget: triggertype.PullRequest,
+				Event: &gitlab.PushEvent{
+					Before: "0000000000000000000000000000000000000000",
+					After:  "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+					Ref:    "refs/heads/release-0.1",
+				},
+			},
+			wantRevision: "refs/heads/release-0.1",
+		},
+		{
+			name: "branch creation without explicit target uses event SHA",
+			event: &info.Event{
+				SHA:           "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+				HeadBranch:    "refs/heads/release-0.1",
+				TriggerTarget: triggertype.Push,
+				Event: &gitlab.PushEvent{
+					Before: "0000000000000000000000000000000000000000",
+					After:  "DC922F5EA0C57EF5FB1CBC0F3EA550DFE3B5786E",
+					Ref:    "refs/heads/release-0.1",
+				},
+			},
+			wantRevision: "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+		},
+		{
+			name: "branch creation uses explicit source revision",
+			event: &info.Event{
+				SHA:           "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+				HeadBranch:    "refs/heads/release-0.1",
+				TriggerTarget: triggertype.Push,
+				Event: &gitlab.PushEvent{
+					Before: "0000000000000000000000000000000000000000",
+					After:  "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+					Ref:    "refs/heads/release-0.1",
+				},
+			},
+			targetRevision: "1111111111111111111111111111111111111111",
+			wantRevision:   "1111111111111111111111111111111111111111",
+		},
+		{
+			name: "branch creation uses explicit default branch revision",
+			event: &info.Event{
+				SHA:           "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+				HeadBranch:    "refs/heads/release-0.1",
+				DefaultBranch: "main",
+				TriggerTarget: triggertype.Push,
+				Event: &gitlab.PushEvent{
+					Before: "0000000000000000000000000000000000000000",
+					After:  "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+					Ref:    "refs/heads/release-0.1",
+				},
+			},
+			targetRevision: "main",
+			wantRevision:   "main",
+		},
 	}
-	v := Provider{
-		sourceProjectID: 10,
-		gitlabClient:    client,
-	}
-	thelp.MuxListTektonDir(t, mux, int(v.sourceProjectID), event.HeadBranch, content, false, false)
-	got, err := v.GetFileInsideRepo(ctx, event, "pr.yaml", "")
-	assert.NilError(t, err)
-	assert.Equal(t, content, got)
 
-	_, err = v.GetFileInsideRepo(ctx, event, "notfound", "")
-	assert.Assert(t, err != nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			client, mux, tearDown := thelp.Setup(t)
+			defer tearDown()
+
+			v := Provider{
+				sourceProjectID: 10,
+				gitlabClient:    client,
+			}
+			// Only pr.yaml is registered, so any other path falls through to a 404.
+			mux.HandleFunc(fmt.Sprintf("/projects/%d/repository/files/pr.yaml/raw", v.sourceProjectID),
+				func(rw http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, tt.wantRevision, r.URL.Query().Get("ref"))
+					fmt.Fprint(rw, content)
+				})
+
+			path := tt.path
+			if path == "" {
+				path = "pr.yaml"
+			}
+			got, err := v.GetFileInsideRepo(ctx, tt.event, path, tt.targetRevision)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected an error but got nil")
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, content, got)
+		})
+	}
 }
 
 func TestValidate(t *testing.T) {

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -115,15 +116,22 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 		processedEvent.EventType = strings.ReplaceAll(event, " Hook", "")
 	case *gitlab.PushEvent:
 		if len(gitEvent.Commits) == 0 {
-			return nil, fmt.Errorf("no commits attached to this push event")
+			if !isBranchCreationPayload(gitEvent) {
+				return nil, fmt.Errorf("no commits attached to this push event")
+			}
+			// After is the immutable branch tip when GitLab creates a branch without adding commits.
+			processedEvent.SHA = gitEvent.After
+			processedEvent.CommitMetadataIncomplete = true
+			processedEvent.PipelineRunSourceRevision = gitEvent.After
+		} else {
+			lastCommitIdx := len(gitEvent.Commits) - 1
+			processedEvent.SHA = gitEvent.Commits[lastCommitIdx].ID
+			processedEvent.SHAURL = gitEvent.Commits[lastCommitIdx].URL
+			processedEvent.SHATitle = gitEvent.Commits[lastCommitIdx].Title
 		}
-		lastCommitIdx := len(gitEvent.Commits) - 1
 		processedEvent.Sender = gitEvent.UserUsername
 		processedEvent.DefaultBranch = gitEvent.Project.DefaultBranch
 		processedEvent.URL = gitEvent.Project.WebURL
-		processedEvent.SHA = gitEvent.Commits[lastCommitIdx].ID
-		processedEvent.SHAURL = gitEvent.Commits[lastCommitIdx].URL
-		processedEvent.SHATitle = gitEvent.Commits[lastCommitIdx].Title
 		processedEvent.HeadBranch = gitEvent.Ref
 		processedEvent.BaseBranch = gitEvent.Ref
 		processedEvent.HeadURL = gitEvent.Project.WebURL
@@ -170,6 +178,22 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 
 	v.repoURL = processedEvent.URL
 	return processedEvent, nil
+}
+
+func isBranchCreationPayload(event *gitlab.PushEvent) bool {
+	const branchRefPrefix = "refs/heads/"
+	return strings.HasPrefix(event.Ref, branchRefPrefix) &&
+		strings.TrimPrefix(event.Ref, branchRefPrefix) != "" &&
+		provider.IsZeroSHA(event.Before) &&
+		isValidCommitSHA(event.After)
+}
+
+func isValidCommitSHA(sha string) bool {
+	if len(sha) != 40 || provider.IsZeroSHA(sha) {
+		return false
+	}
+	_, err := hex.DecodeString(sha)
+	return err == nil
 }
 
 func (v *Provider) initGitLabClient(ctx context.Context, event *info.Event) (*info.Event, error) {

--- a/pkg/provider/gitlab/parse_payload_test.go
+++ b/pkg/provider/gitlab/parse_payload_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/google/go-github/v85/github"
@@ -27,6 +28,11 @@ import (
 )
 
 func TestParsePayload(t *testing.T) {
+	const (
+		zeroSHA         = "0000000000000000000000000000000000000000"
+		branchCreateSHA = "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e"
+		checkoutSHA     = "1111111111111111111111111111111111111111"
+	)
 	sample := thelp.TEvent{
 		Username:          "foo",
 		DefaultBranch:     "main",
@@ -42,6 +48,29 @@ func TestParsePayload(t *testing.T) {
 		SourceProjectID:   200,
 		PathWithNameSpace: "hello/this/is/me/ze/project",
 	}
+	multiCommitPayload := fmt.Sprintf(`{
+    "user_username": %q,
+    "project_id": %d,
+    "user_id": %d,
+    "ref": "refs/heads/main",
+    "project": {
+        "default_branch": %q,
+        "web_url": %q,
+        "path_with_namespace": %q
+    },
+    "commits": [
+        {
+            "id": "1111111111111111111111111111111111111111",
+            "url": "https://gitlab.example/commit/11111111",
+            "title": "first commit"
+        },
+        {
+            "id": "2222222222222222222222222222222222222222",
+            "url": "https://gitlab.example/commit/22222222",
+            "title": "second commit"
+        }
+    ]
+}`, sample.Username, sample.TargetProjectID, sample.UserID, sample.DefaultBranch, sample.URL, sample.PathWithNameSpace)
 	type fields struct {
 		targetProjectID int
 		sourceProjectID int
@@ -113,6 +142,135 @@ func TestParsePayload(t *testing.T) {
 			wantErrMsg: "no commits attached to this push event",
 		},
 		{
+			name: "push event creates branch without commits",
+			args: args{
+				event: gitlab.EventTypePush,
+				payload: sample.PushEventWithoutCommitsAsJSON(
+					zeroSHA,
+					branchCreateSHA,
+					checkoutSHA,
+					"refs/heads/release-0.1",
+				),
+			},
+			want: &info.Event{
+				EventType:                 "push",
+				TriggerTarget:             triggertype.Push,
+				Organization:              "hello/this/is/me/ze",
+				Repository:                "project",
+				SHA:                       branchCreateSHA,
+				HeadBranch:                "refs/heads/release-0.1",
+				BaseBranch:                "refs/heads/release-0.1",
+				CommitMetadataIncomplete:  true,
+				PipelineRunSourceRevision: branchCreateSHA,
+			},
+		},
+		{
+			name: "push event deletes branch without commits",
+			args: args{
+				event: gitlab.EventTypePush,
+				payload: sample.PushEventWithoutCommitsAsJSON(
+					branchCreateSHA,
+					zeroSHA,
+					"",
+					"refs/heads/release-0.1",
+				),
+			},
+			wantErrMsg: "no commits attached to this push event",
+		},
+		{
+			name: "push event without commits is not branch creation when before is nonzero",
+			args: args{
+				event: gitlab.EventTypePush,
+				payload: sample.PushEventWithoutCommitsAsJSON(
+					checkoutSHA,
+					branchCreateSHA,
+					branchCreateSHA,
+					"refs/heads/release-0.1",
+				),
+			},
+			wantErrMsg: "no commits attached to this push event",
+		},
+		{
+			name: "push event without commits rejects tag ref",
+			args: args{
+				event: gitlab.EventTypePush,
+				payload: sample.PushEventWithoutCommitsAsJSON(
+					zeroSHA,
+					branchCreateSHA,
+					branchCreateSHA,
+					"refs/tags/v0.0.1",
+				),
+			},
+			wantErrMsg: "no commits attached to this push event",
+		},
+		{
+			name: "push event without commits rejects empty branch name",
+			args: args{
+				event: gitlab.EventTypePush,
+				payload: sample.PushEventWithoutCommitsAsJSON(
+					zeroSHA,
+					branchCreateSHA,
+					branchCreateSHA,
+					"refs/heads/",
+				),
+			},
+			wantErrMsg: "no commits attached to this push event",
+		},
+		{
+			name: "push event without commits rejects invalid after SHA",
+			args: args{
+				event: gitlab.EventTypePush,
+				payload: sample.PushEventWithoutCommitsAsJSON(
+					zeroSHA,
+					"not-a-commit",
+					"not-a-commit",
+					"refs/heads/release-0.1",
+				),
+			},
+			wantErrMsg: "no commits attached to this push event",
+		},
+		{
+			// Correct length but not hexadecimal, so only the hex decode can reject it.
+			name: "push event without commits rejects non hexadecimal after SHA",
+			args: args{
+				event: gitlab.EventTypePush,
+				payload: sample.PushEventWithoutCommitsAsJSON(
+					zeroSHA,
+					strings.Repeat("z", 40),
+					strings.Repeat("z", 40),
+					"refs/heads/release-0.1",
+				),
+			},
+			wantErrMsg: "no commits attached to this push event",
+		},
+		{
+			name: "push event without commits rejects empty after SHA",
+			args: args{
+				event: gitlab.EventTypePush,
+				payload: sample.PushEventWithoutCommitsAsJSON(
+					zeroSHA,
+					"",
+					"",
+					"refs/heads/release-0.1",
+				),
+			},
+			wantErrMsg: "no commits attached to this push event",
+		},
+		{
+			// An empty before SHA is not the all-zero SHA GitLab sends on branch creation.
+			name: "push event without commits rejects empty before SHA",
+			args: args{
+				event: gitlab.EventTypePush,
+				payload: sample.PushEventWithoutCommitsAsJSON(
+					"",
+					branchCreateSHA,
+					branchCreateSHA,
+					"refs/heads/release-0.1",
+				),
+			},
+			wantErrMsg: "no commits attached to this push event",
+		},
+		{
 			name: "push event",
 			args: args{
 				event:   gitlab.EventTypePush,
@@ -123,6 +281,25 @@ func TestParsePayload(t *testing.T) {
 				TriggerTarget: "push",
 				Organization:  "hello/this/is/me/ze",
 				Repository:    "project",
+				SHA:           "sha",
+				SHATitle:      "commit it",
+				SHAURL:        "https://url",
+			},
+		},
+		{
+			name: "push event with multiple commits uses the last commit",
+			args: args{
+				event:   gitlab.EventTypePush,
+				payload: multiCommitPayload,
+			},
+			want: &info.Event{
+				EventType:     "push",
+				TriggerTarget: triggertype.Push,
+				Organization:  "hello/this/is/me/ze",
+				Repository:    "project",
+				SHA:           "2222222222222222222222222222222222222222",
+				SHATitle:      "second commit",
+				SHAURL:        "https://gitlab.example/commit/22222222",
 			},
 		},
 		{
@@ -510,6 +687,17 @@ func TestParsePayload(t *testing.T) {
 				if tt.want.BaseBranch != "" {
 					assert.Equal(t, tt.want.BaseBranch, got.BaseBranch)
 				}
+				if tt.want.SHA != "" {
+					assert.Equal(t, tt.want.SHA, got.SHA)
+				}
+				if tt.want.EventType == "push" && tt.want.SHATitle != "" {
+					assert.Equal(t, tt.want.SHATitle, got.SHATitle)
+				}
+				if tt.want.EventType == "push" && tt.want.SHAURL != "" {
+					assert.Equal(t, tt.want.SHAURL, got.SHAURL)
+				}
+				assert.Equal(t, tt.want.CommitMetadataIncomplete, got.CommitMetadataIncomplete)
+				assert.Equal(t, tt.want.PipelineRunSourceRevision, got.PipelineRunSourceRevision)
 			}
 		})
 	}
@@ -586,4 +774,139 @@ func TestInitGitLabClientSkipsTokenAutoRotation(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, v.gitlabClient != nil, "gitlab client should be initialized")
 	assert.Assert(t, !introspectionCalled, "token rotation must not run before webhook validation")
+}
+
+func TestIsBranchCreationPayload(t *testing.T) {
+	const (
+		zeroSHA         = "0000000000000000000000000000000000000000"
+		branchCreateSHA = "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e"
+	)
+	tests := []struct {
+		name  string
+		event *gitlab.PushEvent
+		want  bool
+	}{
+		{
+			name: "branch creation push",
+			event: &gitlab.PushEvent{
+				Ref:    "refs/heads/new-branch",
+				Before: zeroSHA,
+				After:  branchCreateSHA,
+			},
+			want: true,
+		},
+		{
+			// Tag creation carries the same all-zero before SHA, so the ref prefix is the
+			// only thing telling the two apart.
+			name: "tag creation is not a branch creation",
+			event: &gitlab.PushEvent{
+				Ref:    "refs/tags/v1.0.0",
+				Before: zeroSHA,
+				After:  branchCreateSHA,
+			},
+			want: false,
+		},
+		{
+			name: "branch ref without a branch name",
+			event: &gitlab.PushEvent{
+				Ref:    "refs/heads/",
+				Before: zeroSHA,
+				After:  branchCreateSHA,
+			},
+			want: false,
+		},
+		{
+			// A non-zero before SHA means the branch already existed, so this is an
+			// ordinary push onto it.
+			name: "push onto an existing branch",
+			event: &gitlab.PushEvent{
+				Ref:    "refs/heads/main",
+				Before: "1111111111111111111111111111111111111111",
+				After:  branchCreateSHA,
+			},
+			want: false,
+		},
+		{
+			// Branch deletion is the mirror image of creation: the after SHA is all zero.
+			name: "branch deletion",
+			event: &gitlab.PushEvent{
+				Ref:    "refs/heads/gone",
+				Before: branchCreateSHA,
+				After:  zeroSHA,
+			},
+			want: false,
+		},
+		{
+			name: "malformed after SHA",
+			event: &gitlab.PushEvent{
+				Ref:    "refs/heads/new-branch",
+				Before: zeroSHA,
+				After:  "not-a-commit",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isBranchCreationPayload(tt.event))
+		})
+	}
+}
+
+func TestIsValidCommitSHA(t *testing.T) {
+	tests := []struct {
+		name string
+		sha  string
+		want bool
+	}{
+		{
+			name: "lowercase hexadecimal SHA",
+			sha:  "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+			want: true,
+		},
+		{
+			// GitLab sends lowercase, but the SHA comparison elsewhere is case-insensitive
+			// so uppercase must stay acceptable here too.
+			name: "uppercase hexadecimal SHA",
+			sha:  "DC922F5EA0C57EF5FB1CBC0F3EA550DFE3B5786E",
+			want: true,
+		},
+		{
+			name: "empty SHA",
+			sha:  "",
+			want: false,
+		},
+		{
+			name: "all zero SHA",
+			sha:  "0000000000000000000000000000000000000000",
+			want: false,
+		},
+		{
+			name: "abbreviated SHA",
+			sha:  "dc922f5",
+			want: false,
+		},
+		{
+			name: "one character too long",
+			sha:  "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786ee",
+			want: false,
+		},
+		{
+			// Right length, wrong alphabet: only the hex decode can reject this one.
+			name: "correct length but not hexadecimal",
+			sha:  strings.Repeat("z", 40),
+			want: false,
+		},
+		{
+			// A single stray character is enough to make the decode fail.
+			name: "single non hexadecimal character",
+			sha:  "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786g",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isValidCommitSHA(tt.sha))
+		})
+	}
 }

--- a/pkg/provider/gitlab/test/test.go
+++ b/pkg/provider/gitlab/test/test.go
@@ -237,6 +237,27 @@ func (t TEvent) PushEventAsJSON(withcommits bool) string {
 	return jeez
 }
 
+func (t TEvent) PushEventWithoutCommitsAsJSON(before, after, checkoutSHA, ref string) string {
+	return fmt.Sprintf(`{
+    "object_kind": "push",
+    "event_name": "push",
+    "before": "%s",
+    "after": "%s",
+    "ref": "%s",
+    "checkout_sha": "%s",
+    "user_username": "%s",
+    "project_id": %d,
+    "user_id": %d,
+    "project": {
+        "default_branch": "%s",
+        "web_url": "%s",
+        "path_with_namespace": "%s"
+    },
+    "commits": [],
+    "total_commits_count": 0
+}`, before, after, ref, checkoutSHA, t.Username, t.TargetProjectID, t.UserID, t.DefaultBranch, t.URL, t.PathWithNameSpace)
+}
+
 func (t TEvent) NoteEventAsJSON(comment string) string {
 	//nolint:misspell
 	return fmt.Sprintf(`{

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -143,10 +143,11 @@ func inlineTasks(tasks []tektonv1.PipelineTask, ropt *Opts, remoteResource Fetch
 }
 
 type Opts struct {
-	GenerateName  bool     // whether to GenerateName
-	RemoteTasks   bool     // whether to parse annotation to fetch tasks from remote
-	SkipInlining  []string // task to skip inlining
-	ProviderToken string
+	GenerateName       bool     // whether to GenerateName
+	RemoteTasks        bool     // whether to parse annotation to fetch tasks from remote
+	SkipInlining       []string // task to skip inlining
+	ProviderToken      string
+	RepositoryRevision string // revision for repository-local Task and Pipeline references
 }
 
 func ReadTektonTypes(ctx context.Context, log *zap.SugaredLogger, data string) (TektonTypes, error) {
@@ -226,10 +227,11 @@ func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, pro
 	}
 
 	rt := &matcher.RemoteTasks{
-		Run:               cs,
-		Event:             event,
-		ProviderInterface: providerintf,
-		Logger:            logger,
+		Run:                cs,
+		Event:              event,
+		ProviderInterface:  providerintf,
+		Logger:             logger,
+		RepositoryRevision: ropt.RepositoryRevision,
 	}
 
 	fetchedResources, err := resolveRemoteResources(ctx, rt, types, ropt)

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -173,6 +173,68 @@ func TestOriginalPRNameLabelSet(t *testing.T) {
 	assert.Equal(t, resolved.GetLabels()["pipelinesascode.tekton.dev/original-prname"], "pr")
 }
 
+// revisionRecordingProvider captures the revision Resolve hands to the provider when it
+// fetches a repository-local Task or Pipeline reference.
+type revisionRecordingProvider struct {
+	*testprovider.TestProviderImp
+	fileInsideRepoRevision string
+}
+
+func (v *revisionRecordingProvider) GetFileInsideRepo(ctx context.Context, event *info.Event, file, revision string) (string, error) {
+	v.fileInsideRepoRevision = revision
+	return v.TestProviderImp.GetFileInsideRepo(ctx, event, file, revision)
+}
+
+// TestResolveRepositoryRevisionPropagation guards the wiring between Opts.RepositoryRevision
+// and RemoteTasks, which decides the revision repository-local references are read from.
+func TestResolveRepositoryRevisionPropagation(t *testing.T) {
+	const taskPath = "tasks/repository-local-task.yaml"
+	tests := []struct {
+		name               string
+		repositoryRevision string
+	}{
+		{
+			name:               "explicit repository revision reaches the provider",
+			repositoryRevision: "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e",
+		},
+		{
+			name: "empty repository revision leaves the provider to pick its own default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			prData, err := os.ReadFile("testdata/pipelinerun-with-repository-local-task.yaml")
+			assert.NilError(t, err)
+			taskData, err := os.ReadFile("testdata/repository-local-task.yaml")
+			assert.NilError(t, err)
+
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+			tprovider := &revisionRecordingProvider{
+				TestProviderImp: &testprovider.TestProviderImp{
+					FilesInsideRepo: map[string]string{taskPath: string(taskData)},
+				},
+			}
+
+			types, err := ReadTektonTypes(ctx, logger, string(prData))
+			assert.NilError(t, err)
+
+			cs := &params.Run{Clients: clients.Clients{}, Info: info.Info{}}
+			// A non-empty SHA routes the repository-local reference through the provider
+			// instead of the local filesystem fallback.
+			event := &info.Event{SHA: "dc922f5ea0c57ef5fb1cbc0f3ea550dfe3b5786e"}
+			_, err = Resolve(ctx, cs, logger, tprovider, types, event, &Opts{
+				RemoteTasks:        true,
+				RepositoryRevision: tt.repositoryRevision,
+			})
+			assert.NilError(t, err)
+			assert.Equal(t, tt.repositoryRevision, tprovider.fileInsideRepoRevision)
+		})
+	}
+}
+
 func TestPipelineRunRemoteTaskNotPacAnnotations(t *testing.T) {
 	resolved, _, err := readTDfile(t, "pipelinerun-pipeline-task-annotations-not-pac", false, true)
 	assert.NilError(t, err)

--- a/pkg/resolve/testdata/pipelinerun-with-repository-local-task.yaml
+++ b/pkg/resolve/testdata/pipelinerun-with-repository-local-task.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/task: "tasks/repository-local-task.yaml"
+  name: pipelinerun-repository-local-task
+spec:
+  pipelineSpec:
+    tasks:
+      - name: repository-local
+        taskRef:
+          name: repository-local-task
+    finally: []

--- a/pkg/resolve/testdata/repository-local-task.yaml
+++ b/pkg/resolve/testdata/repository-local-task.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: repository-local-task
+spec:
+  steps:
+    - name: first-step
+      image: image
+      script: |
+        echo hello


### PR DESCRIPTION
## 📝 Description of the Change

GitLab can send a Push Hook with an empty `commits` array when a new branch is
created at an existing commit. Pipelines as Code currently rejects every such
payload with `no commits attached to this push event`, so the new branch never
triggers a PipelineRun.

This change:

- Accepts only valid branch-creation payloads: a non-empty `refs/heads/<branch>`
  ref, an all-zero `before` SHA, and a valid non-zero 40-character hexadecimal
  `after` SHA.
- Uses `after` as the authoritative immutable revision and fetches commit
  metadata for that exact SHA instead of a mutable branch head.
- Keeps PipelineRun definitions and repository-local Task/Pipeline references
  on the same selected source revision, including `default_branch` provenance.
- Passes the selected repository revision explicitly through the resolver,
  removing the ordering dependency between `GetTektonDir` and
  `GetFileInsideRepo`.
- Resolves the full commit message before the early skip-CI decision when the
  webhook omits commit metadata.
- Continues to reject branch deletion, tag pushes, invalid SHAs, empty branch
  names, and unrelated empty-commit push events.

## 🔍 Root Cause and Code Location

The links below use the fixed pre-change `main` revision
`3bbaf67f5042b852f9acebc59758eeb38e0ee870`.

1. [`ParsePayload` rejected every push with an empty `commits` array](https://github.com/tektoncd/pipelines-as-code/blob/3bbaf67f5042b852f9acebc59758eeb38e0ee870/pkg/provider/gitlab/parse_payload.go#L116-L120).
   A valid GitLab branch-creation payload has an all-zero `before` SHA, a
   non-zero `after` SHA containing the created branch tip, and a
   `refs/heads/...` ref, but no entry in `commits`. The unconditional rejection
   therefore discarded a valid event before matching could begin.
2. [PipelineRun definitions were loaded through `GetTektonDir`](https://github.com/tektoncd/pipelines-as-code/blob/3bbaf67f5042b852f9acebc59758eeb38e0ee870/pkg/pipelineascode/match.go#L144-L152),
   while [the GitLab provider selected the mutable branch ref](https://github.com/tektoncd/pipelines-as-code/blob/3bbaf67f5042b852f9acebc59758eeb38e0ee870/pkg/provider/gitlab/gitlab.go#L573-L594).
   If another push moved the branch after webhook delivery, matching could read
   definitions from a different commit than the event's `after` SHA.
3. Repository-local Task and Pipeline references followed a separate call
   chain: [`getPipelineRunsFromRepo` called `resolve.Resolve`](https://github.com/tektoncd/pipelines-as-code/blob/3bbaf67f5042b852f9acebc59758eeb38e0ee870/pkg/pipelineascode/match.go#L340-L358),
   [`Resolve` created `RemoteTasks` without a selected revision](https://github.com/tektoncd/pipelines-as-code/blob/3bbaf67f5042b852f9acebc59758eeb38e0ee870/pkg/resolve/resolve.go#L218-L235),
   and [`RemoteTasks` passed an empty target to the provider](https://github.com/tektoncd/pipelines-as-code/blob/3bbaf67f5042b852f9acebc59758eeb38e0ee870/pkg/matcher/annotation_tasks_install.go#L136-L142).
   The [GitLab implementation then always fetched from `HeadBranch`](https://github.com/tektoncd/pipelines-as-code/blob/3bbaf67f5042b852f9acebc59758eeb38e0ee870/pkg/provider/gitlab/gitlab.go#L668-L673),
   so repository-local references could drift independently of the PipelineRun
   definitions.
4. [The early push skip-CI check only inspected `SHATitle`](https://github.com/tektoncd/pipelines-as-code/blob/3bbaf67f5042b852f9acebc59758eeb38e0ee870/pkg/adapter/sinker.go#L97-L101).
   Branch-creation payloads do not provide that commit metadata, so the exact
   `after` commit must be queried before checking its full message.

The fix classifies only genuine branch-creation payloads, records `after` as an
immutable event-scoped source revision, and queries commit metadata by that SHA.
For source provenance, `.tekton` definitions use the same SHA. For
`default_branch` provenance, the default branch is selected explicitly. The
chosen revision is then passed through `resolve.Opts` and `RemoteTasks` into
`GetFileInsideRepo`, so repository-local references use the same source without
requiring `GetTektonDir` to mutate shared event state first. If a caller does not
provide an explicit target, GitLab branch creation safely falls back to the
immutable event SHA.

## 📦 Release Notes

GitLab branch creation events can now trigger Pipelines as Code when GitLab
omits the `commits` array from the Push Hook payload.

## 🔗 Linked GitHub Issue

Fixes #2874

## 🧪 Testing Strategy

- [x] Unit tests
- [x] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

The tests cover payload classification, exact-SHA metadata lookup, invalid and
deletion payload rejection, source/default-branch revision selection, explicit
repository-revision propagation, repository-local references, skip-CI
handling, and the adapter event flow.

`make test` passes all 3162 tests. Go, gofumpt, and YAML lint checks pass. The
complete local `make lint` could not run its Markdown/grammar stage because the
local environment does not have `markdownlint` or `vale`; this PR does not
change Markdown files, and CI remains the authoritative complete lint run.

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

OpenAI Codex (GPT-5) assisted with implementation and test development. The
submitter reviewed and understood the changes, validated the behavior, and ran
the test and available lint suites. The commits include an `Assisted-by`
trailer.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. `make test` and all available lint stages pass; the missing local Markdown tools are documented above.
- [x] 📖 I have added or updated documentation for any user-facing changes. No documentation update is needed for this GitLab webhook bug fix; release notes are included above.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. The GitLab webhook edge case is covered by parser, provider, matcher, and adapter integration tests.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation. This is a GitLab bug fix, not a new provider feature.
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
