### PR TITLE
fix(github): query check runs for /retest

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -380,8 +380,64 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 	return nil
 }
 
-func (v *Provider) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
-	return nil, nil
+func (v *Provider) GetCommitStatuses(ctx context.Context, event *info.Event) ([]provider.CommitStatusInfo, error) {
+	if v.ghClient == nil {
+		return nil, fmt.Errorf("no github client has been initialized")
+	}
+
+	var (
+		result []provider.CommitStatusInfo
+		seen   = map[string]struct{}{}
+	)
+
+	if event.InstallationID > 0 {
+		checkRuns, err := v.fetchAllCheckRunPagesWithRetry(ctx, event)
+		if err != nil {
+			return nil, err
+		}
+		for _, cr := range checkRuns {
+			status := cr.GetStatus()
+			if status == "completed" {
+				status = cr.GetConclusion()
+			}
+			key := cr.GetName() + "\x00" + status
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			result = append(result, provider.CommitStatusInfo{
+				Name:   cr.GetName(),
+				Status: status,
+			})
+		}
+	} else {
+		opt := &github.ListOptions{PerPage: v.PaginedNumber}
+		for {
+			statuses, resp, err := wrapAPI(v, "list_statuses", func() ([]*github.RepoStatus, *github.Response, error) {
+				return v.Client().Repositories.ListStatuses(ctx, event.Organization, event.Repository, event.SHA, opt)
+			})
+			if err != nil {
+				return nil, err
+			}
+			for _, s := range statuses {
+				key := s.GetContext() + "\x00" + s.GetState()
+				if _, ok := seen[key]; ok {
+					continue
+				}
+				seen[key] = struct{}{}
+				result = append(result, provider.CommitStatusInfo{
+					Name:   s.GetContext(),
+					Status: s.GetState(),
+				})
+			}
+			if resp.NextPage == 0 {
+				break
+			}
+			opt.Page = resp.NextPage
+		}
+	}
+
+	return result, nil
 }
 
 // GetTektonDir retrieves all YAML files from the .tekton directory and returns them as a single concatenated multi-document YAML file.

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -387,8 +387,51 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 	return nil
 }
 
-func (v *Provider) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
-	return nil, nil
+func (v *Provider) GetCommitStatuses(ctx context.Context, event *info.Event) ([]provider.CommitStatusInfo, error) {
+	if v.ghClient == nil {
+		return nil, fmt.Errorf("no github client has been initialized")
+	}
+
+	var result []provider.CommitStatusInfo
+
+	if event.InstallationID > 0 {
+		checkRuns, err := v.fetchAllCheckRunPagesWithRetry(ctx, event)
+		if err != nil {
+			return nil, err
+		}
+		for _, cr := range checkRuns {
+			status := cr.GetStatus()
+			if status == "completed" {
+				status = cr.GetConclusion()
+			}
+			result = append(result, provider.CommitStatusInfo{
+				Name:   cr.GetName(),
+				Status: status,
+			})
+		}
+	} else {
+		opt := &github.ListOptions{PerPage: v.PaginedNumber}
+		for {
+			statuses, resp, err := wrapAPI(v, "list_statuses", func() ([]*github.RepoStatus, *github.Response, error) {
+				return v.Client().Repositories.ListStatuses(ctx, event.Organization, event.Repository, event.SHA, opt)
+			})
+			if err != nil {
+				return nil, err
+			}
+			for _, s := range statuses {
+				result = append(result, provider.CommitStatusInfo{
+					Name:   s.GetContext(),
+					Status: s.GetState(),
+				})
+			}
+			if resp == nil || resp.NextPage == 0 {
+				break
+			}
+			opt.Page = resp.NextPage
+		}
+	}
+
+	return result, nil
 }
 
 // GetTektonDir retrieves all YAML files from the .tekton directory and returns them as a single concatenated multi-document YAML file.

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	prmetrics "github.com/openshift-pipelines/pipelines-as-code/pkg/pipelinerunmetrics"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
@@ -2744,6 +2745,291 @@ func TestFetchAppSlug(t *testing.T) {
 
 			assert.NilError(t, err)
 			assert.Equal(t, slug, tt.wantSlug)
+		})
+	}
+}
+
+func TestGetCommitStatuses(t *testing.T) {
+	defaultEvent := &info.Event{
+		Organization: "owner",
+		Repository:   "repo",
+		SHA:          "abc123",
+	}
+
+	appEvent := &info.Event{
+		Organization:   "owner",
+		Repository:     "repo",
+		SHA:            "abc123",
+		InstallationID: 12345,
+	}
+
+	tests := []struct {
+		name         string
+		event        *info.Event
+		wantErr      bool
+		wantStatuses []provider.CommitStatusInfo
+		noClient     bool
+		clock        clockwork.Clock
+		setupMux     func(t *testing.T, mux *http.ServeMux, event *info.Event)
+	}{
+		{
+			name:     "nil client returns error",
+			noClient: true,
+			event:    &info.Event{},
+			wantErr:  true,
+		},
+		{
+			name:  "check runs with mixed conclusions",
+			event: appEvent,
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "success"},
+				{Name: "Pipelines as Code CI / test", Status: "failure"},
+				{Name: "Pipelines as Code CI / build", Status: "success"},
+			},
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs",
+					event.Organization, event.Repository, event.SHA),
+					func(w http.ResponseWriter, _ *http.Request) {
+						fmt.Fprint(w, `{
+							"total_count": 3,
+							"check_runs": [
+								{"name": "Pipelines as Code CI / lint", "status": "completed", "conclusion": "success"},
+								{"name": "Pipelines as Code CI / test", "status": "completed", "conclusion": "failure"},
+								{"name": "Pipelines as Code CI / build", "status": "completed", "conclusion": "success"}
+							]
+						}`)
+					})
+			},
+		},
+		{
+			name:  "check runs with in progress status",
+			event: appEvent,
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "success"},
+				{Name: "Pipelines as Code CI / test", Status: "in_progress"},
+			},
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs",
+					event.Organization, event.Repository, event.SHA),
+					func(w http.ResponseWriter, _ *http.Request) {
+						fmt.Fprint(w, `{
+							"total_count": 2,
+							"check_runs": [
+								{"name": "Pipelines as Code CI / lint", "status": "completed", "conclusion": "success"},
+								{"name": "Pipelines as Code CI / test", "status": "in_progress"}
+							]
+						}`)
+					})
+			},
+		},
+		{
+			name:         "no check runs returns empty",
+			event:        appEvent,
+			wantStatuses: nil,
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs",
+					event.Organization, event.Repository, event.SHA),
+					func(w http.ResponseWriter, _ *http.Request) {
+						fmt.Fprint(w, `{"total_count": 0, "check_runs": []}`)
+					})
+			},
+		},
+		{
+			name:    "check runs API error",
+			event:   appEvent,
+			wantErr: true,
+			clock:   clockwork.NewFakeClock(),
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs",
+					event.Organization, event.Repository, event.SHA),
+					func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusInternalServerError)
+					})
+			},
+		},
+		{
+			name:  "check runs with pagination",
+			event: appEvent,
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "success"},
+				{Name: "Pipelines as Code CI / test", Status: "failure"},
+			},
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				urlPath := fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs",
+					event.Organization, event.Repository, event.SHA)
+				mux.HandleFunc(urlPath, func(w http.ResponseWriter, r *http.Request) {
+					page := r.URL.Query().Get("page")
+					if page == "" || page == "1" {
+						w.Header().Add("Link", fmt.Sprintf(`<https://api.github.com%s?page=2&per_page=1>; rel="next"`, urlPath))
+						fmt.Fprint(w, `{
+							"total_count": 2,
+							"check_runs": [
+								{"name": "Pipelines as Code CI / lint", "status": "completed", "conclusion": "success"}
+							]
+						}`)
+					} else {
+						fmt.Fprint(w, `{
+							"total_count": 2,
+							"check_runs": [
+								{"name": "Pipelines as Code CI / test", "status": "completed", "conclusion": "failure"}
+							]
+						}`)
+					}
+				})
+			},
+		},
+		{
+			name:  "check runs deduplication",
+			event: appEvent,
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "success"},
+			},
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs",
+					event.Organization, event.Repository, event.SHA),
+					func(w http.ResponseWriter, _ *http.Request) {
+						fmt.Fprint(w, `{
+							"total_count": 2,
+							"check_runs": [
+								{"name": "Pipelines as Code CI / lint", "status": "completed", "conclusion": "success"},
+								{"name": "Pipelines as Code CI / lint", "status": "completed", "conclusion": "success"}
+							]
+						}`)
+					})
+			},
+		},
+		{
+			name:  "commit statuses PAT mode",
+			event: defaultEvent,
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "success"},
+				{Name: "Pipelines as Code CI / test", Status: "failure"},
+			},
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/statuses",
+					event.Organization, event.Repository, event.SHA),
+					func(w http.ResponseWriter, _ *http.Request) {
+						fmt.Fprint(w, `[
+							{"context": "Pipelines as Code CI / lint", "state": "success"},
+							{"context": "Pipelines as Code CI / test", "state": "failure"}
+						]`)
+					})
+			},
+		},
+		{
+			name:  "commit statuses with pagination PAT mode",
+			event: defaultEvent,
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "success"},
+				{Name: "Pipelines as Code CI / test", Status: "failure"},
+			},
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				urlPath := fmt.Sprintf("/repos/%s/%s/commits/%s/statuses",
+					event.Organization, event.Repository, event.SHA)
+				mux.HandleFunc(urlPath, func(w http.ResponseWriter, r *http.Request) {
+					page := r.URL.Query().Get("page")
+					if page == "" || page == "1" {
+						w.Header().Add("Link", fmt.Sprintf(`<https://api.github.com%s?page=2&per_page=1>; rel="next"`, urlPath))
+						fmt.Fprint(w, `[
+							{"context": "Pipelines as Code CI / lint", "state": "success"}
+						]`)
+					} else {
+						fmt.Fprint(w, `[
+							{"context": "Pipelines as Code CI / test", "state": "failure"}
+						]`)
+					}
+				})
+			},
+		},
+		{
+			name:  "commit statuses deduplication PAT mode",
+			event: defaultEvent,
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "success"},
+			},
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/statuses",
+					event.Organization, event.Repository, event.SHA),
+					func(w http.ResponseWriter, _ *http.Request) {
+						fmt.Fprint(w, `[
+							{"context": "Pipelines as Code CI / lint", "state": "success"},
+							{"context": "Pipelines as Code CI / lint", "state": "success"}
+						]`)
+					})
+			},
+		},
+		{
+			name:    "commit statuses API error PAT mode",
+			event:   defaultEvent,
+			wantErr: true,
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/statuses",
+					event.Organization, event.Repository, event.SHA),
+					func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusInternalServerError)
+					})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			l, _ := logger.GetLogger()
+
+			if tt.noClient {
+				cnx := &Provider{Logger: l}
+				_, err := cnx.GetCommitStatuses(ctx, tt.event)
+				assert.Assert(t, err != nil)
+				return
+			}
+
+			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+
+			cnx := &Provider{
+				ghClient:      fakeclient,
+				PaginedNumber: defaultPaginedNumber,
+				Logger:        l,
+			}
+			if tt.clock != nil {
+				cnx.clock = tt.clock
+			}
+
+			if tt.setupMux != nil {
+				tt.setupMux(t, mux, tt.event)
+			}
+
+			if fc, ok := tt.clock.(*clockwork.FakeClock); ok {
+				go func() {
+					for range checkRunsFetchMaxRetries {
+						fc.BlockUntilContext(ctx, 1) //nolint:errcheck
+						fc.Advance(time.Second)
+					}
+				}()
+			}
+
+			got, err := cnx.GetCommitStatuses(ctx, tt.event)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, len(got), len(tt.wantStatuses))
+			for i, want := range tt.wantStatuses {
+				assert.Equal(t, got[i].Name, want.Name)
+				assert.Equal(t, got[i].Status, want.Status)
+			}
 		})
 	}
 }

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	prmetrics "github.com/openshift-pipelines/pipelines-as-code/pkg/pipelinerunmetrics"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
@@ -2777,6 +2778,234 @@ func TestFetchAppSlug(t *testing.T) {
 
 			assert.NilError(t, err)
 			assert.Equal(t, slug, tt.wantSlug)
+		})
+	}
+}
+
+func TestGetCommitStatuses(t *testing.T) {
+	defaultEvent := &info.Event{
+		Organization: "owner",
+		Repository:   "repo",
+		SHA:          "abc123",
+	}
+
+	appEvent := &info.Event{
+		Organization:   "owner",
+		Repository:     "repo",
+		SHA:            "abc123",
+		InstallationID: 12345,
+	}
+
+	tests := []struct {
+		name          string
+		event         *info.Event
+		wantErr       bool
+		wantStatuses  []provider.CommitStatusInfo
+		noClient      bool
+		clock         clockwork.Clock
+		checkRunsJSON string
+		statusesJSON  string
+		setupMux      func(t *testing.T, mux *http.ServeMux, event *info.Event)
+	}{
+		{
+			name:     "nil client returns error",
+			noClient: true,
+			event:    &info.Event{},
+			wantErr:  true,
+		},
+		{
+			name:  "check runs with mixed conclusions",
+			event: appEvent,
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "success"},
+				{Name: "Pipelines as Code CI / test", Status: "failure"},
+				{Name: "Pipelines as Code CI / build", Status: "success"},
+			},
+			checkRunsJSON: `{"total_count": 3, "check_runs": [
+				{"name": "Pipelines as Code CI / lint", "status": "completed", "conclusion": "success"},
+				{"name": "Pipelines as Code CI / test", "status": "completed", "conclusion": "failure"},
+				{"name": "Pipelines as Code CI / build", "status": "completed", "conclusion": "success"}
+			]}`,
+		},
+		{
+			name:  "check runs with in progress status",
+			event: appEvent,
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "success"},
+				{Name: "Pipelines as Code CI / test", Status: "in_progress"},
+			},
+			checkRunsJSON: `{"total_count": 2, "check_runs": [
+				{"name": "Pipelines as Code CI / lint", "status": "completed", "conclusion": "success"},
+				{"name": "Pipelines as Code CI / test", "status": "in_progress"}
+			]}`,
+		},
+		{
+			name:          "no check runs returns empty",
+			event:         appEvent,
+			wantStatuses:  nil,
+			checkRunsJSON: `{"total_count": 0, "check_runs": []}`,
+		},
+		{
+			name:    "check runs API error",
+			event:   appEvent,
+			wantErr: true,
+			clock:   clockwork.NewFakeClock(),
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs",
+					event.Organization, event.Repository, event.SHA),
+					func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusInternalServerError)
+					})
+			},
+		},
+		{
+			name:  "check runs with pagination",
+			event: appEvent,
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "success"},
+				{Name: "Pipelines as Code CI / test", Status: "failure"},
+			},
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				urlPath := fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs",
+					event.Organization, event.Repository, event.SHA)
+				mux.HandleFunc(urlPath, func(w http.ResponseWriter, r *http.Request) {
+					page := r.URL.Query().Get("page")
+					if page == "" || page == "1" {
+						w.Header().Add("Link", fmt.Sprintf(`<https://api.github.com%s?page=2&per_page=1>; rel="next"`, urlPath))
+						fmt.Fprint(w, `{
+							"total_count": 2,
+							"check_runs": [
+								{"name": "Pipelines as Code CI / lint", "status": "completed", "conclusion": "success"}
+							]
+						}`)
+					} else {
+						fmt.Fprint(w, `{
+							"total_count": 2,
+							"check_runs": [
+								{"name": "Pipelines as Code CI / test", "status": "completed", "conclusion": "failure"}
+							]
+						}`)
+					}
+				})
+			},
+		},
+		{
+			name:  "commit statuses webhook mode",
+			event: defaultEvent,
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "success"},
+				{Name: "Pipelines as Code CI / test", Status: "failure"},
+			},
+			statusesJSON: `[
+				{"context": "Pipelines as Code CI / lint", "state": "success"},
+				{"context": "Pipelines as Code CI / test", "state": "failure"}
+			]`,
+		},
+		{
+			name:  "commit statuses with pagination webhook mode",
+			event: defaultEvent,
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "success"},
+				{Name: "Pipelines as Code CI / test", Status: "failure"},
+			},
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				urlPath := fmt.Sprintf("/repos/%s/%s/commits/%s/statuses",
+					event.Organization, event.Repository, event.SHA)
+				mux.HandleFunc(urlPath, func(w http.ResponseWriter, r *http.Request) {
+					page := r.URL.Query().Get("page")
+					if page == "" || page == "1" {
+						w.Header().Add("Link", fmt.Sprintf(`<https://api.github.com%s?page=2&per_page=1>; rel="next"`, urlPath))
+						fmt.Fprint(w, `[
+							{"context": "Pipelines as Code CI / lint", "state": "success"}
+						]`)
+					} else {
+						fmt.Fprint(w, `[
+							{"context": "Pipelines as Code CI / test", "state": "failure"}
+						]`)
+					}
+				})
+			},
+		},
+		{
+			name:    "commit statuses API error webhook mode",
+			event:   defaultEvent,
+			wantErr: true,
+			setupMux: func(t *testing.T, mux *http.ServeMux, event *info.Event) {
+				t.Helper()
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/statuses",
+					event.Organization, event.Repository, event.SHA),
+					func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusInternalServerError)
+					})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			l, _ := logger.GetLogger()
+
+			if tt.noClient {
+				cnx := &Provider{Logger: l}
+				_, err := cnx.GetCommitStatuses(ctx, tt.event)
+				assert.Assert(t, err != nil)
+				return
+			}
+
+			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+
+			cnx := &Provider{
+				ghClient:      fakeclient,
+				PaginedNumber: defaultPaginedNumber,
+				Logger:        l,
+			}
+			if tt.clock != nil {
+				cnx.clock = tt.clock
+			}
+
+			if tt.checkRunsJSON != "" {
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs",
+					tt.event.Organization, tt.event.Repository, tt.event.SHA),
+					func(w http.ResponseWriter, _ *http.Request) {
+						fmt.Fprint(w, tt.checkRunsJSON)
+					})
+			}
+			if tt.statusesJSON != "" {
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s/statuses",
+					tt.event.Organization, tt.event.Repository, tt.event.SHA),
+					func(w http.ResponseWriter, _ *http.Request) {
+						fmt.Fprint(w, tt.statusesJSON)
+					})
+			}
+			if tt.setupMux != nil {
+				tt.setupMux(t, mux, tt.event)
+			}
+
+			if fc, ok := tt.clock.(*clockwork.FakeClock); ok {
+				go func() {
+					for range checkRunsFetchMaxRetries {
+						fc.BlockUntilContext(ctx, 1) //nolint:errcheck
+						fc.Advance(time.Second)
+					}
+				}()
+			}
+
+			got, err := cnx.GetCommitStatuses(ctx, tt.event)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, len(got), len(tt.wantStatuses))
+			for i, want := range tt.wantStatuses {
+				assert.Equal(t, got[i].Name, want.Name)
+				assert.Equal(t, got[i].Status, want.Status)
+			}
 		})
 	}
 }

--- a/test/github_pullrequest_retest_pruned_test.go
+++ b/test/github_pullrequest_retest_pruned_test.go
@@ -1,0 +1,130 @@
+//go:build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/v85/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// testRetestAfterPruning is the shared flow for both App and Webhook modes:
+// create a PR with 2 pipelines (1 pass, 1 fail), wait for completion, delete
+// all PipelineRuns to simulate pruning, post /retest, and assert that only the
+// failed pipeline is re-run.
+func testRetestAfterPruning(ctx context.Context, t *testing.T, g *tgithub.PRTest) {
+	t.Helper()
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
+
+	sha := g.SHA
+	labelSelector := fmt.Sprintf("%s=%s", keys.SHA, formatting.CleanValueKubernetes(sha))
+
+	g.Cnx.Clients.Log.Infof("Waiting for 2 PipelineRuns to finish")
+	_, err := twait.UntilPipelineRunsFinished(ctx, g.Cnx.Clients, twait.Opts{
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: 2,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       []string{sha},
+	})
+	assert.NilError(t, err)
+
+	pruns, err := g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pruns.Items), 2, "expected 2 initial PipelineRuns")
+
+	initialPRNames := map[string]bool{}
+	for _, pr := range pruns.Items {
+		initialPRNames[pr.Name] = true
+	}
+
+	g.Cnx.Clients.Log.Infof("Deleting all PipelineRuns to simulate pruning")
+	err = g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).DeleteCollection(ctx,
+		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: labelSelector})
+	assert.NilError(t, err)
+
+	g.Cnx.Clients.Log.Infof("Waiting for PipelineRuns to be deleted")
+	pollErr := kubeinteraction.PollImmediateWithContext(ctx, twait.DefaultTimeout, func() (bool, error) {
+		pruns, err = g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			return false, err
+		}
+		return len(pruns.Items) == 0, nil
+	})
+	if pollErr != nil {
+		g.Cnx.Clients.Log.Infof("Warning: PipelineRuns not fully deleted after polling: %v (proceeding anyway)", pollErr)
+	}
+
+	g.Cnx.Clients.Log.Infof("Posting /retest comment on PR %d", g.PRNumber)
+	_, _, err = g.Provider.Client().Issues.CreateComment(ctx,
+		g.Options.Organization, g.Options.Repo, g.PRNumber,
+		&github.IssueComment{Body: github.Ptr("/retest")})
+	assert.NilError(t, err)
+
+	g.Cnx.Clients.Log.Infof("Waiting for retest PipelineRun to finish")
+	_, err = twait.UntilPipelineRunsFinished(ctx, g.Cnx.Clients, twait.Opts{
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       []string{sha},
+	})
+	assert.NilError(t, err)
+
+	prunsAfterRetest, err := g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+
+	newCount := 0
+	for _, pr := range prunsAfterRetest.Items {
+		if !initialPRNames[pr.Name] {
+			newCount++
+		}
+	}
+	assert.Equal(t, newCount, 1,
+		"expected only 1 new PipelineRun after /retest (only the failed pipeline should re-run), but got %d", newCount)
+}
+
+// TestGithubGHERetestAfterPipelineRunPruning verifies that /retest only re-runs
+// failed pipelines when PipelineRun objects have been pruned from the cluster
+// (GitHub App mode — uses Check Runs API).
+func TestGithubGHERetestAfterPipelineRunPruning(t *testing.T) {
+	testRetestAfterPruning(context.Background(), t, &tgithub.PRTest{
+		Label: "Github GHE retest after pruning",
+		YamlFiles: []string{
+			"testdata/always-good-pipelinerun.yaml",
+			"testdata/failures/pipelinerun-exit-1.yaml",
+		},
+		GHE:           true,
+		NoStatusCheck: true,
+	})
+}
+
+// TestGithubGHEWebhookRetestAfterPipelineRunPruning verifies the same
+// retest-after-pruning behavior when using GitHub via direct webhook
+// (PAT mode — uses Commit Statuses API).
+func TestGithubGHEWebhookRetestAfterPipelineRunPruning(t *testing.T) {
+	testRetestAfterPruning(context.Background(), t, &tgithub.PRTest{
+		Label: "Github GHE webhook retest after pruning",
+		YamlFiles: []string{
+			"testdata/always-good-pipelinerun.yaml",
+			"testdata/failures/pipelinerun-exit-1.yaml",
+		},
+		GHE:           true,
+		Webhook:       true,
+		NoStatusCheck: true,
+	})
+}

--- a/test/github_pullrequest_retest_pruned_test.go
+++ b/test/github_pullrequest_retest_pruned_test.go
@@ -1,0 +1,114 @@
+//go:build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/v85/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// testRetestAfterPruning is the shared flow for both App and Webhook modes:
+// create a PR with 2 pipelines (1 pass, 1 fail), wait for completion, delete
+// all PipelineRuns to simulate pruning, post /retest, and assert that only the
+// failed pipeline is re-run.
+func testRetestAfterPruning(ctx context.Context, t *testing.T, g *tgithub.PRTest) {
+	t.Helper()
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
+
+	sha := g.SHA
+	labelSelector := fmt.Sprintf("%s=%s", keys.SHA, formatting.CleanValueKubernetes(sha))
+
+	g.Cnx.Clients.Log.Infof("Waiting for 2 PipelineRuns to finish")
+	pruns, err := twait.UntilPipelineRunsFinished(ctx, g.Cnx.Clients, twait.Opts{
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: 2,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       []string{sha},
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pruns), 2, "expected 2 initial PipelineRuns")
+
+	g.Cnx.Clients.Log.Infof("Deleting all PipelineRuns to simulate pruning")
+	err = g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).DeleteCollection(ctx,
+		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: labelSelector})
+	assert.NilError(t, err)
+
+	g.Cnx.Clients.Log.Infof("Waiting for PipelineRuns to be deleted")
+	pollErr := kubeinteraction.PollImmediateWithContext(ctx, twait.DefaultTimeout, func() (bool, error) {
+		pruns, err := g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			return false, err
+		}
+		return len(pruns.Items) == 0, nil
+	})
+	assert.NilError(t, pollErr, "PipelineRuns not fully deleted after polling")
+
+	g.Cnx.Clients.Log.Infof("Posting /retest comment on PR %d", g.PRNumber)
+	_, _, err = g.Provider.Client().Issues.CreateComment(ctx,
+		g.Options.Organization, g.Options.Repo, g.PRNumber,
+		&github.IssueComment{Body: github.Ptr("/retest")})
+	assert.NilError(t, err)
+
+	g.Cnx.Clients.Log.Infof("Waiting for retest PipelineRun to finish")
+	_, err = twait.UntilPipelineRunsFinished(ctx, g.Cnx.Clients, twait.Opts{
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       []string{sha},
+	})
+	assert.NilError(t, err)
+
+	prunsAfterRetest, err := g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(prunsAfterRetest.Items), 1,
+		"expected exactly 1 new PipelineRun after /retest, but got %d", len(prunsAfterRetest.Items))
+}
+
+// TestGithubGHERetestAfterPipelineRunPruning verifies that /retest only re-runs
+// failed pipelines when PipelineRun objects have been pruned from the cluster.
+// It covers both GitHub App mode (Check Runs API) and direct webhook mode
+// (webhook mode, Commit Statuses API).
+func TestGithubGHERetestAfterPipelineRunPruning(t *testing.T) {
+	tests := []struct {
+		name      string
+		isWebhook bool
+	}{
+		{
+			name:      "Github GHE retest after pruning",
+			isWebhook: false,
+		},
+		{
+			name:      "Github GHE webhook retest after pruning",
+			isWebhook: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testRetestAfterPruning(context.Background(), t, &tgithub.PRTest{
+				Label: tt.name,
+				YamlFiles: []string{
+					"testdata/always-good-pipelinerun.yaml",
+					"testdata/failures/pipelinerun-exit-1.yaml",
+				},
+				GHE:           true,
+				Webhook:       tt.isWebhook,
+				NoStatusCheck: true,
+			})
+		})
+	}
+}


### PR DESCRIPTION
## 📝 Description of the Change
Implement GetCommitStatuses for the GitHub provider so /retest only re-runs failed pipelines when PipelineRuns have been pruned.

The stub returned nil, causing filterSuccessfulTemplates to skip all pipelines through. Now queries the Check Runs API in GitHub App mode and the Commit Statuses API in PAT/webhook mode, with deduplication and retry-with-backoff matching the write path.

## 🔗 Linked GitHub Issue
Partially fixes #2580 

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
