### PR TITLE
Security: Fix CVE-2026-42505 + CVE-2026-39822 (Go stdlib 1.26.5)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-pipelines/pipelines-as-code
 
-go 1.26.4
+go 1.26.5
 
 require (
 	codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3 v3.0.0


### PR DESCRIPTION
## Summary

This PR fixes two Go stdlib security vulnerabilities on the `release-v0.49.x` branch by upgrading Go from 1.26.4 to 1.26.5.

### CVE-2026-42505 Details
- **CVE ID**: CVE-2026-42505 / GO-2026-5856 / BIT-golang-2026-42505
- **Package**: Go stdlib (crypto/tls)
- **Severity**: HIGH
- **Impact**: Invoking Encrypted Client Hello (ECH) causes a privacy leak in `crypto/tls` — the TLS handshake leaks the plaintext Server Name Indication (SNI) to network observers despite ECH being intended to encrypt it
- **Vulnerable version**: Go 1.26.4 (and earlier)
- **Fixed version**: Go 1.26.5

### CVE-2026-39822 Details
- **CVE ID**: CVE-2026-39822 / GO-2026-4970 / BIT-golang-2026-39822
- **Package**: Go stdlib (os)
- **Severity**: HIGH
- **Impact**: Root escape via symlink plus trailing slash in `os` package allows path traversal — attacker with symlink write access can escape intended directory bounds
- **Vulnerable version**: Go 1.26.4 (and earlier)
- **Fixed version**: Go 1.26.5

### Changes
- Updated `go 1.26.4` → `go 1.26.5` in `go.mod`
- Run `go mod tidy && go mod verify`

### Test Results

**Status**: ⚠️ Running in CI

**Post-fix govulncheck**: ✅ CVE-2026-42505 and CVE-2026-39822 no longer detected
- Remaining findings: `GO-2023-1901` (tektoncd/pipeline UID — no fix available) and `GO-2026-5970` (x/text — addressed in separate PR #2882)

### Breaking Changes
- None. This is a patch-level Go compiler update (1.26.4 → 1.26.5) within the same minor version line.

### Verification Steps
- [x] CVE-2026-42505 confirmed present at Go 1.26.4 via OSV API
- [x] CVE-2026-39822 confirmed present at Go 1.26.4 via OSV API
- [x] Post-fix govulncheck shows both stdlib CVEs resolved at Go 1.26.5
- [x] `go mod tidy && go mod verify` passed
- [ ] CI tests pass

### Risk Assessment
| Factor | Assessment |
|--------|-----------|
| Patch type | Go patch-level upgrade (1.26.4 → 1.26.5) |
| API changes | None (patch-level only) |
| Test coverage | Unit tests run in CI |
| Risk level | **Low** |

---

🤖 Generated by CVE Fixer Workflow
<!-- cve-fixer-workflow -->